### PR TITLE
feat(tessera): claimType als named individual (US-2.7)

### DIFF
--- a/backend/app/routers/tessera.py
+++ b/backend/app/routers/tessera.py
@@ -36,10 +36,26 @@ def _normalize_status(raw: str) -> str:
     return get_status_uri_to_label().get(raw, raw)
 
 
+_CLAIM_TYPE_LABELS = {"AsIs": "AsIsStatus", "ToBe": "ToBeStatus"}
+_CLAIM_TYPE_SUFFIX_TO_LABEL = {v: k for k, v in _CLAIM_TYPE_LABELS.items()}
+
+
+def _claim_type_uri(label: str) -> str:
+    return f"{VALOR_NS}{_CLAIM_TYPE_LABELS[label]}"
+
+
+def _claim_type_label_from_raw(raw: str) -> str:
+    """Vertaalt URI of string-literal naar de canonieke label ('AsIs'/'ToBe')."""
+    if raw.startswith("http") or raw.startswith("urn"):
+        suffix = raw.rsplit("/", 1)[-1].rsplit("#", 1)[-1]
+        return _CLAIM_TYPE_SUFFIX_TO_LABEL.get(suffix, raw)
+    return raw
+
+
 class CreateTesseraRequest(BaseModel):
     design_space_id: str
     claim_content: str
-    claim_type: str  # "AsIs" | "ToBe"
+    claim_type: Optional[str] = "AsIs"  # "AsIs" | "ToBe", default AsIs
     in_alternative: Optional[str] = None
     in_phase: Optional[str] = None
 
@@ -93,11 +109,13 @@ async def create_tessera(
     request: CreateTesseraRequest,
     user: dict = Depends(get_current_user),
 ):
-    if request.claim_type not in ("AsIs", "ToBe"):
+    claim_type = request.claim_type or "AsIs"
+    if claim_type not in _CLAIM_TYPE_LABELS:
         raise HTTPException(
             status_code=422,
             detail="claim_type moet 'AsIs' of 'ToBe' zijn.",
         )
+    claim_type_uri = _claim_type_uri(claim_type)
 
     user_id = user["id"]
 
@@ -135,7 +153,7 @@ INSERT DATA {{
     <{tessera_uri}> a valor:Tessera ;
       valor:claimContent "{escaped_content}"@nl ;
       valor:epistemicStatus <{proposed_uri}> ;
-      valor:claimType "{request.claim_type}" ;
+      valor:claimType <{claim_type_uri}> ;
       valor:claimedBy <{user_uri}> ;
       valor:claimedAt "{claimed_at}"^^xsd:dateTime ;
       valor:inDesignSpace <{graph_uri}> .
@@ -151,10 +169,58 @@ INSERT DATA {{
         tessera_uri=tessera_uri,
         design_space_id=request.design_space_id,
         claim_content=request.claim_content,
-        claim_type=request.claim_type,
+        claim_type=claim_type,
         epistemic_status="Proposed",
         claimed_by=user_id,
         claimed_at=claimed_at,
+    )
+
+
+@router.get("/{tessera_id}", response_model=TesseraResponse)
+async def get_tessera(
+    tessera_id: str,
+    design_space_id: str,
+    user: dict = Depends(get_current_user),
+):
+    user_id = user["id"]
+
+    has_permission = await check_permission(user_id, design_space_id, Role.VIEWER)
+    if not has_permission:
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten voor deze DesignSpace.")
+
+    tessera_uri = f"urn:valor:tessera:{tessera_id}"
+    graph_uri = named_graph_uri(design_space_id)
+
+    rows = await sparql_select(
+        f"""SELECT ?content ?claimType ?status ?claimedBy ?claimedAt WHERE {{
+          GRAPH <{graph_uri}> {{
+            <{tessera_uri}> a <{VALOR_NS}Tessera> ;
+              <{VALOR_NS}claimContent> ?content ;
+              <{VALOR_NS}epistemicStatus> ?status ;
+              <{VALOR_NS}claimedBy> ?claimedBy ;
+              <{VALOR_NS}claimedAt> ?claimedAt .
+            OPTIONAL {{ <{tessera_uri}> <{VALOR_NS}claimType> ?claimType . }}
+          }}
+        }}""",
+        design_space_id,
+    )
+
+    if not rows:
+        raise HTTPException(status_code=404, detail="Tessera niet gevonden in deze DesignSpace.")
+
+    row = rows[0]
+    raw_claim_type = row.get("claimType", "")
+    claim_type = _claim_type_label_from_raw(raw_claim_type) if raw_claim_type else "AsIs"
+
+    return TesseraResponse(
+        tessera_id=tessera_id,
+        tessera_uri=tessera_uri,
+        design_space_id=design_space_id,
+        claim_content=row["content"],
+        claim_type=claim_type,
+        epistemic_status=_normalize_status(row["status"]),
+        claimed_by=row["claimedBy"].rsplit(":", 1)[-1],
+        claimed_at=row["claimedAt"],
     )
 
 


### PR DESCRIPTION
## Samenvatting

- `valor:claimType` wordt opgeslagen als named individual URI (`valor:AsIsStatus` / `valor:ToBeStatus`) in plaats van string-literal
- `claim_type` is optioneel in `POST /tessera/` met default `"AsIs"`
- Nieuw `GET /tessera/{id}` endpoint retourneert `claim_type` in de response
- Backwards-compatible: bestaande Tesserae met string-literal worden correct gelezen

## Geteste acceptatiecriteria

- [x] `POST /tessera/` accepteert optioneel `claim_type: "AsIs" | "ToBe"` (default `"AsIs"`)
- [x] Waarde opgeslagen als `valor:claimType` URI triple in Fuseki
- [x] `GET /tessera/{id}` retourneert `claim_type` in response
- [x] Backwards compatible: bestaande Tesserae zonder `claimType` worden niet gebroken

Closes #348