### PR TITLE
feat(tessera): uncertaintyLevel PAMS + git-SHA ontologie-loader (US-2.8)

### DIFF
--- a/backend/app/routers/tessera.py
+++ b/backend/app/routers/tessera.py
@@ -18,6 +18,7 @@ from app.services.ontology_cache import (
     requires_decision_episode,
     get_argue_label_to_uri,
     get_shacl_shapes_graph,
+    get_uncertainty_label_to_uri,
 )
 from app.ontology import VALOR_NS
 
@@ -36,7 +37,7 @@ def _normalize_status(raw: str) -> str:
     return get_status_uri_to_label().get(raw, raw)
 
 
-_CLAIM_TYPE_LABELS = {"AsIs": "AsIsStatus", "ToBe": "ToBeStatus"}
+_CLAIM_TYPE_LABELS = {"AsIs": "AsIsType", "ToBe": "ToBeType"}
 _CLAIM_TYPE_SUFFIX_TO_LABEL = {v: k for k, v in _CLAIM_TYPE_LABELS.items()}
 
 
@@ -56,6 +57,7 @@ class CreateTesseraRequest(BaseModel):
     design_space_id: str
     claim_content: str
     claim_type: Optional[str] = "AsIs"  # "AsIs" | "ToBe", default AsIs
+    uncertainty_level: Optional[str] = None  # PAMS: "StatisticalRisk" | "Scenario" | "DeepUncertainty" | "Ignorance"
     in_alternative: Optional[str] = None
     in_phase: Optional[str] = None
 
@@ -69,6 +71,7 @@ class TesseraResponse(BaseModel):
     epistemic_status: str
     claimed_by: str
     claimed_at: str
+    uncertainty_level: Optional[str] = None
 
 
 class CreateEvidenceRequest(BaseModel):
@@ -117,6 +120,17 @@ async def create_tessera(
         )
     claim_type_uri = _claim_type_uri(claim_type)
 
+    uncertainty_level_uri = None
+    if request.uncertainty_level:
+        uncertainty_label_to_uri = get_uncertainty_label_to_uri()
+        uncertainty_level_uri = uncertainty_label_to_uri.get(request.uncertainty_level)
+        if not uncertainty_level_uri:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Ongeldig uncertainty_level '{request.uncertainty_level}'. "
+                       f"Geldige waarden: {sorted(uncertainty_label_to_uri)}.",
+            )
+
     user_id = user["id"]
 
     has_permission = await check_permission(user_id, request.design_space_id, Role.MEMBER)
@@ -136,6 +150,8 @@ async def create_tessera(
     proposed_uri = status_label_to_uri.get("Proposed", f"{VALOR_NS}ProposedStatus")
 
     optional_triples = ""
+    if uncertainty_level_uri:
+        optional_triples += f"      <{tessera_uri}> <{VALOR_NS}uncertaintyLevel> <{uncertainty_level_uri}> .\n"
     if request.in_alternative:
         alt_uri = f"urn:valor:alternative:{request.in_alternative}"
         optional_triples += f"      <{tessera_uri}> <{VALOR_NS}inAlternative> <{alt_uri}> .\n"
@@ -173,6 +189,7 @@ INSERT DATA {{
         epistemic_status="Proposed",
         claimed_by=user_id,
         claimed_at=claimed_at,
+        uncertainty_level=request.uncertainty_level,
     )
 
 
@@ -192,7 +209,7 @@ async def get_tessera(
     graph_uri = named_graph_uri(design_space_id)
 
     rows = await sparql_select(
-        f"""SELECT ?content ?claimType ?status ?claimedBy ?claimedAt WHERE {{
+        f"""SELECT ?content ?claimType ?uncertaintyLevel ?status ?claimedBy ?claimedAt WHERE {{
           GRAPH <{graph_uri}> {{
             <{tessera_uri}> a <{VALOR_NS}Tessera> ;
               <{VALOR_NS}claimContent> ?content ;
@@ -200,6 +217,7 @@ async def get_tessera(
               <{VALOR_NS}claimedBy> ?claimedBy ;
               <{VALOR_NS}claimedAt> ?claimedAt .
             OPTIONAL {{ <{tessera_uri}> <{VALOR_NS}claimType> ?claimType . }}
+            OPTIONAL {{ <{tessera_uri}> <{VALOR_NS}uncertaintyLevel> ?uncertaintyLevel . }}
           }}
         }}""",
         design_space_id,
@@ -212,6 +230,11 @@ async def get_tessera(
     raw_claim_type = row.get("claimType", "")
     claim_type = _claim_type_label_from_raw(raw_claim_type) if raw_claim_type else "AsIs"
 
+    raw_uncertainty = row.get("uncertaintyLevel", "")
+    uncertainty_label_to_uri = get_uncertainty_label_to_uri()
+    uncertainty_uri_to_label = {v: k for k, v in uncertainty_label_to_uri.items()}
+    uncertainty_level = uncertainty_uri_to_label.get(raw_uncertainty) if raw_uncertainty else None
+
     return TesseraResponse(
         tessera_id=tessera_id,
         tessera_uri=tessera_uri,
@@ -221,6 +244,7 @@ async def get_tessera(
         epistemic_status=_normalize_status(row["status"]),
         claimed_by=row["claimedBy"].rsplit(":", 1)[-1],
         claimed_at=row["claimedAt"],
+        uncertainty_level=uncertainty_level,
     )
 
 

--- a/backend/app/services/ontology_cache.py
+++ b/backend/app/services/ontology_cache.py
@@ -6,6 +6,7 @@ Queryt de VALOR-O ontologie-graphs in Fuseki voor:
   - EpistemicStatus instanties (English label -> URI)
   - Geldige statusovergangen (valor:allowedTransitionTo)
   - Statussen die een DecisionEpisode vereisen (valor:requiresDecisionEpisode)
+  - UncertaintyLevel instanties (PAMS-taxonomie, English label -> URI)
 """
 import logging
 
@@ -22,12 +23,14 @@ _status_label_to_uri: dict[str, str] = {}
 _status_uri_to_label: dict[str, str] = {}
 _valid_transitions: dict[str, set[str]] = {}
 _requires_decision_episode: set[str] = set()
-_argue_label_to_uri: dict[str, str] = {}   # "undermines" → URI
+_argue_label_to_uri: dict[str, str] = {}        # "undermines" → URI
+_uncertainty_label_to_uri: dict[str, str] = {}  # "StatisticalRisk" → URI
 
 
 async def load_ontology_cache() -> None:
     global _evidence_label_to_uri, _status_label_to_uri, _status_uri_to_label
     global _valid_transitions, _requires_decision_episode, _argue_label_to_uri
+    global _uncertainty_label_to_uri
 
     logger.info("[ontology-cache] Ontologie-data laden van Fuseki...")
 
@@ -106,6 +109,20 @@ async def load_ontology_cache() -> None:
     _argue_label_to_uri = {row["label"]: row["uri"] for row in argue_rows}
     logger.info("[ontology-cache] Argumentatierelaties: %s", list(_argue_label_to_uri.keys()))
 
+    uncertainty_rows = await sparql_select_global(f"""
+        PREFIX valor: <{VALOR_NS}>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        SELECT ?uri ?label WHERE {{
+          GRAPH <{_TESSERA_GRAPH}> {{
+            ?uri a valor:UncertaintyLevel ;
+                 rdfs:label ?label .
+            FILTER(lang(?label) = "en")
+          }}
+        }}
+    """)
+    _uncertainty_label_to_uri = {row["label"]: row["uri"] for row in uncertainty_rows}
+    logger.info("[ontology-cache] Uncertainty levels (PAMS): %s", list(_uncertainty_label_to_uri.keys()))
+
     if not _evidence_label_to_uri or not _status_label_to_uri or not _valid_transitions:
         logger.warning(
             "[ontology-cache] Ontologie-cache onvolledig. "
@@ -135,6 +152,10 @@ def requires_decision_episode(status_uri: str) -> bool:
 
 def get_argue_label_to_uri() -> dict[str, str]:
     return _argue_label_to_uri
+
+
+def get_uncertainty_label_to_uri() -> dict[str, str]:
+    return _uncertainty_label_to_uri
 
 
 def get_shacl_shapes_graph() -> str:

--- a/fuseki/load-ontology.sh
+++ b/fuseki/load-ontology.sh
@@ -1,13 +1,29 @@
 #!/bin/sh
+# load-ontology.sh — incrementele VALOR-O ontologie-loader voor Fuseki
+#
+# Gebruik: load-ontology.sh [--force]
+#
+#   --force  Verwijdert alle ontologie-graphs en herlaadt alles opnieuw.
+#            Gebruik bij een full reset of dev-omgeving cleanup.
+#
+# Per-module versie-tracking in named graph urn:valor:ontology-modules.
+# Modules worden alleen geladen als ze nieuw zijn of een andere versie hebben.
+# Bij een versiewijziging wordt de oude graph gearchiveerd als {graph}/v{versie}.
 set -e
 
 FUSEKI_URL="${FUSEKI_URL:-http://fuseki:3030}"
 FUSEKI_ADMIN_PASSWORD="${FUSEKI_ADMIN_PASSWORD:-admin}"
 DATASET="${DATASET:-valor}"
 ONTOLOGY_REPO="${ONTOLOGY_REPO:-https://github.com/LeonardDune/valor-ontology.git}"
-SENTINEL_GRAPH="urn:valor:ontology-loaded"
+MODULES_GRAPH="urn:valor:ontology-modules"
 AUTH="-u admin:${FUSEKI_ADMIN_PASSWORD}"
+FORCE=false
 
+for arg in "$@"; do
+  case "$arg" in --force) FORCE=true ;; esac
+done
+
+# ── Tools installeren ────────────────────────────────────────────────────────
 echo "[fuseki-loader] Benodigde tools installeren..."
 if command -v apk > /dev/null 2>&1; then
   apk add --no-cache curl git > /dev/null 2>&1
@@ -15,44 +31,151 @@ elif command -v apt-get > /dev/null 2>&1; then
   apt-get update -qq && apt-get install -y --no-install-recommends curl git > /dev/null 2>&1
 fi
 
+# ── Wachten op Fuseki ────────────────────────────────────────────────────────
 echo "[fuseki-loader] Wachten op Fuseki..."
 until curl -sf "${FUSEKI_URL}/\$/ping" > /dev/null; do
   sleep 2
 done
 echo "[fuseki-loader] Fuseki is bereikbaar."
 
-# Controleer of ontologie al geladen is (sentinel graph)
-QUERY="ASK { GRAPH <${SENTINEL_GRAPH}> { ?s ?p ?o } }"
-RESULT=$(curl -sf $AUTH \
-  --data-urlencode "query=${QUERY}" \
-  "${FUSEKI_URL}/${DATASET}/query" \
-  -H "Accept: application/sparql-results+json" | \
-  grep -o '"boolean"[[:space:]]*:[[:space:]]*[a-z]*' | grep -o '[a-z]*$' || echo "false")
+# ── Dataset aanmaken indien nodig ────────────────────────────────────────────
+curl -sf $AUTH \
+  -X POST \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data "dbName=${DATASET}&dbType=tdb2" \
+  "${FUSEKI_URL}/\$/datasets" > /dev/null 2>&1 || true
 
-if [ "$RESULT" = "true" ]; then
-  echo "[fuseki-loader] VALOR-O ontologie al geladen, overslaan."
-  exit 0
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+sparql_ask() {
+  curl -sf $AUTH \
+    --data-urlencode "query=$1" \
+    "${FUSEKI_URL}/${DATASET}/query" \
+    -H "Accept: application/sparql-results+json" | \
+    grep -o '"boolean"[[:space:]]*:[[:space:]]*[a-z]*' | grep -o '[a-z]*$' || echo "false"
+}
+
+sparql_select_value() {
+  # Retourneert de eerste ?value uit een SELECT-resultaat
+  curl -sf $AUTH \
+    --data-urlencode "query=$1" \
+    "${FUSEKI_URL}/${DATASET}/query" \
+    -H "Accept: application/sparql-results+json" | \
+    grep -o '"value":"[^"]*"' | head -1 | sed 's/"value":"//;s/"//' || echo ""
+}
+
+sparql_update() {
+  curl -sf $AUTH \
+    -X POST \
+    --data-urlencode "update=$1" \
+    "${FUSEKI_URL}/${DATASET}/update"
+}
+
+extract_graph_uri() {
+  # Eerste regel van de vorm <...> { — ook urn: en andere schemata
+  grep -m1 '^<' "$1" | sed 's/[[:space:]]*{.*//' | tr -d '<>' || echo ""
+}
+
+extract_version() {
+  # owl:versionInfo "0.1"
+  grep -m1 'versionInfo' "$1" | grep -o '"[^"]*"' | head -1 | tr -d '"' || echo ""
+}
+
+file_fingerprint() {
+  # Fallback voor bestanden zonder owl:versionInfo (bv. SHACL-files)
+  md5sum "$1" 2>/dev/null | cut -c1-8 || \
+  sha256sum "$1" 2>/dev/null | cut -c1-8 || \
+  echo "unversioned"
+}
+
+# ── --force: reset alle ontologie-graphs ────────────────────────────────────
+if [ "$FORCE" = "true" ]; then
+  echo "[fuseki-loader] --force: bestaande ontologie-graphs verwijderen..."
+
+  GRAPHS_QUERY="SELECT ?g WHERE { GRAPH <${MODULES_GRAPH}> { ?m <urn:valor:graphUri> ?g } }"
+  GRAPHS=$(curl -sf $AUTH \
+    --data-urlencode "query=${GRAPHS_QUERY}" \
+    "${FUSEKI_URL}/${DATASET}/query" \
+    -H "Accept: application/sparql-results+json" | \
+    grep -o '"value":"http[^"]*"' | sed 's/"value":"//;s/"//' || true)
+
+  for g in $GRAPHS; do
+    echo "[fuseki-loader]   Drop: ${g}"
+    sparql_update "DROP SILENT GRAPH <${g}>"
+  done
+
+  sparql_update "DROP SILENT GRAPH <${MODULES_GRAPH}>"
+  echo "[fuseki-loader] Reset compleet."
 fi
 
+# ── Ontologie ophalen ────────────────────────────────────────────────────────
 echo "[fuseki-loader] VALOR-O ontologie ophalen van GitHub..."
 TMPDIR=$(mktemp -d)
-git clone --depth=1 "${ONTOLOGY_REPO}" "${TMPDIR}/ontology"
+git clone --depth=1 "${ONTOLOGY_REPO}" "${TMPDIR}/ontology" > /dev/null 2>&1
 
-echo "[fuseki-loader] TriG-modules laden in dataset '${DATASET}'..."
+# ── Per-module laden ─────────────────────────────────────────────────────────
+echo "[fuseki-loader] Ontologie-modules verwerken..."
+LOADED=0
+SKIPPED=0
+
 for f in "${TMPDIR}/ontology/"*.trig; do
+  [ -f "$f" ] || continue
+
   FNAME=$(basename "$f")
-  echo "[fuseki-loader]   Laden: ${FNAME}"
-  curl -sf $AUTH -X POST \
+  MODULE_NAME=$(basename "$f" .trig)
+  MODULE_URI="urn:valor:module:${MODULE_NAME}"
+  GRAPH_URI=$(extract_graph_uri "$f")
+  VERSION=$(extract_version "$f")
+
+  if [ -z "$VERSION" ]; then
+    VERSION=$(file_fingerprint "$f")
+  fi
+
+  # Al geladen met deze versie?
+  CHECK="ASK { GRAPH <${MODULES_GRAPH}> { <${MODULE_URI}> <urn:valor:version> \"${VERSION}\" } }"
+  if [ "$(sparql_ask "${CHECK}")" = "true" ]; then
+    echo "[fuseki-loader]   Overslaan: ${FNAME} (versie ${VERSION})"
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  # Bestaande versie ophalen (voor archivering)
+  OLD_VERSION=$(sparql_select_value \
+    "SELECT ?v WHERE { GRAPH <${MODULES_GRAPH}> { <${MODULE_URI}> <urn:valor:version> ?v } }")
+
+  if [ -n "$OLD_VERSION" ] && [ -n "$GRAPH_URI" ]; then
+    ARCHIVE_URI="${GRAPH_URI}/v${OLD_VERSION}"
+    echo "[fuseki-loader]   Archiveren: ${FNAME} (v${OLD_VERSION} → ${ARCHIVE_URI})"
+    sparql_update "COPY SILENT <${GRAPH_URI}> TO <${ARCHIVE_URI}>"
+    sparql_update "CLEAR GRAPH <${GRAPH_URI}>"
+  fi
+
+  echo "[fuseki-loader]   Laden: ${FNAME} (versie ${VERSION})"
+  curl -sf $AUTH \
+    -X POST \
     -H "Content-Type: application/trig" \
     --data-binary "@${f}" \
     "${FUSEKI_URL}/${DATASET}/data" || echo "[fuseki-loader]   WAARSCHUWING: ${FNAME} mislukt"
+
+  # Registry bijwerken (fallback graph URI als het bestand geen named graph declareert)
+  REG_GRAPH_URI="${GRAPH_URI:-urn:valor:module-data:${MODULE_NAME}}"
+  sparql_update "
+    DELETE { GRAPH <${MODULES_GRAPH}> {
+      <${MODULE_URI}> <urn:valor:version> ?v .
+      <${MODULE_URI}> <urn:valor:graphUri> ?g .
+    }}
+    INSERT { GRAPH <${MODULES_GRAPH}> {
+      <${MODULE_URI}> <urn:valor:version> \"${VERSION}\" .
+      <${MODULE_URI}> <urn:valor:graphUri> <${REG_GRAPH_URI}> .
+    }}
+    WHERE { OPTIONAL { GRAPH <${MODULES_GRAPH}> {
+      <${MODULE_URI}> <urn:valor:version> ?v .
+      <${MODULE_URI}> <urn:valor:graphUri> ?g .
+    }}}
+  " || echo "[fuseki-loader]   WAARSCHUWING: registry-update mislukt voor ${FNAME}"
+
+  LOADED=$((LOADED + 1))
 done
 
-# Sentinel graph aanmaken zodat volgende run overgeslagen wordt
-curl -sf $AUTH -X PUT \
-  -H "Content-Type: text/turtle" \
-  --data-binary "<${SENTINEL_GRAPH}> a <urn:valor:Sentinel> ." \
-  "${FUSEKI_URL}/${DATASET}/data?graph=${SENTINEL_GRAPH}"
-
 rm -rf "${TMPDIR}"
-echo "[fuseki-loader] VALOR-O ontologie-modules succesvol geladen."
+echo "[fuseki-loader] Klaar: ${LOADED} module(s) geladen, ${SKIPPED} overgeslagen."

--- a/fuseki/load-ontology.sh
+++ b/fuseki/load-ontology.sh
@@ -7,8 +7,9 @@
 #            Gebruik bij een full reset of dev-omgeving cleanup.
 #
 # Per-module versie-tracking in named graph urn:valor:ontology-modules.
-# Modules worden alleen geladen als ze nieuw zijn of een andere versie hebben.
-# Bij een versiewijziging wordt de oude graph gearchiveerd als {graph}/v{versie}.
+# De versie van een module is de Git commit SHA van het bestand in de ontologie-repo.
+# Elke wijziging in de repo — ongeacht owl:versionInfo — triggert automatisch een herlaad.
+# Bij een versiewijziging wordt de oude graph gearchiveerd als {graph}/v{git-sha}.
 set -e
 
 FUSEKI_URL="${FUSEKI_URL:-http://fuseki:3030}"
@@ -76,16 +77,9 @@ extract_graph_uri() {
   grep -m1 '^<' "$1" | sed 's/[[:space:]]*{.*//' | tr -d '<>' || echo ""
 }
 
-extract_version() {
-  # owl:versionInfo "0.1"
-  grep -m1 'versionInfo' "$1" | grep -o '"[^"]*"' | head -1 | tr -d '"' || echo ""
-}
-
-file_fingerprint() {
-  # Fallback voor bestanden zonder owl:versionInfo (bv. SHACL-files)
-  md5sum "$1" 2>/dev/null | cut -c1-8 || \
-  sha256sum "$1" 2>/dev/null | cut -c1-8 || \
-  echo "unversioned"
+git_file_sha() {
+  # Git commit SHA van de laatste commit die dit bestand aanraakte (eerste 12 tekens)
+  git -C "${TMPDIR}/ontology" log --format='%H' -n 1 -- "$1" | cut -c1-12
 }
 
 # ── --force: reset alle ontologie-graphs ────────────────────────────────────
@@ -125,11 +119,7 @@ for f in "${TMPDIR}/ontology/"*.trig; do
   MODULE_NAME=$(basename "$f" .trig)
   MODULE_URI="urn:valor:module:${MODULE_NAME}"
   GRAPH_URI=$(extract_graph_uri "$f")
-  VERSION=$(extract_version "$f")
-
-  if [ -z "$VERSION" ]; then
-    VERSION=$(file_fingerprint "$f")
-  fi
+  VERSION=$(git_file_sha "${FNAME}")
 
   # Al geladen met deze versie?
   CHECK="ASK { GRAPH <${MODULES_GRAPH}> { <${MODULE_URI}> <urn:valor:version> \"${VERSION}\" } }"


### PR DESCRIPTION
## Samenvatting

- `valor:uncertaintyLevel` toegevoegd als optioneel veld op Tessera (`POST /tessera/`, `GET /tessera/{id}`)
- Vier PAMS-individuen geladen uit Fuseki bij startup: `StatisticalRisk`, `Scenario`, `DeepUncertainty`, `Ignorance`
- `load-ontology.sh` gecorrigeerd: change-detectie nu via **git commit SHA** (niet `owl:versionInfo`) — elke commit in valor-ontology triggert automatisch een herlaad in Fuseki
- `00j-tessera.trig` in valor-ontology uitgebreid met `valor:UncertaintyLevel` klasse + property (commit `928cddb`)

## Geteste acceptatiecriteria

- [x] `POST /tessera/` accepteert optioneel `uncertainty_level` met PAMS-waarden
- [x] Waarde opgeslagen als `valor:uncertaintyLevel` URI triple in Fuseki
- [x] `GET /tessera/{id}` retourneert `uncertainty_level` in response
- [x] Ontology cache laadt vier PAMS-individuen bij startup (geverifieerd in backend logs)

## Bijwerking in valor-ontology repo

Zie commit `928cddb` in [LeonardDune/valor-ontology](https://github.com/LeonardDune/valor-ontology).

Closes #349