### PR TITLE
epic: Fuseki Triplestore Infrastructuur (#268)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ playwright/
 *.yml
 !.agent/*.yaml
 !.agent/*.yml
+!docker-compose*.yml
+!docker-compose*.yaml
 docs/.env-prod
 backend/.env.production
 frontend/lint_output*.txt

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -24,7 +24,27 @@ Dit is de primaire deployment methode voor de Valor applicatie op een eigen VPS 
    - Voeg `https://valor-ecosystem.nl` toe aan de **Redirect URLs** (zodat invites en login werken).
    - Voeg ook `https://valor-ecosystem.nl/update-password` toe voor wachtwoord resets.
 
-## 3. Frontend Setup (valor-ecosystem.nl)
+## 3. Fuseki Setup (intern netwerk — geen publiek domein)
+
+Fuseki draait als interne service — alleen bereikbaar voor de backend via het interne Coolify-netwerk.
+
+1. **Service:** Maak een nieuwe "Application" aan in Coolify.
+2. **Context:** Zet de `Base Directory` op `/fuseki`.
+3. **Dockerfile:** Coolify detecteert automatisch de `Dockerfile` in `/fuseki`.
+4. **Domeinen:** Geen publiek domein instellen.
+5. **Poort:** Intern op `3030` — niet exposen naar buiten.
+6. **Environment Variables:**
+   - `ADMIN_PASSWORD`: (sterk wachtwoord — gebruik hetzelfde als `FUSEKI_ADMIN_PASSWORD` in de backend)
+   - `FUSEKI_DATASET_1`: `valor`
+   - `FUSEKI_ADMIN_PASSWORD`: (zelfde wachtwoord als `ADMIN_PASSWORD`)
+   - `ONTOLOGY_REPO`: `https://github.com/LeonardDune/valor-ontology.git`
+7. **Volume:** Voeg een persistent volume toe met mount path `/fuseki` (TDB2-persistentie).
+8. **Backend koppelen:** Voeg aan de backend-service toe:
+   - `FUSEKI_URL`: `http://<coolify-interne-naam>:3030` (de interne Coolify-hostnaam van deze service)
+
+> De `entrypoint.sh` laadt bij eerste opstart automatisch de VALOR-O ontologie vanuit GitHub. Volgende starts slaan dit over via een sentinel graph.
+
+## 4. Frontend Setup (valor-ecosystem.nl)
 1. **Service:** Maak een nieuwe "Application" aan in Coolify.
 2. **Context:** Zet de `Base Directory` op `/frontend`.
 3. **Dockerfile:** Coolify gebruikt de `Dockerfile` in `/frontend` (multi-stage build met Nginx).

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,66 @@
+services:
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: valor-backend-prod
+    restart: always
+    environment:
+      - PORT=8000
+    # Env variables like NEO4J_URI are managed in Coolify UI
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8000/health" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  fuseki:
+    image: stain/jena-fuseki
+    container_name: valor-fuseki-prod
+    restart: always
+    # Geen publieke poort — alleen bereikbaar via intern Coolify-netwerk
+    volumes:
+      - fuseki_data:/fuseki
+    environment:
+      # ADMIN_PASSWORD en FUSEKI_DATASET_1 worden ingesteld via Coolify UI
+      - ADMIN_PASSWORD=${FUSEKI_ADMIN_PASSWORD}
+      - FUSEKI_DATASET_1=valor
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:3030/$/ping || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
+  fuseki-loader:
+    image: alpine
+    container_name: valor-fuseki-loader-prod
+    volumes:
+      - ./fuseki/load-ontology.sh:/load-ontology.sh:ro
+    command: sh /load-ontology.sh
+    environment:
+      - FUSEKI_URL=http://fuseki:3030
+      - FUSEKI_ADMIN_PASSWORD=${FUSEKI_ADMIN_PASSWORD}
+      - DATASET=valor
+      - ONTOLOGY_REPO=https://github.com/LeonardDune/valor-ontology.git
+    depends_on:
+      fuseki:
+        condition: service_healthy
+    restart: "no"
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      args:
+        - VITE_API_URL=https://api.valor-ecosystem.nl
+    container_name: valor-frontend-prod
+    restart: always
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost/health" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+volumes:
+  fuseki_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,3 +16,39 @@ services:
       - WATCHFILES_FORCE_POLLING=true # Often needed for hot reload in Docker on some systems
     # Neo4j is cloud-hosted (AuraDB)
     # See backend/.env for connection details
+
+  fuseki:
+    image: stain/jena-fuseki
+    container_name: valor-fuseki
+    ports:
+      - "3030:3030"
+    volumes:
+      - fuseki_data:/fuseki
+    environment:
+      - ADMIN_PASSWORD=admin
+      - FUSEKI_DATASET_1=valor
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:3030/$/ping || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+
+  fuseki-loader:
+    image: alpine
+    container_name: valor-fuseki-loader
+    volumes:
+      - ./fuseki/load-ontology.sh:/load-ontology.sh:ro
+    command: sh /load-ontology.sh
+    environment:
+      - FUSEKI_URL=http://fuseki:3030
+      - FUSEKI_ADMIN_PASSWORD=admin
+      - DATASET=valor
+      - ONTOLOGY_REPO=https://github.com/LeonardDune/valor-ontology.git
+    depends_on:
+      fuseki:
+        condition: service_healthy
+    restart: "no"
+
+volumes:
+  fuseki_data:

--- a/fuseki/Dockerfile
+++ b/fuseki/Dockerfile
@@ -1,0 +1,11 @@
+FROM stain/jena-fuseki
+
+USER root
+
+COPY load-ontology.sh /load-ontology.sh
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /load-ontology.sh /entrypoint.sh
+
+USER fuseki
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/fuseki/entrypoint.sh
+++ b/fuseki/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# Start Fuseki via de originele entrypoint in de achtergrond
+/docker-entrypoint.sh &
+FUSEKI_PID=$!
+
+# Laad de VALOR-O ontologie (script wacht zelf op Fuseki health)
+/load-ontology.sh
+
+# Fuseki op de voorgrond houden
+wait $FUSEKI_PID

--- a/fuseki/load-ontology.sh
+++ b/fuseki/load-ontology.sh
@@ -9,7 +9,11 @@ SENTINEL_GRAPH="urn:valor:ontology-loaded"
 AUTH="-u admin:${FUSEKI_ADMIN_PASSWORD}"
 
 echo "[fuseki-loader] Benodigde tools installeren..."
-apk add --no-cache curl git > /dev/null 2>&1
+if command -v apk > /dev/null 2>&1; then
+  apk add --no-cache curl git > /dev/null 2>&1
+elif command -v apt-get > /dev/null 2>&1; then
+  apt-get update -qq && apt-get install -y --no-install-recommends curl git > /dev/null 2>&1
+fi
 
 echo "[fuseki-loader] Wachten op Fuseki..."
 until curl -sf "${FUSEKI_URL}/\$/ping" > /dev/null; do

--- a/fuseki/load-ontology.sh
+++ b/fuseki/load-ontology.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+set -e
+
+FUSEKI_URL="${FUSEKI_URL:-http://fuseki:3030}"
+FUSEKI_ADMIN_PASSWORD="${FUSEKI_ADMIN_PASSWORD:-admin}"
+DATASET="${DATASET:-valor}"
+ONTOLOGY_REPO="${ONTOLOGY_REPO:-https://github.com/LeonardDune/valor-ontology.git}"
+SENTINEL_GRAPH="urn:valor:ontology-loaded"
+AUTH="-u admin:${FUSEKI_ADMIN_PASSWORD}"
+
+echo "[fuseki-loader] Benodigde tools installeren..."
+apk add --no-cache curl git > /dev/null 2>&1
+
+echo "[fuseki-loader] Wachten op Fuseki..."
+until curl -sf "${FUSEKI_URL}/\$/ping" > /dev/null; do
+  sleep 2
+done
+echo "[fuseki-loader] Fuseki is bereikbaar."
+
+# Controleer of ontologie al geladen is (sentinel graph)
+QUERY="ASK { GRAPH <${SENTINEL_GRAPH}> { ?s ?p ?o } }"
+RESULT=$(curl -sf $AUTH \
+  --data-urlencode "query=${QUERY}" \
+  "${FUSEKI_URL}/${DATASET}/query" \
+  -H "Accept: application/sparql-results+json" | \
+  grep -o '"boolean"[[:space:]]*:[[:space:]]*[a-z]*' | grep -o '[a-z]*$' || echo "false")
+
+if [ "$RESULT" = "true" ]; then
+  echo "[fuseki-loader] VALOR-O ontologie al geladen, overslaan."
+  exit 0
+fi
+
+echo "[fuseki-loader] VALOR-O ontologie ophalen van GitHub..."
+TMPDIR=$(mktemp -d)
+git clone --depth=1 "${ONTOLOGY_REPO}" "${TMPDIR}/ontology"
+
+echo "[fuseki-loader] TriG-modules laden in dataset '${DATASET}'..."
+for f in "${TMPDIR}/ontology/"*.trig; do
+  FNAME=$(basename "$f")
+  echo "[fuseki-loader]   Laden: ${FNAME}"
+  curl -sf $AUTH -X POST \
+    -H "Content-Type: application/trig" \
+    --data-binary "@${f}" \
+    "${FUSEKI_URL}/${DATASET}/data" || echo "[fuseki-loader]   WAARSCHUWING: ${FNAME} mislukt"
+done
+
+# Sentinel graph aanmaken zodat volgende run overgeslagen wordt
+curl -sf $AUTH -X PUT \
+  -H "Content-Type: text/turtle" \
+  --data-binary "<${SENTINEL_GRAPH}> a <urn:valor:Sentinel> ." \
+  "${FUSEKI_URL}/${DATASET}/data?graph=${SENTINEL_GRAPH}"
+
+rm -rf "${TMPDIR}"
+echo "[fuseki-loader] VALOR-O ontologie-modules succesvol geladen."


### PR DESCRIPTION
## Epic #268 — Fuseki Triplestore Infrastructuur

### User Stories afgerond
- **#321 (US-1.0):** Fuseki toevoegen aan lokale docker-compose (dev)
- **#285 (US-1.1):** Fuseki deployen via Coolify op intern netwerk (prod)
- **#286 (US-1.2):** Alle VALOR-O TriG-modules laden in Fuseki
- **#287 (US-1.3):** Geautomatiseerd idempotent laadscript

### Wijzigingen
- `docker-compose.yml` — Fuseki + fuseki-loader service voor lokale ontwikkeling
- `docker-compose.prod.yml` — Fuseki + fuseki-loader voor Coolify (lokale productie-simulatie)
- `fuseki/Dockerfile` — Coolify-ready image met ingebakken ontologie-loader
- `fuseki/entrypoint.sh` — start Fuseki + laadt ontologie automatisch bij eerste run
- `fuseki/load-ontology.sh` — idempotent laadscript (sentinel graph, cross-platform)
- `DEPLOY.md` — Fuseki setup-instructies voor Coolify toegevoegd
- `.gitignore` — docker-compose*.yml gewhitelist

Closes #268