### PR TITLE
feat(dual-write): POST /factors en /claims_manual schrijven naar Neo4j + Fuseki (US-2.6 #293)

### DIFF
--- a/backend/app/routers/claims.py
+++ b/backend/app/routers/claims.py
@@ -11,6 +11,7 @@ from app.db.crud import (
     get_active_version_id_if_theme, get_claims_for_theme, check_permission,
 )
 from app.services.connection_manager import manager
+from app.services.fuseki_sync import try_write_claim
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +69,8 @@ async def create_claim(claim: ClaimManualCreate, user: dict = Depends(get_curren
         claim.evidence_text,
         claim.evidence_url
     )
+    await try_write_claim(cid, claim.source_id, claim.target_id, claim.polarity or "+", claim.theme_id)
+
     if project_id:
         await manager.broadcast_data(project_id, {
             "type": "CLAIM_CREATED",

--- a/backend/app/routers/factors.py
+++ b/backend/app/routers/factors.py
@@ -11,6 +11,7 @@ from app.db.crud import (
     get_active_version_id_if_theme, get_factors_for_theme, check_permission,
 )
 from app.services.connection_manager import manager
+from app.services.fuseki_sync import try_write_factor
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +52,7 @@ async def create_factor(factor: FactorManualCreate, user: dict = Depends(get_cur
     if not check_entity or not await check_permission(user["id"], check_entity, Role.MEMBER):
         raise HTTPException(status_code=403, detail="Geen toegang om een factor aan te maken")
     fid = await create_factor_manual(factor.name, factor.description, factor.type or "systeemelement", factor.theme_id, author_id=user["id"])
+    await try_write_factor(fid, factor.name, factor.theme_id or "", user["id"])
 
     if project_id_check:
         await manager.broadcast_data(project_id_check, {

--- a/backend/app/services/fuseki_sync.py
+++ b/backend/app/services/fuseki_sync.py
@@ -1,0 +1,83 @@
+"""Fire-and-forget dual-write helpers voor Fuseki.
+
+Fuseki-fouten worden gelogd als warning en blokkeren nooit de primaire response.
+"""
+import logging
+from datetime import datetime, timezone
+
+from app.ontology import VALOR_NS
+from app.services.fuseki import named_graph_uri, sparql_update
+from app.services.ontology_cache import get_argue_label_to_uri, get_status_label_to_uri
+
+logger = logging.getLogger(__name__)
+
+_XSD = "http://www.w3.org/2001/XMLSchema#"
+
+
+async def try_write_factor(factor_id: str, name: str, theme_id: str, user_id: str) -> None:
+    """Schrijft een Factor als Tessera naar Fuseki. Fouten worden gelogd als warning."""
+    if not theme_id:
+        return
+    try:
+        tessera_uri = f"urn:valor:tessera:{factor_id}"
+        user_uri = f"urn:valor:user:{user_id}"
+        graph_uri = named_graph_uri(theme_id)
+        claimed_at = datetime.now(timezone.utc).isoformat()
+        proposed_uri = get_status_label_to_uri().get("Proposed", f"{VALOR_NS}ProposedStatus")
+        escaped_name = name.replace("\\", "\\\\").replace('"', '\\"')
+
+        sparql = f"""PREFIX valor: <{VALOR_NS}>
+PREFIX xsd: <{_XSD}>
+
+INSERT DATA {{
+  GRAPH <{graph_uri}> {{
+    <{tessera_uri}> a valor:Tessera ;
+      valor:claimContent "{escaped_name}"@nl ;
+      valor:epistemicStatus <{proposed_uri}> ;
+      valor:claimType "AsIs" ;
+      valor:claimedBy <{user_uri}> ;
+      valor:claimedAt "{claimed_at}"^^xsd:dateTime ;
+      valor:inDesignSpace <{graph_uri}> .
+  }}
+}}"""
+        await sparql_update(sparql, theme_id)
+        logger.debug("Fuseki sync: factor %s → tessera %s", factor_id, tessera_uri)
+    except Exception:
+        logger.warning("Fuseki sync mislukt voor factor %s", factor_id, exc_info=True)
+
+
+async def try_write_claim(
+    claim_id: str,
+    source_id: str,
+    target_id: str,
+    polarity: str,
+    theme_id: str,
+) -> None:
+    """Schrijft een Claim als argumentatierelatie naar Fuseki. Fouten worden gelogd als warning."""
+    if not theme_id:
+        return
+    try:
+        relation_label = "supports" if polarity == "+" else "undermines"
+        relation_uri = get_argue_label_to_uri().get(relation_label)
+        if not relation_uri:
+            logger.warning(
+                "Fuseki sync: relatie '%s' niet in ontologie, claim %s niet gesynchroniseerd",
+                relation_label, claim_id,
+            )
+            return
+
+        source_uri = f"urn:valor:tessera:{source_id}"
+        target_uri = f"urn:valor:tessera:{target_id}"
+        graph_uri = named_graph_uri(theme_id)
+
+        await sparql_update(
+            f"""INSERT DATA {{
+  GRAPH <{graph_uri}> {{
+    <{source_uri}> <{relation_uri}> <{target_uri}> .
+  }}
+}}""",
+            theme_id,
+        )
+        logger.debug("Fuseki sync: claim %s → %s -[%s]-> %s", claim_id, source_uri, relation_label, target_uri)
+    except Exception:
+        logger.warning("Fuseki sync mislukt voor claim %s", claim_id, exc_info=True)

--- a/backend/scripts/verify_fuseki_sync.py
+++ b/backend/scripts/verify_fuseki_sync.py
@@ -1,0 +1,145 @@
+"""Verificatiescript voor de dual-write fuseki_sync functies.
+
+Gebruik:
+    cd backend && python scripts/verify_fuseki_sync.py
+"""
+import asyncio
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import httpx
+
+FUSEKI_URL = os.getenv("FUSEKI_URL", "http://localhost:3030")
+FUSEKI_DATASET = "valor"
+FUSEKI_PASSWORD = os.getenv("FUSEKI_ADMIN_PASSWORD", "admin")
+SPARQL = f"{FUSEKI_URL}/{FUSEKI_DATASET}/sparql"
+
+TEST_THEME_ID = "test-theme-sync-verify"
+TEST_FACTOR_ID = "test-factor-aaaaaaaa"
+TEST_FACTOR2_ID = "test-factor-bbbbbbbb"
+TEST_CLAIM_ID = "test-claim-cccccccc"
+
+
+async def query_fuseki(sparql: str) -> list[dict]:
+    from app.services.fuseki import _SPARQL_ENDPOINT
+    async with httpx.AsyncClient() as client:
+        r = await client.post(
+            _SPARQL_ENDPOINT,
+            data={"query": sparql},
+            headers={"Accept": "application/sparql-results+json"},
+            timeout=10,
+        )
+    r.raise_for_status()
+    return r.json()["results"]["bindings"]
+
+
+async def cleanup():
+    """Verwijder testdata uit Fuseki."""
+    from app.services.fuseki import _UPDATE_ENDPOINT
+    graph = f"urn:valor:ds:{TEST_THEME_ID}"
+    async with httpx.AsyncClient() as client:
+        await client.post(
+            _UPDATE_ENDPOINT,
+            data={"update": f"DROP GRAPH <{graph}>"},
+            auth=("admin", FUSEKI_PASSWORD),
+            timeout=10,
+        )
+
+
+async def main():
+    # Bootstrap ontologie-cache (laadt relaties vanuit Fuseki)
+    from app.services.ontology_cache import load_ontology_cache
+    print("Ontologie-cache laden...")
+    await load_ontology_cache()
+
+    from app.services.fuseki_sync import try_write_factor, try_write_claim
+    from app.services.fuseki import named_graph_uri
+    from app.ontology import VALOR_NS
+
+    graph_uri = named_graph_uri(TEST_THEME_ID)
+
+    # --- Test 1: try_write_factor ---
+    print(f"\n[1] try_write_factor (factor_id={TEST_FACTOR_ID})")
+    await try_write_factor(TEST_FACTOR_ID, "Testfactor Alpha", TEST_THEME_ID, "user-test-001")
+
+    rows = await query_fuseki(f"""
+        SELECT ?type ?content WHERE {{
+          GRAPH <{graph_uri}> {{
+            <urn:valor:tessera:{TEST_FACTOR_ID}> a ?type ;
+              <{VALOR_NS}claimContent> ?content .
+          }}
+        }}
+    """)
+    if rows:
+        print(f"  OK  Tessera aangemaakt: type={rows[0]['type']['value']}, content={rows[0]['content']['value']}")
+    else:
+        print("  FAIL  Geen Tessera gevonden in Fuseki!")
+        sys.exit(1)
+
+    # --- Test 2: tweede factor voor claim ---
+    print(f"\n[2] try_write_factor (factor_id={TEST_FACTOR2_ID})")
+    await try_write_factor(TEST_FACTOR2_ID, "Testfactor Beta", TEST_THEME_ID, "user-test-001")
+    rows2 = await query_fuseki(f"""
+        SELECT ?t WHERE {{
+          GRAPH <{graph_uri}> {{
+            <urn:valor:tessera:{TEST_FACTOR2_ID}> a <{VALOR_NS}Tessera> .
+            BIND(<urn:valor:tessera:{TEST_FACTOR2_ID}> AS ?t)
+          }}
+        }}
+    """)
+    if rows2:
+        print(f"  OK  Tweede Tessera aangemaakt")
+    else:
+        print("  FAIL  Tweede Tessera niet gevonden!")
+        sys.exit(1)
+
+    # --- Test 3: try_write_claim polarity "+" → supports ---
+    print(f"\n[3] try_write_claim polarity '+' (claim_id={TEST_CLAIM_ID})")
+    await try_write_claim(TEST_CLAIM_ID, TEST_FACTOR_ID, TEST_FACTOR2_ID, "+", TEST_THEME_ID)
+
+    rows3 = await query_fuseki(f"""
+        SELECT ?rel WHERE {{
+          GRAPH <{graph_uri}> {{
+            <urn:valor:tessera:{TEST_FACTOR_ID}> ?rel <urn:valor:tessera:{TEST_FACTOR2_ID}> .
+          }}
+        }}
+    """)
+    if rows3:
+        print(f"  OK  Relatie aangemaakt: {rows3[0]['rel']['value']}")
+        if "supports" in rows3[0]["rel"]["value"]:
+            print(f"  OK  Relatie is correct 'supports'")
+        else:
+            print(f"  FAIL  Verwacht 'supports', got: {rows3[0]['rel']['value']}")
+            sys.exit(1)
+    else:
+        print("  FAIL  Geen relatie gevonden in Fuseki!")
+        sys.exit(1)
+
+    # --- Test 4: try_write_claim polarity "-" → undermines ---
+    print(f"\n[4] try_write_claim polarity '-' (claim_id={TEST_CLAIM_ID}-2)")
+    await try_write_claim(TEST_CLAIM_ID + "-2", TEST_FACTOR2_ID, TEST_FACTOR_ID, "-", TEST_THEME_ID)
+
+    rows4 = await query_fuseki(f"""
+        SELECT ?rel WHERE {{
+          GRAPH <{graph_uri}> {{
+            <urn:valor:tessera:{TEST_FACTOR2_ID}> ?rel <urn:valor:tessera:{TEST_FACTOR_ID}> .
+          }}
+        }}
+    """)
+    if rows4 and "undermines" in rows4[0]["rel"]["value"]:
+        print(f"  OK  Relatie is correct 'undermines': {rows4[0]['rel']['value']}")
+    else:
+        print(f"  FAIL  Verwacht 'undermines', got: {rows4}")
+        sys.exit(1)
+
+    # --- Cleanup ---
+    print(f"\nTestdata opruimen (graph {graph_uri})...")
+    await cleanup()
+    print("Klaar.\n")
+    print("Alle checks geslaagd.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

- Nieuw `fuseki_sync.py` met `try_write_factor()` en `try_write_claim()`: fire-and-forget dual-write helpers
- `POST /factors`: schrijft Factor na Neo4j-opslag ook als `valor:Tessera` naar Fuseki (claimType=AsIs, status=Proposed, named graph = `urn:valor:ds:{theme_id}`)
- `POST /claims_manual`: schrijft Claim als argumentatierelatie naar Fuseki (`+` → `valor:supports`, `-` → `valor:undermines`)
- Alle Fuseki-fouten worden opgevangen en gelogd als warning — blokkeren nooit de response
- Neo4j blijft de leading store

## Test plan

- [ ] `POST /factors` → factor verschijnt in Neo4j én als Tessera in Fuseki
- [ ] `POST /claims_manual` met polarity `+` → `valor:supports` triple in Fuseki
- [ ] `POST /claims_manual` met polarity `-` → `valor:undermines` triple in Fuseki
- [ ] Fuseki neer (container gestopt) → factor/claim worden gewoon aangemaakt in Neo4j, warning in logs
- [ ] Bestaande integratietests slagen

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)