### PR TITLE
fix: add CMD directive to Fuseki Dockerfile so fuseki-server starts

### DIFF
--- a/fuseki/Dockerfile
+++ b/fuseki/Dockerfile
@@ -9,3 +9,4 @@ COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /load-ontology.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/jena-fuseki/fuseki-server"]


### PR DESCRIPTION
## Probleem

De `stain/jena-fuseki` base image definieert geen `CMD`. Doordat onze `Dockerfile` de `ENTRYPOINT` overschrijft zonder zelf een `CMD` te declareren, is `$@` in `entrypoint.sh` altijd leeg.

Gevolg: `/docker-entrypoint.sh "$@" &` wordt `/docker-entrypoint.sh &` zonder argumenten → `exec "$@"` in de base entrypoint doet niets → Java/Fuseki JVM start nooit → beide ping-loops (in `load-ontology.sh` en `/docker-entrypoint.sh`) blijven eindeloos draaien.

## Fix

`CMD ["/jena-fuseki/fuseki-server"]` toegevoegd aan `fuseki/Dockerfile`.

Docker geeft dit als `$@` mee aan de ENTRYPOINT, zodat `entrypoint.sh` het doorstuurt naar `/docker-entrypoint.sh`, die vervolgens `exec /jena-fuseki/fuseki-server` aanroept en Fuseki daadwerkelijk start.

## Root cause chain

1. `ENTRYPOINT ["/entrypoint.sh"]` — geen CMD in Dockerfile
2. Base image heeft ook geen CMD → `docker inspect` toont `"Cmd": null`
3. `entrypoint.sh`: `/docker-entrypoint.sh "$@" &` → `$@` is leeg
4. In `/docker-entrypoint.sh`: `exec "$@" &` → no-op
5. Fuseki Java process start nooit
6. Beide ping loops hangen

🤖 Generated with [Claude Code](https://claude.com/claude-code)