### PR TITLE
feat(causa): scaffold perspective module structure (US-CAUSA-01)

### DIFF
--- a/frontend/src/perspectives/causa/index.ts
+++ b/frontend/src/perspectives/causa/index.ts
@@ -1,0 +1,10 @@
+import { Perspective } from '../types';
+
+export const CausalPerspective: Perspective = {
+    id: 'causa',
+    name: 'Causal Analyst',
+    description: 'Analyze cause-and-effect relationships with strict validation.',
+
+    // Placeholder - will be implemented in subsequent US
+    Shell: () => null,
+};

--- a/frontend/src/perspectives/causa/projections/graph.ts
+++ b/frontend/src/perspectives/causa/projections/graph.ts
@@ -1,0 +1,9 @@
+/**
+ * Logic to transform specific Neo4j/Backend data into the Causal internal model.
+ * Should be a pure function.
+ */
+
+// Placeholder for transformation logic
+export function projectToCausalGraph(rawData: any): any {
+    return rawData;
+}

--- a/frontend/src/perspectives/causa/types.ts
+++ b/frontend/src/perspectives/causa/types.ts
@@ -1,0 +1,19 @@
+/**
+ * Domain-specific types for the Causal Perspective.
+ * This ensures strict typing internal to the module.
+ */
+
+export interface CausalNode {
+    id: string;
+    label: string;
+    type: 'factor' | 'system';
+    // Future: status, confidence, evidence
+}
+
+export interface CausalLink {
+    id: string;
+    source: string;
+    target: string;
+    polarity: 'positive' | 'negative' | 'ambiguous';
+    // Future: weight, status
+}

--- a/frontend/src/perspectives/causa/views/registry.ts
+++ b/frontend/src/perspectives/causa/views/registry.ts
@@ -1,0 +1,10 @@
+import { FunctionComponent } from 'react';
+
+/**
+ * Registry of available views within the Causal Perspective.
+ * Currently empty, will hold 'cld', 'list', 'matrix', etc.
+ */
+export const ViewRegistry: Record<string, FunctionComponent<any>> = {
+    // To be populated:
+    // 'cld': CLDView,
+};

--- a/frontend/src/perspectives/types.ts
+++ b/frontend/src/perspectives/types.ts
@@ -1,0 +1,17 @@
+import { ReactNode } from 'react';
+
+/**
+ * A Perspective provides a specific way to interact with the underlying Graph.
+ * It defines how data is projected, what views are available, and what rules apply.
+ */
+export interface Perspective {
+    id: string;
+    name: string;
+    description: string;
+
+    /**
+     * The React component that renders the shell/layout for this perspective.
+     * Starts blank, will eventually manage the layout sessions.
+     */
+    Shell: () => ReactNode;
+}


### PR DESCRIPTION
**Implementation of US-CAUSA-01: Perspective Module Isolation**

This PR establishes the directory structure and core contracts for the Causal Perspective.

**Changes:**
- Created `src/perspectives/types.ts`: Generic `Perspective` interface.
- Created `src/perspectives/causa/`:
    - `index.ts`: Public API.
    - `types.ts`: Domain types (CausalNode, CausalLink).
    - `projections/graph.ts`: Placeholder for graph projection.
    - `views/registry.ts`: Placeholder for view registry.

**Verification:**
- `npx tsc -b` passes.
- Structure aligns with architectural plan.
- No impact on existing functionality (purely additive scaffolding).

**Epic**: #69
**Fixes**: #70