### PR TITLE
feat: Fuseki deployen via Coolify op intern netwerk (#285)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ playwright/
 *.yml
 !.agent/*.yaml
 !.agent/*.yml
+!docker-compose*.yml
+!docker-compose*.yaml
 docs/.env-prod
 backend/.env.production
 frontend/lint_output*.txt

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -24,7 +24,27 @@ Dit is de primaire deployment methode voor de Valor applicatie op een eigen VPS 
    - Voeg `https://valor-ecosystem.nl` toe aan de **Redirect URLs** (zodat invites en login werken).
    - Voeg ook `https://valor-ecosystem.nl/update-password` toe voor wachtwoord resets.
 
-## 3. Frontend Setup (valor-ecosystem.nl)
+## 3. Fuseki Setup (intern netwerk — geen publiek domein)
+
+Fuseki draait als interne service — alleen bereikbaar voor de backend via het interne Coolify-netwerk.
+
+1. **Service:** Maak een nieuwe "Application" aan in Coolify.
+2. **Context:** Zet de `Base Directory` op `/fuseki`.
+3. **Dockerfile:** Coolify detecteert automatisch de `Dockerfile` in `/fuseki`.
+4. **Domeinen:** Geen publiek domein instellen.
+5. **Poort:** Intern op `3030` — niet exposen naar buiten.
+6. **Environment Variables:**
+   - `ADMIN_PASSWORD`: (sterk wachtwoord — gebruik hetzelfde als `FUSEKI_ADMIN_PASSWORD` in de backend)
+   - `FUSEKI_DATASET_1`: `valor`
+   - `FUSEKI_ADMIN_PASSWORD`: (zelfde wachtwoord als `ADMIN_PASSWORD`)
+   - `ONTOLOGY_REPO`: `https://github.com/LeonardDune/valor-ontology.git`
+7. **Volume:** Voeg een persistent volume toe met mount path `/fuseki` (TDB2-persistentie).
+8. **Backend koppelen:** Voeg aan de backend-service toe:
+   - `FUSEKI_URL`: `http://<coolify-interne-naam>:3030` (de interne Coolify-hostnaam van deze service)
+
+> De `entrypoint.sh` laadt bij eerste opstart automatisch de VALOR-O ontologie vanuit GitHub. Volgende starts slaan dit over via een sentinel graph.
+
+## 4. Frontend Setup (valor-ecosystem.nl)
 1. **Service:** Maak een nieuwe "Application" aan in Coolify.
 2. **Context:** Zet de `Base Directory` op `/frontend`.
 3. **Dockerfile:** Coolify gebruikt de `Dockerfile` in `/frontend` (multi-stage build met Nginx).

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,66 @@
+services:
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: valor-backend-prod
+    restart: always
+    environment:
+      - PORT=8000
+    # Env variables like NEO4J_URI are managed in Coolify UI
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8000/health" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  fuseki:
+    image: stain/jena-fuseki
+    container_name: valor-fuseki-prod
+    restart: always
+    # Geen publieke poort — alleen bereikbaar via intern Coolify-netwerk
+    volumes:
+      - fuseki_data:/fuseki
+    environment:
+      # ADMIN_PASSWORD en FUSEKI_DATASET_1 worden ingesteld via Coolify UI
+      - ADMIN_PASSWORD=${FUSEKI_ADMIN_PASSWORD}
+      - FUSEKI_DATASET_1=valor
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:3030/$/ping || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
+  fuseki-loader:
+    image: alpine
+    container_name: valor-fuseki-loader-prod
+    volumes:
+      - ./fuseki/load-ontology.sh:/load-ontology.sh:ro
+    command: sh /load-ontology.sh
+    environment:
+      - FUSEKI_URL=http://fuseki:3030
+      - FUSEKI_ADMIN_PASSWORD=${FUSEKI_ADMIN_PASSWORD}
+      - DATASET=valor
+      - ONTOLOGY_REPO=https://github.com/LeonardDune/valor-ontology.git
+    depends_on:
+      fuseki:
+        condition: service_healthy
+    restart: "no"
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      args:
+        - VITE_API_URL=https://api.valor-ecosystem.nl
+    container_name: valor-frontend-prod
+    restart: always
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost/health" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+volumes:
+  fuseki_data:

--- a/fuseki/Dockerfile
+++ b/fuseki/Dockerfile
@@ -1,0 +1,11 @@
+FROM stain/jena-fuseki
+
+USER root
+
+COPY load-ontology.sh /load-ontology.sh
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /load-ontology.sh /entrypoint.sh
+
+USER fuseki
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/fuseki/entrypoint.sh
+++ b/fuseki/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# Start Fuseki via de originele entrypoint in de achtergrond
+/docker-entrypoint.sh &
+FUSEKI_PID=$!
+
+# Laad de VALOR-O ontologie (script wacht zelf op Fuseki health)
+/load-ontology.sh
+
+# Fuseki op de voorgrond houden
+wait $FUSEKI_PID

--- a/fuseki/load-ontology.sh
+++ b/fuseki/load-ontology.sh
@@ -9,7 +9,11 @@ SENTINEL_GRAPH="urn:valor:ontology-loaded"
 AUTH="-u admin:${FUSEKI_ADMIN_PASSWORD}"
 
 echo "[fuseki-loader] Benodigde tools installeren..."
-apk add --no-cache curl git > /dev/null 2>&1
+if command -v apk > /dev/null 2>&1; then
+  apk add --no-cache curl git > /dev/null 2>&1
+elif command -v apt-get > /dev/null 2>&1; then
+  apt-get update -qq && apt-get install -y --no-install-recommends curl git > /dev/null 2>&1
+fi
 
 echo "[fuseki-loader] Wachten op Fuseki..."
 until curl -sf "${FUSEKI_URL}/\$/ping" > /dev/null; do


### PR DESCRIPTION
## Samenvatting

- Voegt `fuseki` service toe aan `docker-compose.prod.yml` zonder publieke poort (alleen bereikbaar via intern Coolify-netwerk)
- Voegt `fuseki-loader` init-container toe die bij opstart VALOR-O ontologie kloont van GitHub en laadt
- Voegt `fuseki_data` named volume toe voor persistente TDB2-opslag
- Fixet `.gitignore` om `docker-compose*.yml` bestanden te whitelisten

## Configuratie (Coolify UI)
- `FUSEKI_ADMIN_PASSWORD` — vereist, stel in via Coolify environment variabelen
- Fuseki is bereikbaar via intern Docker-netwerk op `http://fuseki:3030`

## Testplan
- [ ] `docker-compose.prod.yml` is aanwezig in repository
- [ ] Fuseki-service heeft geen publieke poort in productieconfiguratie
- [ ] `fuseki-loader` is afhankelijk van `fuseki` health check
- [ ] `FUSEKI_ADMIN_PASSWORD` wordt doorgegeven via omgevingsvariabele (niet hardcoded)

Closes #285