### PR TITLE
fix: missing models and context menu localization (#145)

### DIFF
--- a/backend/app/models/domain.py
+++ b/backend/app/models/domain.py
@@ -162,9 +162,18 @@ class Decision(BaseModel):
 class ConversationThread(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     topic: Optional[str] = None
-    theme_version_id: str = Field(..., alias="space_id") # Aliased for backward DB compatibility until migration is complete
+    target_id: str = Field(..., description="Polymorphic reference to ThemeVersion, FactorVersion, etc.")
     status: str = "active"
     created_at: datetime = Field(default_factory=datetime.now)
+
+class ConversationMessage(BaseModel):
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    content: str
+    created_at: datetime = Field(default_factory=datetime.now)
+    user_id: str
+
+class ThreadMessageCreate(BaseModel):
+    content: str
 
 class Proposal(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))

--- a/frontend/src/components/shell/CanvasContextMenu.tsx
+++ b/frontend/src/components/shell/CanvasContextMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
-import { MessageSquareText, X } from 'lucide-react';
+import { MessageSquareText, MessageSquare, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 
@@ -41,6 +41,11 @@ interface CanvasContextMenuProps {
     onOpenObjectConversation: (object: ContextObject) => void;
 
     /**
+     * Handler to open the human-to-human discussion thread
+     */
+    onOpenThread?: (object: ContextObject) => void;
+
+    /**
      * Handler to edit the object
      */
     onEdit?: (object: ContextObject) => void;
@@ -58,6 +63,7 @@ export const CanvasContextMenu: React.FC<CanvasContextMenuProps> = ({
     contextObject,
     onDismiss,
     onOpenObjectConversation,
+    onOpenThread,
     onEdit,
     additionalActions = [],
     className
@@ -107,7 +113,7 @@ export const CanvasContextMenu: React.FC<CanvasContextMenuProps> = ({
                 <button
                     onClick={onDismiss}
                     className="text-muted-foreground hover:text-foreground"
-                    aria-label="Close menu"
+                    aria-label="Sluiten"
                 >
                     <X className="h-3 w-3" />
                 </button>
@@ -129,7 +135,7 @@ export const CanvasContextMenu: React.FC<CanvasContextMenuProps> = ({
                 </Button>
             )}
 
-            {/* Primary Action: Conversation */}
+            {/* Primary Action: AI Conversation */}
             <Button
                 variant="ghost"
                 size="sm"
@@ -140,8 +146,24 @@ export const CanvasContextMenu: React.FC<CanvasContextMenuProps> = ({
                 }}
             >
                 <MessageSquareText className="h-4 w-4" />
-                <span>Open Conversation</span>
+                <span>AI Chat openen</span>
             </Button>
+
+            {/* Human Thread Action */}
+            {onOpenThread && (
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    className="justify-start gap-2 h-8 px-2 w-full text-blue-600 hover:text-blue-700 hover:bg-blue-50 dark:hover:bg-blue-900/20"
+                    onClick={() => {
+                        onOpenThread(contextObject);
+                        onDismiss();
+                    }}
+                >
+                    <MessageSquare className="h-4 w-4" />
+                    <span>Discussie openen</span>
+                </Button>
+            )}
 
             {/* Additional Actions */}
             {additionalActions.map((action) => (


### PR DESCRIPTION
Nagekomen wijzigingen voor #145.
- Toevoegen van `ConversationMessage` en `ThreadMessageCreate` modellen.
- Lokalisatie van `CanvasContextMenu` en toevoegen van 'Discussie openen' actie.