### PR TITLE
feat: PATCH /tessera/{id}/status — epistemische statusmachine (US-2.3)

### DIFF
--- a/backend/app/routers/tessera.py
+++ b/backend/app/routers/tessera.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 import logging
 from datetime import datetime, timezone
@@ -9,7 +10,7 @@ from pydantic import BaseModel
 from app.auth import get_current_user
 from app.db.permissions import check_permission
 from app.models.domain import Role
-from app.services.fuseki import sparql_update, named_graph_uri
+from app.services.fuseki import sparql_select, sparql_update, named_graph_uri
 from app.ontology import VALOR_NS
 
 logger = logging.getLogger(__name__)
@@ -20,6 +21,36 @@ router = APIRouter(
 )
 
 XSD_NS = "http://www.w3.org/2001/XMLSchema#"
+
+# Ontologie-base voor named individuals (valor:ProposedStatus etc.)
+# Dit is de `valor:` prefix zoals gedefinieerd in de VALOR-O ontologie.
+_ONTOLOGY_BASE = os.getenv("VALOR_ONTOLOGY_BASE_URL", "https://valor-ecosystem.nl/ontology/")
+
+EPISTEMIC_STATUS_URIS: dict[str, str] = {
+    "Proposed":     f"{_ONTOLOGY_BASE}ProposedStatus",
+    "Contested":    f"{_ONTOLOGY_BASE}ContestedStatus",
+    "Accepted":     f"{_ONTOLOGY_BASE}AcceptedStatus",
+    "Rejected":     f"{_ONTOLOGY_BASE}RejectedStatus",
+    "Reconsidered": f"{_ONTOLOGY_BASE}ReconsideredStatus",
+}
+
+_STATUS_URI_TO_NAME: dict[str, str] = {v: k for k, v in EPISTEMIC_STATUS_URIS.items()}
+
+# Statusmachine conform DD-065
+VALID_TRANSITIONS: dict[str, set[str]] = {
+    "Proposed":     {"Contested", "Accepted", "Rejected"},
+    "Contested":    {"Accepted", "Rejected"},
+    "Accepted":     {"Reconsidered"},
+    "Rejected":     {"Reconsidered"},
+    "Reconsidered": {"Proposed"},
+}
+
+REQUIRES_DECISION_EPISODE = {"Accepted", "Rejected"}
+
+
+def _normalize_status(raw: str) -> str:
+    """Vertaalt een URI of legacy string-literal naar de canonieke statusnaam."""
+    return _STATUS_URI_TO_NAME.get(raw, raw)
 
 
 class CreateTesseraRequest(BaseModel):
@@ -39,6 +70,19 @@ class TesseraResponse(BaseModel):
     epistemic_status: str
     claimed_by: str
     claimed_at: str
+
+
+class PatchTesseraStatusRequest(BaseModel):
+    design_space_id: str
+    new_status: str
+    decision_episode_uri: Optional[str] = None
+
+
+class PatchTesseraStatusResponse(BaseModel):
+    tessera_id: str
+    tessera_uri: str
+    previous_status: str
+    new_status: str
 
 
 @router.post("/", response_model=TesseraResponse, status_code=201)
@@ -66,6 +110,7 @@ async def create_tessera(
     user_uri = f"urn:valor:user:{user_id}"
     graph_uri = named_graph_uri(request.design_space_id)
     claimed_at = datetime.now(timezone.utc).isoformat()
+    proposed_uri = EPISTEMIC_STATUS_URIS["Proposed"]
 
     optional_triples = ""
     if request.in_alternative:
@@ -84,7 +129,7 @@ INSERT DATA {{
   GRAPH <{graph_uri}> {{
     <{tessera_uri}> a valor:Tessera ;
       valor:claimContent "{escaped_content}"@nl ;
-      valor:epistemicStatus "Proposed" ;
+      valor:epistemicStatus <{proposed_uri}> ;
       valor:claimType "{request.claim_type}" ;
       valor:claimedBy <{user_uri}> ;
       valor:claimedAt "{claimed_at}"^^xsd:dateTime ;
@@ -105,4 +150,105 @@ INSERT DATA {{
         epistemic_status="Proposed",
         claimed_by=user_id,
         claimed_at=claimed_at,
+    )
+
+
+@router.patch("/{tessera_id}/status", response_model=PatchTesseraStatusResponse)
+async def patch_tessera_status(
+    tessera_id: str,
+    request: PatchTesseraStatusRequest,
+    user: dict = Depends(get_current_user),
+):
+    if request.new_status not in VALID_TRANSITIONS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Ongeldig doelstatus '{request.new_status}'. Geldige waarden: {sorted(VALID_TRANSITIONS)}.",
+        )
+
+    user_id = user["id"]
+
+    has_permission = await check_permission(user_id, request.design_space_id, Role.MEMBER)
+    if not has_permission:
+        raise HTTPException(
+            status_code=403,
+            detail="Onvoldoende rechten voor deze DesignSpace.",
+        )
+
+    tessera_uri = f"urn:valor:tessera:{tessera_id}"
+    graph_uri = named_graph_uri(request.design_space_id)
+
+    # Huidige status ophalen (ondersteunt zowel URI als legacy string-literal)
+    rows = await sparql_select(
+        f"""SELECT ?status WHERE {{
+          <{tessera_uri}> <{VALOR_NS}epistemicStatus> ?status .
+        }}""",
+        request.design_space_id,
+    )
+
+    if not rows:
+        raise HTTPException(status_code=404, detail="Tessera niet gevonden in deze DesignSpace.")
+
+    current_raw = rows[0]["status"]
+    current_status = _normalize_status(current_raw)
+
+    if request.new_status not in VALID_TRANSITIONS.get(current_status, set()):
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Ongeldige transitie: {current_status} → {request.new_status}. "
+                f"Toegestaan vanuit '{current_status}': {sorted(VALID_TRANSITIONS.get(current_status, set()))}."
+            ),
+        )
+
+    if request.new_status in REQUIRES_DECISION_EPISODE and not request.decision_episode_uri:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Status '{request.new_status}' vereist een decision_episode_uri.",
+        )
+
+    new_status_uri = EPISTEMIC_STATUS_URIS[request.new_status]
+
+    # Bepaal de waarde om te verwijderen (URI of literal, afhankelijk van wat er staat)
+    if current_raw.startswith("http") or current_raw.startswith("urn"):
+        old_status_sparql = f"<{current_raw}>"
+    else:
+        old_status_sparql = f'"{current_raw}"'
+
+    update = f"""DELETE {{
+  GRAPH <{graph_uri}> {{
+    <{tessera_uri}> <{VALOR_NS}epistemicStatus> {old_status_sparql} .
+  }}
+}}
+INSERT {{
+  GRAPH <{graph_uri}> {{
+    <{tessera_uri}> <{VALOR_NS}epistemicStatus> <{new_status_uri}> .
+  }}
+}}
+WHERE {{
+  GRAPH <{graph_uri}> {{
+    <{tessera_uri}> <{VALOR_NS}epistemicStatus> {old_status_sparql} .
+  }}
+}}"""
+
+    await sparql_update(update, request.design_space_id)
+
+    # Koppel DecisionEpisode indien vereist
+    if request.decision_episode_uri:
+        episode_update = f"""INSERT DATA {{
+  GRAPH <{graph_uri}> {{
+    <{request.decision_episode_uri}> <{VALOR_NS}concernsTessera> <{tessera_uri}> .
+  }}
+}}"""
+        await sparql_update(episode_update, request.design_space_id)
+
+    logger.info(
+        "Tessera %s status: %s → %s (door %s)",
+        tessera_uri, current_status, request.new_status, user_id,
+    )
+
+    return PatchTesseraStatusResponse(
+        tessera_id=tessera_id,
+        tessera_uri=tessera_uri,
+        previous_status=current_status,
+        new_status=request.new_status,
     )


### PR DESCRIPTION
## Summary

- **Bug fix (US-2.2 carry-over):** `epistemicStatus` werd opgeslagen als string literal `"Proposed"` — dit is ontologisch incorrect. Nu opgeslagen als URI `<https://valor-ecosystem.nl/ontology/ProposedStatus>` conform VALOR-O DD-065.
- **Nieuw endpoint:** `PATCH /tessera/{tessera_id}/status` implementeert de 5-waardige statusmachine uit DD-065.
- **Backward compat:** `_normalize_status()` vertaalt legacy string-literals correct bij PATCH-operaties.
- **Issue #342 aangemaakt** voor ontologie-versioning strategie (incrementele updates, backward compat voor bestaande triples).

## Statusmachine (DD-065)

```
Proposed     → Contested | Accepted | Rejected
Contested    → Accepted | Rejected
Accepted     → Reconsidered
Rejected     → Reconsidered
Reconsidered → Proposed
```

## Validatie

- HTTP 422 bij ongeldige transitie
- HTTP 422 bij `Accepted`/`Rejected` zonder `decision_episode_uri`
- HTTP 404 als tessera niet bestaat in de DesignSpace
- HTTP 403 bij onvoldoende rechten (MEMBER+)

## Test plan

- [x] Syntax check: `python3 -m py_compile`
- [x] Smoke test in container: statusmachine, URIs, normalize, DecisionEpisode-vereiste
- [x] OpenAPI schema's correct gegenereerd (`/openapi.json`)
- [x] Auth-guard actief (`401 Not authenticated` zonder token)

Closes #290