### PR TITLE
fix: pass $@ to /docker-entrypoint.sh so Fuseki JVM actually starts

### DIFF
--- a/fuseki/entrypoint.sh
+++ b/fuseki/entrypoint.sh
@@ -5,7 +5,7 @@ set -e
 export FUSEKI_URL="http://localhost:3030"
 
 # Start Fuseki via de originele entrypoint in de achtergrond
-/docker-entrypoint.sh &
+/docker-entrypoint.sh "$@" &
 FUSEKI_PID=$!
 
 # Laad de VALOR-O ontologie (script wacht zelf op Fuseki health)


### PR DESCRIPTION
## Root cause
`/docker-entrypoint.sh` (van de `stain/jena-fuseki` base image) doet intern `exec "$@" &` om de Fuseki JVM te starten. `$@` bevat de CMD van de base image: `/jena-fuseki/fuseki-server`.

Onze `entrypoint.sh` riep `/docker-entrypoint.sh &` aan **zonder `"$@"` door te geven**. Daardoor was `$@` leeg in het entrypoint-script, `exec "" &` deed niets, en Java startte nooit. Het script hing vervolgens eeuwig in zijn eigen ping-wachtlus op `http://localhost:3030`.

## Fix
```sh
/docker-entrypoint.sh "$@" &
```
Docker geeft de CMD van de base image als `$@` door aan onze ENTRYPOINT. Door dit door te geven aan het originele entrypoint, start de Fuseki JVM correct.