### PR TITLE
fix: remove auth from Fuseki ping check

### DIFF
--- a/fuseki/load-ontology.sh
+++ b/fuseki/load-ontology.sh
@@ -16,7 +16,7 @@ elif command -v apt-get > /dev/null 2>&1; then
 fi
 
 echo "[fuseki-loader] Wachten op Fuseki..."
-until curl -sf -u "admin:${FUSEKI_ADMIN_PASSWORD}" "${FUSEKI_URL}/\$/ping" > /dev/null; do
+until curl -sf "${FUSEKI_URL}/\$/ping" > /dev/null; do
   sleep 2
 done
 echo "[fuseki-loader] Fuseki is bereikbaar."


### PR DESCRIPTION
## Regressie in PR #338
De vorige hotfix voegde `-u "admin:${FUSEKI_ADMIN_PASSWORD}"` toe aan de ping-check. `/$/ping` is echter een **publiek** Fuseki-endpoint — authenticatie is niet nodig én werkt contraproductief als `FUSEKI_ADMIN_PASSWORD` niet overeenkomt met het werkelijke wachtwoord.

## Fix
Auth verwijderd uit de ping-regel. De forced localhost uit PR #338 blijft behouden.