### PR TITLE
feat: temporal attributes for knowledge nodes

### DIFF
--- a/backend/app/db/crud.py
+++ b/backend/app/db/crud.py
@@ -1175,7 +1175,9 @@ async def create_factor_manual(name: str, description: Optional[str], type: str,
         description: $desc,
         type: $type,
         version_id: tv.id,
-        created_at: datetime()
+        created_at: datetime(),
+        valid_from: datetime(),
+        valid_to: NULL
     })
     CREATE (fb)-[:HAS_VERSION]->(fv) // Base -> Version
     CREATE (tv)-[:HAS_FACTOR]->(fv)
@@ -1250,7 +1252,9 @@ async def create_claim_manual(theme_id: str, source_id: str, target_id: str, sta
         confidence: $conf,
         source_version_id: fv_source.id,
         target_version_id: fv_target.id,
-        created_at: datetime()
+        created_at: datetime(),
+        valid_from: datetime(),
+        valid_to: NULL
     })
     CREATE (cb)-[:HAS_VERSION]->(cv) // Base -> Version
     
@@ -1340,10 +1344,13 @@ async def create_decision(theme_id: str, description: str, author_id: str) -> st
         type: old_f.type,
         description: old_f.description,
         version_id: new_v.id,
-        created_at: datetime()
+        created_at: datetime(),
+        valid_from: datetime(),
+        valid_to: NULL
     })
     CREATE (new_v)-[:HAS_FACTOR]->(new_f)
     CREATE (new_f)-[:DERIVED_FROM]->(old_f) // Lineage
+    SET old_f.valid_to = datetime() // Close validity of old factor
     
     // Link to existing FactorBase
     WITH new_v, old_v, old_f, new_f
@@ -1376,12 +1383,15 @@ async def create_decision(theme_id: str, description: str, author_id: str) -> st
         polarity: old_c.polarity,
         source_version_id: new_f_source.id,
         target_version_id: new_f_target.id,
-        created_at: datetime()
+        created_at: datetime(),
+        valid_from: datetime(),
+        valid_to: NULL
     })
     
     CREATE (new_f_source)-[:CLAIMS]->(new_c)
     CREATE (new_c)-[:TO]->(new_f_target)
     CREATE (new_c)-[:DERIVED_FROM]->(old_c) // Lineage
+    SET old_c.valid_to = datetime() // Close validity of old claim
     
     // Link to existing ClaimBase
     WITH new_c, old_c, new_v

--- a/backend/app/models/domain.py
+++ b/backend/app/models/domain.py
@@ -57,6 +57,8 @@ class FactorVersion(BaseModel):
     type: str = "systeemelement"
     description: Optional[str] = None
     version_id: str = Field(description="Belongs to ThemeVersion")
+    valid_from: datetime
+    valid_to: Optional[datetime] = None
     # Derived from? Optional logic
 
 class ClaimVersion(BaseModel):
@@ -68,6 +70,8 @@ class ClaimVersion(BaseModel):
     # Note: connect to FactorVersions in graph
     source_version_id: str
     target_version_id: str
+    valid_from: datetime
+    valid_to: Optional[datetime] = None
 
 # --- API Data Models (Legacy Compatibility / Frontend View) ---
 

--- a/backend/scripts/verify_temporal_logic.py
+++ b/backend/scripts/verify_temporal_logic.py
@@ -52,6 +52,18 @@ async def verify_temporal_logic():
         print(f"   V1 FactorVersion Count: {c} (Expected 2)")
         assert c == 2
 
+        # Verify Factor Temporal Attributes (V1)
+        check_temp = """
+        MATCH (t:ThemeBase {id: $tid})-[:HAS_VERSION]->(v:ThemeVersion {status: 'active'})
+        MATCH (v)-[:HAS_FACTOR]->(fv:FactorVersion)
+        RETURN fv.valid_from as vf, fv.valid_to as vt
+        """
+        temp_res = session.run(check_temp, {"tid": theme_id}).data()
+        for rec in temp_res:
+             assert rec['vf'] is not None
+             assert rec['vt'] is None
+        print("   V1 FactorVersion Temporal Attributes Verified (valid_from IS SET, valid_to IS NULL)")
+
     # 3. Decision Time: Snapshot V1 -> Start V2
     print("3. Creating Decision (Snapshotting V1, Starting V2)...")
     new_version_id = await create_decision(theme_id, "Baseline Established", user_id)
@@ -124,6 +136,25 @@ async def verify_temporal_logic():
         """, {"cid": c1_id}).single()
         print(f"   Claim 1 Version Linked Count: {r['count']} (Expected 2)")
         assert r['count'] == 2
+        
+        # Verify Temporal Attributes Logic (Snapshot Effect)
+        # Old Version (V1) Factors should have valid_to SET
+        r = session.run("""
+            MATCH (v1:ThemeVersion)-[:HAS_FACTOR]->(fv1:FactorVersion {base_id: $fid})
+            WHERE v1.valid_to IS NOT NULL
+            RETURN fv1.valid_to as vt
+        """, {"fid": f1_id}).single()
+        print(f"   Old Factor (V1, A) valid_to: {r['vt']}")
+        assert r['vt'] is not None
+
+        # New Version (V2) Factors should have valid_from SET, valid_to NULL
+        r = session.run("""
+            MATCH (v2:ThemeVersion {id: $vid})-[:HAS_FACTOR]->(fv2:FactorVersion {base_id: $fid})
+            RETURN fv2.valid_from as vf, fv2.valid_to as vt
+        """, {"vid": new_version_id, "fid": f1_id}).single()
+        print(f"   New Factor (V2, A) valid_from: {r['vf']}, valid_to: {r['vt']}")
+        assert r['vf'] is not None
+        assert r['vt'] is None
 
     print("🎉 BASE/VERSION REFACTOR VERIFIED SUCCESSFULLY.")
 


### PR DESCRIPTION
Fixes #170

Implemented valid_from and valid_to attributes on FactorVersion and ClaimVersion nodes.
Updated CRUD logic to:
- Initialize valid_from=now() on creation.
- Close old versions (valid_to=now()) during snapshotting.
- Open new versions (valid_from=now()) during snapshotting.

Verified with backend/scripts/verify_temporal_logic.py.