### PR TITLE
feat(causa): kleurcodering epistemische status op nodes en edges (US-4.1 #298)

### DIFF
--- a/frontend/src/perspectives/causa/layout/mappers.ts
+++ b/frontend/src/perspectives/causa/layout/mappers.ts
@@ -1,5 +1,13 @@
 import type { Factor, Claim } from '../../../services/api';
-import type { CausalNode, CausalLink } from '../types';
+import type { CausalNode, CausalLink, EpistemicStatus } from '../types';
+
+const VALID_EPISTEMIC_STATUSES: EpistemicStatus[] = ['Proposed', 'Contested', 'Accepted', 'Rejected', 'Reconsidered'];
+
+function normalizeEpistemicStatus(raw?: string): EpistemicStatus {
+    if (!raw) return 'Proposed';
+    const normalized = raw.charAt(0).toUpperCase() + raw.slice(1).toLowerCase() as EpistemicStatus;
+    return VALID_EPISTEMIC_STATUSES.includes(normalized) ? normalized : 'Proposed';
+}
 
 /**
  * Maps API Factor to Internal CausalNode
@@ -11,6 +19,7 @@ export const mapFactorToNode = (factor: Factor): CausalNode => {
         type: factor.type === 'systeemelement' ? 'system' : 'factor',
         role: factor.type,
         description: factor.description,
+        epistemicStatus: normalizeEpistemicStatus(factor.epistemic_status),
         version_id: factor.version_id
     };
 };
@@ -29,8 +38,7 @@ export const mapClaimToLink = (claim: Claim): CausalLink => {
         source: claim.source_id || '',
         target: claim.target_id || '',
         polarity: polarity,
-        // Using US-CAUSA-05 default logic for now until backend supports it
-        status: 'validated',
+        epistemicStatus: normalizeEpistemicStatus(claim.status),
         certainty: claim.confidence || 1.0,
         statement: claim.statement,
         version_id: claim.version_id,

--- a/frontend/src/perspectives/causa/types.ts
+++ b/frontend/src/perspectives/causa/types.ts
@@ -3,13 +3,15 @@
  * This ensures strict typing internal to the module.
  */
 
+export type EpistemicStatus = 'Proposed' | 'Contested' | 'Accepted' | 'Rejected' | 'Reconsidered';
+
 export interface CausalNode {
     id: string;
     label: string;
     type: 'factor' | 'system';
     role?: string; // e.g. 'middel', 'extern', 'criterium'
     description?: string;
-    // Future: status, confidence, evidence
+    epistemicStatus?: EpistemicStatus;
     version_id?: string;
 }
 
@@ -18,8 +20,7 @@ export interface CausalLink {
     source: string;
     target: string;
     polarity: 'positive' | 'negative' | 'ambiguous';
-    // Visualization properties (US-CAUSA-05/06)
-    status?: 'proposed' | 'validated' | 'rejected';
+    epistemicStatus?: EpistemicStatus;
     certainty?: number; // 0.0 - 1.0
     statement?: string;
     version_id?: string;

--- a/frontend/src/perspectives/causa/views/CLDView.tsx
+++ b/frontend/src/perspectives/causa/views/CLDView.tsx
@@ -164,6 +164,7 @@ export const CLDView: FunctionComponent<CLDViewProps> = ({
                         type: cn.type,
                         role: cn.role,
                         description: cn.description,
+                        epistemicStatus: cn.epistemicStatus,
                         threadCount: (cn.version_id && threadStats[cn.version_id]) || 0,
                         version_id: cn.version_id,
                         onOpenThread: handleOpenThread,
@@ -247,7 +248,7 @@ export const CLDView: FunctionComponent<CLDViewProps> = ({
                     },
                     data: {
                         polarity: cl.polarity,
-                        status: cl.status || 'validated',
+                        epistemicStatus: cl.epistemicStatus,
                         certainty: cl.certainty,
                         statement: cl.statement, // Include statement/claim text
                         source: cl.source, // redundancy for data access

--- a/frontend/src/perspectives/causa/views/edges/CLDEdge.tsx
+++ b/frontend/src/perspectives/causa/views/edges/CLDEdge.tsx
@@ -3,6 +3,15 @@ import React from 'react';
 import { type EdgeProps, getBezierPath, EdgeLabelRenderer, BaseEdge } from 'reactflow';
 import { PlusCircle, MinusCircle, MessageSquare, FileText } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import type { EpistemicStatus } from '../../types';
+
+const epistemicStrokeColor: Record<EpistemicStatus, string> = {
+    Proposed:     '#94a3b8', // slate-400
+    Contested:    '#fb923c', // orange-400
+    Accepted:     '#22c55e', // green-500
+    Rejected:     '#ef4444', // red-500
+    Reconsidered: '#a855f7', // purple-500
+};
 
 const CLDEdge = ({
     id,
@@ -31,9 +40,13 @@ const CLDEdge = ({
     // Use global CSS variable for causal colors
     const color = isPositive ? 'var(--color-causal-positive)' : 'var(--color-causal-negative)';
 
+    const epistemicStatus = (data?.epistemicStatus || 'Proposed') as EpistemicStatus;
+    const strokeColor = epistemicStrokeColor[epistemicStatus] || epistemicStrokeColor.Proposed;
+    const strokeOpacity = epistemicStatus === 'Rejected' ? 0.4 : 1;
+
     return (
         <>
-            <BaseEdge id={id} path={edgePath} markerEnd={markerEnd} style={style} />
+            <BaseEdge id={id} path={edgePath} markerEnd={markerEnd} style={{ ...style, stroke: strokeColor, strokeOpacity }} />
             <EdgeLabelRenderer>
                 <div
                     style={{

--- a/frontend/src/perspectives/causa/views/nodes/CLDNode.tsx
+++ b/frontend/src/perspectives/causa/views/nodes/CLDNode.tsx
@@ -5,6 +5,15 @@ import { Wrench, Cloud, Cpu, Target, HelpCircle, MessageSquare, type LucideProps
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import type { EpistemicStatus } from '../../types';
+
+const epistemicStatusStyles: Record<EpistemicStatus, { borderLeft: string; dot: string; label: string }> = {
+    Proposed:     { borderLeft: 'border-l-slate-400',  dot: 'bg-slate-400',   label: 'Voorgesteld' },
+    Contested:    { borderLeft: 'border-l-orange-400', dot: 'bg-orange-400',  label: 'Betwist' },
+    Accepted:     { borderLeft: 'border-l-green-500',  dot: 'bg-green-500',   label: 'Geaccepteerd' },
+    Rejected:     { borderLeft: 'border-l-red-500',    dot: 'bg-red-500',     label: 'Afgewezen' },
+    Reconsidered: { borderLeft: 'border-l-purple-500', dot: 'bg-purple-500',  label: 'Heroverwogen' },
+};
 
 // Use strict Lucide types
 const iconMap: Record<string, FunctionComponent<LucideProps>> = {
@@ -50,17 +59,20 @@ const CARD_HEIGHT = '100px';
 const CLDNode: FunctionComponent<NodeProps> = ({ id, data, selected }) => {
     const role = (data.role || 'systeemelement').toLowerCase() as keyof typeof iconMap;
     const isReadOnly = data.isReadOnly || false;
+    const epistemicStatus = (data.epistemicStatus || 'Proposed') as EpistemicStatus;
 
     const Icon = iconMap[role] || iconMap.unknown;
     const styles = roleStyles[role] || roleStyles.unknown;
+    const statusStyle = epistemicStatusStyles[epistemicStatus] || epistemicStatusStyles.Proposed;
 
     return (
         <div
-            className={`
-                group bg-white rounded-panel relative hover:shadow-lg transition-all
-                flex flex-col border border-border-standard
-                ${selected ? 'ring-2 ring-blue-500 border-transparent' : ''}
-            `}
+            className={cn(
+                'group bg-white rounded-panel relative hover:shadow-lg transition-all',
+                'flex flex-col border border-border-standard border-l-4',
+                statusStyle.borderLeft,
+                selected ? 'ring-2 ring-blue-500 border-transparent' : ''
+            )}
             style={{
                 width: CARD_WIDTH,
                 height: CARD_HEIGHT,
@@ -119,9 +131,15 @@ const CLDNode: FunctionComponent<NodeProps> = ({ id, data, selected }) => {
                 </span>
             </div>
 
-            {/* Footer Icon */}
-            <div className={`absolute bottom-2 right-2 opacity-50 ${styles.icon}`}>
-                <Icon size={16} />
+            {/* Footer: rol-icoon + status-badge */}
+            <div className="absolute bottom-2 right-2 flex items-center gap-1">
+                <span
+                    className={cn('w-2 h-2 rounded-full', statusStyle.dot)}
+                    title={statusStyle.label}
+                />
+                <span className={cn('opacity-50', styles.icon)}>
+                    <Icon size={16} />
+                </span>
             </div>
         </div>
     );

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -102,6 +102,7 @@ export interface Factor {
     type: FactorType;
     version_id?: string;
     thread_id?: string;
+    epistemic_status?: string;
 }
 
 export interface Organization {


### PR DESCRIPTION
## Summary
- `EpistemicStatus` type toegevoegd: `Proposed | Contested | Accepted | Rejected | Reconsidered`
- `CLDNode`: gekleurde linker border + status-dot per epistemische status (grijs/oranje/groen/rood/paars)
- `CLDEdge`: stroke-kleur aangestuurd door epistemische status; `Rejected` edges krijgen 40% opacity
- `mappers.ts`: `epistemicStatus` normaliseren en doorgeven vanuit API in plaats van hardcoderen
- `api.ts`: `epistemic_status?: string` veld toegevoegd aan `Factor` interface

## Kleurschema
| Status | Kleur |
|---|---|
| Proposed | Grijs |
| Contested | Oranje |
| Accepted | Groen |
| Rejected | Rood (40% opacity) |
| Reconsidered | Paars |

## Test plan
- [ ] Workspace openen met bestaande factors/claims — alle nodes tonen grijze (Proposed) border en dot
- [ ] Acceptatiecriteria: juiste kleur per epistemische status, badge zichtbaar op node
- [ ] Bestaande workspace-functionaliteit (sleep, verbinden, threads) ongewijzigd

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)