### PR TITLE
feat(designspace): US-3.2 — SPARQL proxy met access control

### DIFF
--- a/backend/app/routers/designspace.py
+++ b/backend/app/routers/designspace.py
@@ -1,13 +1,14 @@
 import logging
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import JSONResponse
 
 from app.auth import get_current_user
 from app.db.designspace import create_design_space as db_create_design_space
 from app.db.permissions import check_permission
 from app.models.domain import DesignSpaceCreate, DesignSpaceResponse, Role
-from app.services.fuseki import initialize_design_space_graphs
+from app.services.fuseki import initialize_design_space_graphs, sparql_proxy_query
 
 logger = logging.getLogger(__name__)
 
@@ -49,3 +50,24 @@ async def create_design_space(
         named_graphs=named_graphs,
         created_at=datetime.now(timezone.utc).isoformat(),
     )
+
+
+@router.get("/{design_space_id}/sparql")
+async def sparql_query(
+    design_space_id: str,
+    query: str = Query(..., description="SPARQL SELECT/CONSTRUCT/ASK/DESCRIBE query"),
+    user: dict = Depends(get_current_user),
+) -> JSONResponse:
+    user_id = user["id"]
+
+    if not await check_permission(user_id, design_space_id, Role.VIEWER):
+        raise HTTPException(
+            status_code=403,
+            detail="Onvoldoende rechten voor deze DesignSpace.",
+        )
+
+    result = await sparql_proxy_query(query, design_space_id)
+
+    logger.info("SPARQL proxy: DesignSpace %s bevraagd door gebruiker %s", design_space_id, user_id)
+
+    return JSONResponse(content=result)

--- a/backend/app/services/fuseki.py
+++ b/backend/app/services/fuseki.py
@@ -60,6 +60,43 @@ async def sparql_select(query: str, named_graph: str) -> list[dict[str, Any]]:
     ]
 
 
+_READONLY_QUERY_TYPES = ("select", "construct", "ask", "describe")
+
+
+async def sparql_proxy_query(query: str, ds_id: str) -> dict[str, Any]:
+    """Voert een read-only SPARQL query uit binnen de scope van een DesignSpace.
+
+    Alle 5 named graphs van de DesignSpace worden als default graph toegevoegd,
+    zodat de query alleen data van die DesignSpace kan zien (isolatie gegarandeerd).
+    UPDATE/INSERT/DELETE queries worden geweigerd.
+    """
+    query_type = query.strip().split()[0].lower() if query.strip() else ""
+    if query_type not in _READONLY_QUERY_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Alleen read-only SPARQL queries toegestaan (SELECT, CONSTRUCT, ASK, DESCRIBE). Ontvangen: '{query_type}'.",
+        )
+
+    graph_names = ["base", "asis", "decisions", "agents", "provenance"]
+    params = [
+        ("default-graph-uri", f"urn:valor:ds:{ds_id}/{g}")
+        for g in graph_names
+    ]
+    headers = {"Accept": "application/sparql-results+json, application/ld+json;q=0.9, text/turtle;q=0.8"}
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            _SPARQL_ENDPOINT,
+            params=params,
+            data={"query": query},
+            headers=headers,
+            timeout=30,
+        )
+
+    _raise_for_fuseki_error(response)
+    return response.json()
+
+
 async def sparql_update(update: str, named_graph: str) -> None:
     """Voert een SPARQL UPDATE uit.
 

--- a/backend/scripts/verify_sparql_proxy_us32.py
+++ b/backend/scripts/verify_sparql_proxy_us32.py
@@ -1,0 +1,117 @@
+"""Verificatiescript voor US-3.2: SPARQL proxy access control.
+
+Test de sparql_proxy_query functie direct tegen Fuseki:
+- Scoping: query ziet alleen de 5 graphs van de opgegeven DesignSpace
+- Isolatie: data van andere DesignSpaces is onzichtbaar
+- Blokkering van UPDATE-queries
+
+Gebruik:
+    cd backend && FUSEKI_URL=http://localhost:3030 python scripts/verify_sparql_proxy_us32.py
+"""
+import asyncio
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import httpx
+
+FUSEKI_URL = os.getenv("FUSEKI_URL", "http://localhost:3030")
+FUSEKI_DATASET = "valor"
+FUSEKI_PASSWORD = os.getenv("FUSEKI_ADMIN_PASSWORD", "admin")
+UPDATE_ENDPOINT = f"{FUSEKI_URL}/{FUSEKI_DATASET}/update"
+
+DS_A = "verify-us32-ds-a"
+DS_B = "verify-us32-ds-b"
+ISSUE_A = "urn:valor:issue:us32-a"
+ISSUE_B = "urn:valor:issue:us32-b"
+
+
+async def cleanup(*ds_ids: str):
+    graphs = [
+        f"urn:valor:ds:{ds}/{g}"
+        for ds in ds_ids
+        for g in ["base", "asis", "decisions", "agents", "provenance"]
+    ]
+    drop = " ; ".join(f"DROP SILENT GRAPH <{g}>" for g in graphs)
+    async with httpx.AsyncClient() as client:
+        await client.post(
+            UPDATE_ENDPOINT,
+            data={"update": drop},
+            auth=("admin", FUSEKI_PASSWORD),
+            timeout=10,
+        )
+
+
+async def main():
+    from app.services.fuseki import initialize_design_space_graphs, sparql_proxy_query
+    from fastapi import HTTPException
+
+    print("=== US-3.2 Verificatie: SPARQL proxy access control ===\n")
+    await cleanup(DS_A, DS_B)
+
+    print("1. Twee DesignSpaces initialiseren...")
+    await initialize_design_space_graphs(DS_A, ISSUE_A)
+    await initialize_design_space_graphs(DS_B, ISSUE_B)
+    print("   OK\n")
+
+    ok = True
+
+    print("2. Query op DS_A ziet DS_A data...")
+    result = await sparql_proxy_query(
+        "SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 10", DS_A
+    )
+    bindings = result.get("results", {}).get("bindings", [])
+    a_subjects = {b["s"]["value"] for b in bindings}
+    ds_a_uri = f"urn:valor:ds:{DS_A}"
+    ds_b_uri = f"urn:valor:ds:{DS_B}"
+    if ds_a_uri in a_subjects:
+        print(f"   [OK] DS_A URI aanwezig in resultaat")
+    else:
+        print(f"   [FAIL] DS_A URI niet gevonden: {a_subjects}")
+        ok = False
+
+    print("\n3. Query op DS_A ziet GEEN DS_B data...")
+    if ds_b_uri not in a_subjects:
+        print(f"   [OK] DS_B URI afwezig in DS_A query resultaat")
+    else:
+        print(f"   [FAIL] DS_B URI lekt in DS_A resultaat!")
+        ok = False
+
+    print("\n4. UPDATE query wordt geblokkeerd...")
+    try:
+        await sparql_proxy_query(
+            "INSERT DATA { GRAPH <urn:test> { <a> <b> <c> } }", DS_A
+        )
+        print("   [FAIL] UPDATE niet geblokkeerd!")
+        ok = False
+    except HTTPException as e:
+        if e.status_code == 400:
+            print(f"   [OK] UPDATE geblokkeerd met 400: {e.detail[:60]}")
+        else:
+            print(f"   [FAIL] Verkeerde statuscode: {e.status_code}")
+            ok = False
+
+    print("\n5. ASK query werkt...")
+    result = await sparql_proxy_query(
+        f"ASK {{ <{ds_a_uri}> ?p ?o }}", DS_A
+    )
+    if result.get("boolean") is True:
+        print("   [OK] ASK True voor bestaande triple")
+    else:
+        print(f"   [FAIL] ASK gaf: {result}")
+        ok = False
+
+    await cleanup(DS_A, DS_B)
+    print("\n6. Testdata opgeruimd.")
+
+    if ok:
+        print("\n✓ US-3.2 verificatie geslaagd")
+        sys.exit(0)
+    else:
+        print("\n✗ US-3.2 verificatie MISLUKT")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Samenvatting

- Nieuw endpoint `GET /designspace/{id}/sparql?query=...`
- Permissie-check via Neo4j (VIEWER-rol vereist) — 403 bij onbevoegde aanroep
- Query automatisch gescoopt op de 5 named graphs van de DesignSpace (`base`, `asis`, `decisions`, `agents`, `provenance`)
- UPDATE/INSERT/DELETE queries geblokkeerd met HTTP 400
- Fuseki nooit direct publiek bereikbaar

## Gewijzigde bestanden

| Bestand | Wijziging |
|---------|-----------|
| `app/services/fuseki.py` | `sparql_proxy_query()` toegevoegd |
| `app/routers/designspace.py` | `GET /{id}/sparql` endpoint toegevoegd |

## Testplan

- [x] Syntaxcheck geslaagd
- [x] `scripts/verify_sparql_proxy_us32.py`:
  - [x] DS_A query ziet DS_A data
  - [x] DS_A query ziet geen DS_B data (isolatie)
  - [x] UPDATE query geblokkeerd (400)
  - [x] ASK query werkt correct

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)