### PR TITLE
fix: pre-install curl/git in Fuseki image and use localhost URL

### DIFF
--- a/fuseki/entrypoint.sh
+++ b/fuseki/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 
-# In de gecombineerde container draait Fuseki lokaal
-export FUSEKI_URL="${FUSEKI_URL:-http://localhost:3030}"
+# Altijd localhost gebruiken — externe FUSEKI_URL (voor de backend) mag dit niet overschrijven
+export FUSEKI_URL="http://localhost:3030"
 
 # Start Fuseki via de originele entrypoint in de achtergrond
 /docker-entrypoint.sh &

--- a/fuseki/load-ontology.sh
+++ b/fuseki/load-ontology.sh
@@ -16,7 +16,7 @@ elif command -v apt-get > /dev/null 2>&1; then
 fi
 
 echo "[fuseki-loader] Wachten op Fuseki..."
-until curl -sf "${FUSEKI_URL}/\$/ping" > /dev/null; do
+until curl -sf -u "admin:${FUSEKI_ADMIN_PASSWORD}" "${FUSEKI_URL}/\$/ping" > /dev/null; do
   sleep 2
 done
 echo "[fuseki-loader] Fuseki is bereikbaar."


### PR DESCRIPTION
## Problemen
1. `entrypoint.sh`: `FUSEKI_URL` werd niet geforceerd naar `localhost` — als Coolify `FUSEKI_URL=http://fuseki:3030` als env var doorgaf (voor de backend), pingde de loader zichzelf via een niet-resolvende hostnaam.
2. `load-ontology.sh`: de healthcheck-ping had geen authenticatie. Nieuwere Fuseki-versies beveiligen `/$/ping`, waardoor `curl -sf` altijd faalde met 401.

## Fixes
- `entrypoint.sh`: `FUSEKI_URL` altijd geforceerd op `http://localhost:3030` (geen conditionale default)
- `load-ontology.sh`: ping gebruikt nu `-u "admin:${FUSEKI_ADMIN_PASSWORD}"`

## Na merge
Redeploy triggeren in Coolify. Fuseki-loader zou nu door de startup-loop heen moeten komen.