### PR TITLE
feat(disc): US-16.1 — OWL-module valor-disc (00w) definiëren en laden in Fuseki

### DIFF
--- a/backend/app/services/ontology_cache.py
+++ b/backend/app/services/ontology_cache.py
@@ -7,6 +7,7 @@ Queryt de VALOR-O ontologie-graphs in Fuseki voor:
   - Geldige statusovergangen (valor:allowedTransitionTo)
   - Statussen die een DecisionEpisode vereisen (valor:requiresDecisionEpisode)
   - UncertaintyLevel instanties (PAMS-taxonomie, English label -> URI)
+  - disc:ContributionType instanties (Dutch label -> URI)
 """
 import logging
 
@@ -29,12 +30,17 @@ _uncertainty_label_to_uri: dict[str, str] = {}  # "StatisticalRisk" → URI
 _participant_role_data: dict[str, dict] = {}
 # RBAC role weights derived from ontology: "admin" → 30
 _rbac_role_weights: dict[str, int] = {}
+_disc_contribution_type_label_to_uri: dict[str, str] = {}  # "Vraag" → URI
+
+
+_DISC_GRAPH = f"{VALOR_NS}disc"
 
 
 async def load_ontology_cache() -> None:
     global _evidence_label_to_uri, _status_label_to_uri, _status_uri_to_label
     global _valid_transitions, _requires_decision_episode, _argue_label_to_uri
     global _uncertainty_label_to_uri, _participant_role_data, _rbac_role_weights
+    global _disc_contribution_type_label_to_uri
 
     logger.info("[ontology-cache] Ontologie-data laden van Fuseki...")
 
@@ -161,6 +167,20 @@ async def load_ontology_cache() -> None:
     logger.info("[ontology-cache] ParticipantRoles: %s", list(_participant_role_data.keys()))
     logger.info("[ontology-cache] RBAC gewichten: %s", _rbac_role_weights)
 
+    disc_type_rows = await sparql_select_global(f"""
+        PREFIX disc: <{VALOR_NS}disc#>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        SELECT ?uri ?label WHERE {{
+          GRAPH <{_DISC_GRAPH}> {{
+            ?uri a disc:ContributionType ;
+                 rdfs:label ?label .
+            FILTER(lang(?label) = "nl")
+          }}
+        }}
+    """)
+    _disc_contribution_type_label_to_uri = {row["label"]: row["uri"] for row in disc_type_rows}
+    logger.info("[ontology-cache] Bijdragetypes (disc): %s", list(_disc_contribution_type_label_to_uri.keys()))
+
     if not _evidence_label_to_uri or not _status_label_to_uri or not _valid_transitions:
         logger.warning(
             "[ontology-cache] Ontologie-cache onvolledig. "
@@ -213,6 +233,10 @@ def get_rbac_role_weights() -> dict[str, int]:
 def has_voting_right(valor_role_label: str) -> bool:
     """True als de VALOR-O rol stemrecht heeft (uit ontologie)."""
     return _participant_role_data.get(valor_role_label, {}).get("voting_right", False)
+
+
+def get_disc_contribution_type_label_to_uri() -> dict[str, str]:
+    return _disc_contribution_type_label_to_uri
 
 
 def rbac_to_valor_role(rbac_role: str) -> str:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -88,6 +88,16 @@ def _seed_ontology_cache() -> None:
         v: k for k, v in ontology_cache._status_label_to_uri.items()
     }
 
+    DISC_NS = f"{VALOR_NS}disc#"
+    ontology_cache._disc_contribution_type_label_to_uri = {
+        "Vraag":       f"{DISC_NS}Vraag",
+        "Stelling":    f"{DISC_NS}Stelling",
+        "Bewijs":      f"{DISC_NS}Bewijs",
+        "Bezwaar":     f"{DISC_NS}Bezwaar",
+        "Toelichting": f"{DISC_NS}Toelichting",
+        "Akkoord":     f"{DISC_NS}Akkoord",
+    }
+
 
 # ---------------------------------------------------------------------------
 # Sessie-scoped fixtures

--- a/backend/tests/integration/test_disc_ontology.py
+++ b/backend/tests/integration/test_disc_ontology.py
@@ -1,0 +1,129 @@
+"""Integratietests voor de disc:ContributionType ontologie (US-16.1).
+
+Verifieert:
+- Na het laden van disc-triples in Fuseki retourneert een SPARQL-query
+  de zes disc:ContributionType instanties.
+- load_ontology_cache() vult _disc_contribution_type_label_to_uri correct.
+"""
+import pytest
+
+pytestmark = pytest.mark.integration
+
+DISC_NS = "https://valor-ecosystem.nl/ontology/disc#"
+DISC_GRAPH = "https://valor-ecosystem.nl/ontology/disc"
+
+EXPECTED_CONTRIBUTION_TYPES = {
+    "Vraag",
+    "Stelling",
+    "Bewijs",
+    "Bezwaar",
+    "Toelichting",
+    "Akkoord",
+}
+
+_DISC_SEED_UPDATE = f"""
+PREFIX disc:  <{DISC_NS}>
+PREFIX rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl:   <http://www.w3.org/2002/07/owl#>
+PREFIX prov:  <https://www.w3.org/ns/prov#>
+
+INSERT DATA {{
+  GRAPH <{DISC_GRAPH}> {{
+    disc:ContributionType a owl:Class .
+
+    disc:Vraag       a disc:ContributionType ; rdfs:label "Vraag"@nl .
+    disc:Stelling    a disc:ContributionType ; rdfs:label "Stelling"@nl .
+    disc:Bewijs      a disc:ContributionType ; rdfs:label "Bewijs"@nl .
+    disc:Bezwaar     a disc:ContributionType ; rdfs:label "Bezwaar"@nl .
+    disc:Toelichting a disc:ContributionType ; rdfs:label "Toelichting"@nl .
+    disc:Akkoord     a disc:ContributionType ; rdfs:label "Akkoord"@nl .
+
+    disc:DiscussionThread  a owl:Class ; rdfs:subClassOf prov:Activity .
+    disc:ThreadContribution a owl:Class ; rdfs:subClassOf prov:Activity .
+    disc:ThreadResolution  a owl:Class ; rdfs:subClassOf prov:Entity .
+  }}
+}}
+"""
+
+
+@pytest.fixture
+async def disc_graph_seeded():
+    """Seed de disc-module triples in de test-Fuseki instantie."""
+    from app.services.fuseki import sparql_select_global
+    import app.services.fuseki as fs
+    import httpx
+
+    url = f"{fs.FUSEKI_URL}/{fs.FUSEKI_DATASET}/update"
+    async with httpx.AsyncClient() as client:
+        r = await client.post(
+            url,
+            data={"update": _DISC_SEED_UPDATE},
+            auth=("admin", fs.FUSEKI_ADMIN_PASSWORD),
+            timeout=15,
+        )
+        r.raise_for_status()
+
+
+# ---------------------------------------------------------------------------
+# SPARQL-query test
+# ---------------------------------------------------------------------------
+
+async def test_sparql_retourneert_zes_contribution_types(disc_graph_seeded):
+    from app.services.fuseki import sparql_select_global
+
+    rows = await sparql_select_global(f"""
+        PREFIX disc: <{DISC_NS}>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        SELECT ?uri ?label WHERE {{
+          GRAPH <{DISC_GRAPH}> {{
+            ?uri a disc:ContributionType ;
+                 rdfs:label ?label .
+            FILTER(lang(?label) = "nl")
+          }}
+        }}
+    """)
+
+    labels = {row["label"] for row in rows}
+    assert labels == EXPECTED_CONTRIBUTION_TYPES, (
+        f"Verwachte types: {EXPECTED_CONTRIBUTION_TYPES}, gevonden: {labels}"
+    )
+
+
+async def test_sparql_retourneert_drie_disc_klassen(disc_graph_seeded):
+    from app.services.fuseki import sparql_select_global
+
+    rows = await sparql_select_global(f"""
+        PREFIX disc: <{DISC_NS}>
+        PREFIX owl:  <http://www.w3.org/2002/07/owl#>
+        SELECT ?uri WHERE {{
+          GRAPH <{DISC_GRAPH}> {{
+            ?uri a owl:Class .
+          }}
+        }}
+    """)
+
+    uris = {row["uri"] for row in rows}
+    assert f"{DISC_NS}DiscussionThread" in uris
+    assert f"{DISC_NS}ThreadContribution" in uris
+    assert f"{DISC_NS}ThreadResolution" in uris
+    assert f"{DISC_NS}ContributionType" in uris
+
+
+# ---------------------------------------------------------------------------
+# Ontologie-cache test
+# ---------------------------------------------------------------------------
+
+async def test_load_ontology_cache_vult_disc_contribution_types(disc_graph_seeded):
+    from app.services.ontology_cache import (
+        load_ontology_cache,
+        get_disc_contribution_type_label_to_uri,
+    )
+
+    await load_ontology_cache()
+
+    disc_types = get_disc_contribution_type_label_to_uri()
+    assert set(disc_types.keys()) == EXPECTED_CONTRIBUTION_TYPES
+
+    for label, uri in disc_types.items():
+        assert uri.startswith(DISC_NS), f"URI {uri} heeft niet de verwachte disc namespace"
+        assert uri == f"{DISC_NS}{label}", f"URI voor '{label}' klopt niet: {uri}"


### PR DESCRIPTION
## Samenvatting

Sluit #411

- `00w-valor-disc.trig` toegevoegd aan [valor-ontology repo](https://github.com/LeonardDune/valor-ontology/blob/master/00w-valor-disc.trig) met klassen `disc:DiscussionThread`, `disc:ThreadContribution`, `disc:ThreadResolution`, `disc:ContributionType` en 6 instanties (Vraag, Stelling, Bewijs, Bezwaar, Toelichting, Akkoord)
- `ontology_cache.py` uitgebreid: laadt `disc:ContributionType` instanties bij startup + getter `get_disc_contribution_type_label_to_uri()`
- `conftest.py` uitgebreid: disc contribution types geseed voor integratietests
- 3 nieuwe integratietests: SPARQL-query, klasse-verificatie, cache-loading

## Acceptatiecriteria verificatie

- [x] Module `00w-valor-disc.trig` aanwezig in valor-ontology repository
- [x] Module geladen in Fuseki bij startup (via bestaande `load-ontology.sh`)
- [x] `ontology_cache.py` laadt `disc:`-prefixes en contribution types
- [x] SPARQL-query op Fuseki retourneert disc:ContributionType instanties

## Tests

```
38 passed in 4.76s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)