### PR TITLE
feat(causa): implement Link Status and Uncertainty UI (US-CAUSA-05)

### DIFF
--- a/frontend/src/perspectives/causa/layout/types.ts
+++ b/frontend/src/perspectives/causa/layout/types.ts
@@ -25,6 +25,10 @@ export interface LayoutLink {
     // Layout properties
     strength?: number;
     distance?: number;
+
+    // Visualization properties (from US-CAUSA-05)
+    status?: 'proposed' | 'validated' | 'rejected';
+    certainty?: number; // 0.0 - 1.0 (Opacity)
 }
 
 export interface LayoutConfig {

--- a/frontend/src/perspectives/causa/views/CLDView.tsx
+++ b/frontend/src/perspectives/causa/views/CLDView.tsx
@@ -42,7 +42,11 @@ export const CLDView: FunctionComponent<CLDViewProps> = ({ session, runner }) =>
         source: typeof l.source === 'object' ? (l.source as any).id : l.source,
         target: typeof l.target === 'object' ? (l.target as any).id : l.target,
         type: 'cldEdge',
-        data: { polarity: '+' } // Todo: Real polarity from link data
+        data: {
+            polarity: '+', // Todo: Real polarity from link data
+            status: Math.random() > 0.5 ? 'validated' : 'proposed',
+            certainty: Math.random()
+        }
     }));
 
     const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);

--- a/frontend/src/perspectives/causa/views/edges/CLDEdge.tsx
+++ b/frontend/src/perspectives/causa/views/edges/CLDEdge.tsx
@@ -22,10 +22,24 @@ const CLDEdge: FunctionComponent<EdgeProps> = ({
     });
 
     const polarity = data?.polarity; // '+' or '-'
+    const status = data?.status || 'validated';
+    const certainty = data?.certainty ?? 1.0;
+
+    // Visual Mapping
+    const isProposed = status === 'proposed';
+    const opacity = 0.3 + (certainty * 0.7); // Min 0.3 opacity
 
     return (
         <>
-            <BaseEdge path={edgePath} markerEnd={markerEnd} style={style} />
+            <BaseEdge
+                path={edgePath}
+                markerEnd={markerEnd}
+                style={{
+                    ...style,
+                    opacity,
+                    strokeDasharray: isProposed ? '5,5' : undefined,
+                }}
+            />
             {polarity && (
                 <EdgeLabelRenderer>
                     <div


### PR DESCRIPTION
**Implementation of US-CAUSA-05: Uncertainty & Status UI**

This PR updates the internal data model and visualization to support "uncertain" or "proposed" causal links.

**Changes:**
- `types.ts`: Added `status` ('proposed' | 'validated') and `certainty` to `LayoutLink`.
- `CLDEdge.tsx`: Implemented visual mapping:
    - **Dashed Line**: `status === 'proposed'`
    - **Opacity**: Derived from `certainty`.
    - **Mock Data**: Injected random status in `CLDView` for verification.

**Note**:
- Backend persistence is deferred to **US-CAUSA-Backend-01** (GH #84). This PR uses frontend-defaults for now.

**Epic**: #69
**Fixes**: #74