### PR TITLE
Refactoren: Rol van Factoren naar Relatie verplaatst (#188)

### DIFF
--- a/backend/app/db/crud.py
+++ b/backend/app/db/crud.py
@@ -50,11 +50,11 @@ async def save_claims(conversation_id: str, claims: List[Claim]):
             id: randomUUID(),
             base_id: fb_source.id,
             name: claim.source_node,
-            type: coalesce(claim.source_type, 'systeemelement'),
+            // type removed - now context-dependent on relationship
             version_id: v.id,
             created_at: datetime()
         })
-        CREATE (v)-[:HAS_FACTOR]->(fv_source)
+        CREATE (v)-[:HAS_FACTOR {role: coalesce(claim.source_type, 'systeemelement')}]->(fv_source)
         // No User-Created ink for agent? Or link to System Admin?
         RETURN fv_source as source_v
         
@@ -81,11 +81,11 @@ async def save_claims(conversation_id: str, claims: List[Claim]):
             id: randomUUID(),
             base_id: fb_target.id,
             name: claim.target_node,
-            type: coalesce(claim.target_type, 'systeemelement'),
+            // type removed - now context-dependent on relationship
             version_id: v.id,
             created_at: datetime()
         })
-        CREATE (v)-[:HAS_FACTOR]->(fv_target)
+        CREATE (v)-[:HAS_FACTOR {role: coalesce(claim.target_type, 'systeemelement')}]->(fv_target)
         RETURN fv_target as target_v
         
         UNION
@@ -1151,14 +1151,14 @@ async def get_factors_for_version(version_id: str) -> List[Dict]:
     driver = get_driver()
     query = """
     MATCH (tv:ThemeVersion {id: $vid})
-    MATCH (tv)-[:HAS_FACTOR]->(fv:FactorVersion)
+    MATCH (tv)-[r:HAS_FACTOR]->(fv:FactorVersion)
     OPTIONAL MATCH (fv)-[:HAS_THREAD]->(t:ConversationThread)
     RETURN DISTINCT {
         id: fv.base_id,              // Frontend expects Identity ID
         version_id: fv.id,           // Specific Version ID
         name: fv.name,
         description: fv.description,
-        type: fv.type,
+        type: r.role,                // Fetched from relationship
         theme_id: fv.theme_id,       // If encoded in FactorVersion, or we omit
         thread_id: t.id
     } as factor
@@ -1225,14 +1225,14 @@ async def create_factor_manual(name: str, description: Optional[str], type: str,
         base_id: $fid,
         name: $name,
         description: $desc,
-        type: $type,
+        // type removed - now context-dependent on relationship
         version_id: tv.id,
         created_at: datetime(),
         valid_from: datetime(),
         valid_to: NULL
     })
     CREATE (fb)-[:HAS_VERSION]->(fv) // Base -> Version
-    CREATE (tv)-[:HAS_FACTOR]->(fv)
+    CREATE (tv)-[:HAS_FACTOR {role: $type}]->(fv)
     
     RETURN fb.id as id // Return Base ID to be consistent with "Entity Identity"
     """
@@ -1274,12 +1274,12 @@ async def update_factor_manual(factor_id: str, name: Optional[str], description:
     WHERE tv.status = 'active' AND tv.valid_to IS NULL
     
     MATCH (fb:FactorBase {id: $fid})
-    MATCH (tv)-[:HAS_FACTOR]->(fv:FactorVersion)
+    MATCH (tv)-[rel:HAS_FACTOR]->(fv:FactorVersion)
     WHERE fv.base_id = fb.id
     
     SET fv.name = coalesce($name, fv.name), 
         fv.description = coalesce($desc, fv.description),
-        fv.type = coalesce($type, fv.type)
+        rel.role = coalesce($type, rel.role)
     """
     with driver.session() as session:
         session.run(query, {"fid": factor_id, "tid": theme_id, "name": name, "desc": description, "type": type})
@@ -1452,21 +1452,21 @@ async def create_decision(theme_id: str, description: str, author_id: str) -> st
     q_copy_factors = """
     MATCH (old_v:ThemeVersion {id: $old_id})
     MATCH (new_v:ThemeVersion {id: $new_id})
-    MATCH (old_v)-[:HAS_FACTOR]->(old_f:FactorVersion)
-    WITH DISTINCT old_v, new_v, old_f
+    MATCH (old_v)-[r:HAS_FACTOR]->(old_f:FactorVersion)
+    WITH DISTINCT old_v, new_v, old_f, r
     
     CREATE (new_f:FactorVersion {
         id: randomUUID(),
         base_id: old_f.base_id,
         name: old_f.name,
-        type: old_f.type,
+        // type removed from node
         description: old_f.description,
         version_id: new_v.id,
         created_at: datetime(),
         valid_from: datetime(),
         valid_to: NULL
     })
-    CREATE (new_v)-[:HAS_FACTOR]->(new_f)
+    CREATE (new_v)-[:HAS_FACTOR {role: r.role}]->(new_f)
     CREATE (new_f)-[:DERIVED_FROM]->(old_f)
     SET old_f.valid_to = datetime()
     

--- a/backend/app/models/domain.py
+++ b/backend/app/models/domain.py
@@ -55,7 +55,7 @@ class FactorVersion(BaseModel):
     id: str
     base_id: str = Field(description="Reference to FactorBase")
     name: str
-    type: str = "systeemelement"
+    # type removed - now context-dependent on relationship role
     description: Optional[str] = None
     version_id: str = Field(description="Belongs to ThemeVersion")
     valid_from: datetime
@@ -79,7 +79,7 @@ class ClaimVersion(BaseModel):
 class Factor(FactorBase): 
     # Use Base ID as 'id' for stable reference
     name: str 
-    type: str
+    type: str = Field(description="Derived from HAS_FACTOR relationship role")
     description: Optional[str]
     version_id: str # The ID of the specific version being viewed
     thread_id: Optional[str] = None

--- a/backend/scripts/migrate_factor_roles.py
+++ b/backend/scripts/migrate_factor_roles.py
@@ -1,80 +1,61 @@
 import os
+import uuid
 import logging
+from datetime import datetime
 from neo4j import GraphDatabase
-from dotenv import load_dotenv
-import sys
 
-# Setup logging
+# Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-# Load env vars - try multiple paths
-load_dotenv(dotenv_path="../.env")
-if not os.getenv("NEO4J_URI"):
-    load_dotenv(dotenv_path="../../.env")
-if not os.getenv("NEO4J_URI"):
-    # Fallback for when running from project root
-    load_dotenv(dotenv_path=".env")
+# Neo4j connection details from environment
+NEO4J_URI = os.environ.get("NEO4J_URI", "bolt://causa-neo4j:7687")
+NEO4J_USER = os.environ.get("NEO4J_USER", "neo4j")
+NEO4J_PASSWORD = os.environ.get("NEO4J_PASSWORD", "password")
 
-NEO4J_URI = os.getenv("NEO4J_URI")
-NEO4J_USERNAME = os.getenv("NEO4J_USERNAME")
-NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD")
-
-def migrate_roles():
-    if not NEO4J_URI or not NEO4J_USERNAME or not NEO4J_PASSWORD:
-        logger.error("Neo4j credentials not found in env.")
-        # Fallback to defaults or exit
-        return
-
-    try:
-        driver = GraphDatabase.driver(NEO4J_URI, auth=(NEO4J_USERNAME, NEO4J_PASSWORD))
-        driver.verify_connectivity()
-        logger.info("Connected to Neo4j.")
-    except Exception as e:
-        logger.error(f"Failed to connect to Neo4j: {e}")
-        return
-
-    query_migrate = """
-    MATCH (th:Theme)-[r:HAS_FACTOR]->(f:Factor)
-    WHERE f.type IS NOT NULL
-    SET r.role = f.type
+def migrate_factor_roles():
     """
+    Migrates the 'type' property from FactorVersion nodes to the 'role' property
+    on the incoming HAS_FACTOR relationship from ThemeVersion.
+    """
+    logger.info("Starting migration: FactorVersion.type -> HAS_FACTOR.role")
     
-    query_cleanup = """
-    MATCH (f:Factor)
-    WHERE f.type IS NOT NULL
-    REMOVE f.type
-    """
+    driver = GraphDatabase.driver(NEO4J_URI, auth=(NEO4J_USER, NEO4J_PASSWORD))
     
-    # Optional: Set default role for relationships that might not have one (if any)
-    query_default = """
-    MATCH (th:Theme)-[r:HAS_FACTOR]->(f:Factor)
-    WHERE r.role IS NULL
-    SET r.role = 'systeemelement'
-    """
-
-    try:
-        with driver.session() as session:
-            logger.info("Migrating roles from Factor nodes to HAS_FACTOR relationships...")
-            result = session.run(query_migrate)
-            summary = result.consume()
-            logger.info(f"Updated {summary.counters.properties_set} properties in relationships.")
-
-            logger.info("Setting default role for any missing relationships...")
-            result = session.run(query_default)
-            summary = result.consume()
-            logger.info(f"Set default defaults for {summary.counters.properties_set} relationships.")
-
-            logger.info("Removing 'type' property from Factor nodes (Cleanup)...")
-            result = session.run(query_cleanup)
-            summary = result.consume()
-            logger.info(f"Removed type property from {summary.counters.properties_set} nodes.")
+    with driver.session() as session:
+        # 1. Find all relationships to migrate
+        # We look for ThemeVersion -> FactorVersion where FactorVersion has a 'type' property
+        query_find = """
+        MATCH (tv:ThemeVersion)-[r:HAS_FACTOR]->(fv:FactorVersion)
+        WHERE fv.type IS NOT NULL
+        RETURN tv.id as theme_version_id, fv.id as factor_version_id, fv.type as factor_type, r.role as existing_role
+        """
+        
+        results = session.run(query_find)
+        records = list(results)
+        logger.info(f"Found {len(records)} relationships to potentially migrate.")
+        
+        # 2. Apply migration in a transaction
+        query_migrate = """
+        MATCH (tv:ThemeVersion)-[r:HAS_FACTOR]->(fv:FactorVersion)
+        WHERE fv.type IS NOT NULL
+        SET r.role = fv.type
+        REMOVE fv.type
+        RETURN count(*) as migrated_count
+        """
+        
+        with session.begin_transaction() as tx:
+            result = tx.run(query_migrate)
+            migrated_count = result.single()["migrated_count"]
+            tx.commit()
             
-            logger.info("Migration complete.")
-    except Exception as e:
-        logger.error(f"Migration failed: {e}")
-    finally:
-        driver.close()
+        logger.info(f"Migration complete. {migrated_count} relationships updated and properties removed.")
+
+    driver.close()
 
 if __name__ == "__main__":
-    migrate_roles()
+    try:
+        migrate_factor_roles()
+    except Exception as e:
+        logger.error(f"Migration failed: {e}")
+        exit(1)


### PR DESCRIPTION
Sluit issue #188. Factortypen zijn met succes verplaatst van `FactorVersion` nodes naar de `role` string property op `[:HAS_FACTOR]` relaties. Migratiescript is gedraaid en frontend UI geverifieerd.