### PR TITLE
feat: auth op DELETE /factors/{id} (US-0.2)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -756,9 +756,11 @@ async def update_factor_route(factor_id: str, factor: FactorUpdate, user: dict =
     return {"status": "updated"}
 
 @app.delete("/factors/{factor_id}")
-async def delete_factor_route(factor_id: str):
+async def delete_factor_route(factor_id: str, user: dict = Depends(get_current_user)):
     # Get project ID before deletion!
     project_id = await get_project_id_by_factor(factor_id)
+    if not project_id or not await check_permission(user["id"], project_id, Role.MEMBER):
+        raise HTTPException(status_code=403, detail="Geen toegang om deze factor te verwijderen")
     await delete_factor_manual(factor_id)
     if project_id:
          await manager.broadcast_data(project_id, {


### PR DESCRIPTION
## Wat

Voegt authenticatie en autorisatie toe aan `DELETE /factors/{factor_id}`.

## Wijzigingen

- `get_current_user` dependency toegevoegd aan de route
- `check_permission(user["id"], project_id, Role.MEMBER)` vóór de delete
- HTTP 403 bij ontbrekende rechten of onbekende factor

## Acceptatiecriteria

- [x] get_current_user toegevoegd aan route
- [x] check_permission(MEMBER) uitgevoerd vóór delete
- [x] HTTP 403 bij onbevoegde aanroep
- [x] HTTP 200 bij bevoegde aanroep ongewijzigd

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)