### PR TITLE
fix: use apk instead of apt-get in Fuseki Dockerfile

### DIFF
--- a/fuseki/Dockerfile
+++ b/fuseki/Dockerfile
@@ -2,7 +2,7 @@ FROM stain/jena-fuseki
 
 USER root
 
-RUN apt-get update -qq && apt-get install -y --no-install-recommends curl git && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache curl git
 
 COPY load-ontology.sh /load-ontology.sh
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
## Probleem
`stain/jena-fuseki` is gebaseerd op Alpine Linux. `apt-get` bestaat niet op Alpine — dit veroorzaakte een deployment-fout op Coolify.

## Oplossing
`apt-get` vervangen door `apk add --no-cache curl git`.

## Test
Na merge: redeploy via Coolify triggeren en build-logs controleren.