### PR TITLE
feat(disc): US-16.2 — Backend: DiscussionThread aanmaken en opslaan in Fuseki

### DIFF
--- a/backend/app/db/disc.py
+++ b/backend/app/db/disc.py
@@ -1,0 +1,83 @@
+"""Fuseki-operaties voor de disc:DiscussionThread entiteit (Epic 16)."""
+import uuid
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from app.services.fuseki import sparql_update, sparql_select, named_graph_uri
+
+logger = logging.getLogger(__name__)
+
+DISC_NS = "https://valor-ecosystem.nl/ontology/disc#"
+PROV_NS = "https://www.w3.org/ns/prov#"
+XSD_NS = "http://www.w3.org/2001/XMLSchema#"
+VALOR_NS_BASE = "https://valor-ecosystem.nl/ontology/"
+
+
+async def create_discussion_thread(
+    tessera_id: str,
+    design_space_id: str,
+    user_id: str,
+) -> str:
+    """Schrijft een disc:DiscussionThread naar de named graph van de DesignSpace.
+
+    Retourneert het thread_id (UUID).
+    """
+    thread_id = str(uuid.uuid4())
+    thread_uri = f"urn:valor:thread:{thread_id}"
+    tessera_uri = f"urn:valor:tessera:{tessera_id}"
+    user_uri = f"urn:valor:user:{user_id}"
+    ds_uri = f"urn:valor:ds:{design_space_id}"
+    graph_uri = named_graph_uri(design_space_id)
+    timestamp = datetime.now(timezone.utc).isoformat()
+
+    update = f"""PREFIX disc: <{DISC_NS}>
+PREFIX prov: <{PROV_NS}>
+PREFIX xsd:  <{XSD_NS}>
+PREFIX valor: <{VALOR_NS_BASE}>
+
+INSERT DATA {{
+  GRAPH <{graph_uri}> {{
+    <{thread_uri}> a disc:DiscussionThread ;
+      prov:wasStartedBy <{user_uri}> ;
+      prov:startedAtTime "{timestamp}"^^xsd:dateTime ;
+      disc:aboutTessera <{tessera_uri}> ;
+      valor:inDesignSpace <{ds_uri}> .
+  }}
+}}"""
+
+    await sparql_update(update, design_space_id)
+    logger.info("DiscussionThread %s aangemaakt in DesignSpace %s", thread_uri, design_space_id)
+    return thread_id
+
+
+async def get_threads_by_tessera(
+    tessera_id: str,
+    design_space_id: str,
+) -> list[dict[str, Any]]:
+    """Geeft alle disc:DiscussionThreads voor een Tessera binnen een DesignSpace."""
+    tessera_uri = f"urn:valor:tessera:{tessera_id}"
+
+    query = f"""PREFIX disc: <{DISC_NS}>
+PREFIX prov: <{PROV_NS}>
+
+SELECT ?thread_uri ?started_by ?started_at WHERE {{
+  ?thread_uri a disc:DiscussionThread ;
+    disc:aboutTessera <{tessera_uri}> ;
+    prov:wasStartedBy ?started_by ;
+    prov:startedAtTime ?started_at .
+}}
+ORDER BY DESC(?started_at)"""
+
+    rows = await sparql_select(query, design_space_id)
+    return [
+        {
+            "thread_id": row["thread_uri"].split(":")[-1],
+            "thread_uri": row["thread_uri"],
+            "tessera_id": tessera_id,
+            "design_space_id": design_space_id,
+            "started_by": row["started_by"],
+            "started_at": row["started_at"],
+        }
+        for row in rows
+    ]

--- a/backend/app/routers/threads.py
+++ b/backend/app/routers/threads.py
@@ -1,58 +1,68 @@
-from fastapi import APIRouter, HTTPException, Depends
-from typing import List, Dict, Optional
+"""Discussiethreads router — Fuseki-backed (Epic 16, US-16.2).
+
+Vervangt de Neo4j-implementatie. Threads worden opgeslagen als
+disc:DiscussionThread in de named graph van de DesignSpace.
+"""
 import logging
-from app.models.domain import ThreadCreate, ThreadMessageCreate
-from app.db.crud import (
-    create_conversation_thread, 
-    get_threads_by_target, 
-    get_thread_counts, 
-    create_thread_message, 
-    get_thread_messages
-)
-from app.auth import get_current_user, verify_token
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from app.auth import get_current_user
+from app.db.disc import create_discussion_thread, get_threads_by_tessera
+from app.db.permissions import check_permission
+from app.models.domain import Role
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(
     tags=["threads"],
     responses={404: {"description": "Not found"}},
 )
 
-logger = logging.getLogger(__name__)
 
-@router.post("/threads")
-async def create_thread_generic(thread: ThreadCreate, user: dict = Depends(get_current_user)):
-    # Check permissions (Member access okay for creating threads? Or Admin? Intent says "Participant", so Member is likely fine.)
-    # Let's enforce Membership at least.
-    email = user.get("email")
-    # For now, relying on space existing. Ideally check `is_member`.
-    # Assuming if you can see the space, you can create a thread.
-    # Refine later if strict permissions needed.
-    
-    target_id = thread.target_id
-    if not target_id:
-         raise HTTPException(status_code=400, detail="target_id is required for generic threads")
+class CreateThreadRequest(BaseModel):
+    tessera_id: str
+    design_space_id: str
 
-    tid = await create_conversation_thread(target_id, thread.topic)
-    return {"id": tid, "topic": thread.topic}
 
-@router.get("/threads")
-async def list_threads_generic(target_id: str, user: dict = Depends(get_current_user)):
-    # target_id passed as query param
-    return await get_threads_by_target(target_id)
+class ThreadResponse(BaseModel):
+    thread_id: str
+    thread_uri: str
+    tessera_id: str
+    design_space_id: str
+    started_by: str
+    started_at: str
 
-@router.post("/threads/stats")
-async def get_thread_stats(target_ids: List[str], user: dict = Depends(get_current_user)):
-    return await get_thread_counts(target_ids)
 
-@router.post("/threads/{thread_id}/messages")
-async def add_thread_message(thread_id: str, message: ThreadMessageCreate, user: dict = Depends(get_current_user)):
-    user_id = user.get("id")
-    if not user_id:
-        logger.error(f"User from dependency missing ID field: {user}")
-        raise HTTPException(status_code=500, detail="User identity error")
-        
-    logger.info(f"Adding message to thread {thread_id} for user {user_id}")
-    return await create_thread_message(thread_id, user_id, message.content)
+@router.post("/threads", response_model=dict[str, str], status_code=201)
+async def create_thread(
+    request: CreateThreadRequest,
+    user: dict = Depends(get_current_user),
+) -> dict[str, Any]:
+    user_id = user["id"]
+    has_permission = await check_permission(user_id, request.design_space_id, Role.MEMBER)
+    if not has_permission:
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten om een discussiethread aan te maken.")
 
-@router.get("/threads/{thread_id}/messages")
-async def list_thread_messages(thread_id: str, user: dict = Depends(get_current_user)):
-    return await get_thread_messages(thread_id)
+    thread_id = await create_discussion_thread(
+        tessera_id=request.tessera_id,
+        design_space_id=request.design_space_id,
+        user_id=user_id,
+    )
+    return {"thread_id": thread_id}
+
+
+@router.get("/threads", response_model=list[ThreadResponse])
+async def list_threads(
+    tessera_id: str = Query(..., description="ID van de Tessera"),
+    design_space_id: str = Query(..., description="ID van de DesignSpace"),
+    user: dict = Depends(get_current_user),
+) -> list[dict[str, Any]]:
+    user_id = user["id"]
+    has_permission = await check_permission(user_id, design_space_id, Role.MEMBER)
+    if not has_permission:
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten om threads op te halen.")
+
+    return await get_threads_by_tessera(tessera_id=tessera_id, design_space_id=design_space_id)

--- a/backend/tests/integration/test_disc_threads.py
+++ b/backend/tests/integration/test_disc_threads.py
@@ -1,0 +1,140 @@
+"""Integratietests voor disc:DiscussionThread aanmaken en ophalen (US-16.2).
+
+Verifieert:
+- create_discussion_thread schrijft correcte triples naar Fuseki
+- get_threads_by_tessera retourneert de juiste threads
+- Meerdere threads per tessera worden correct teruggegeven
+"""
+import pytest
+
+from app.db.disc import create_discussion_thread, get_threads_by_tessera
+from app.services.fuseki import named_graph_uri
+
+pytestmark = pytest.mark.integration
+
+DISC_NS = "https://valor-ecosystem.nl/ontology/disc#"
+PROV_NS = "https://www.w3.org/ns/prov#"
+
+TESSERA_A = "tessera-disc-test-001"
+TESSERA_B = "tessera-disc-test-002"
+USER_ID = "user-disc-test-001"
+
+
+async def _sparql_select(graph_uri: str, query: str) -> list[dict]:
+    import httpx
+    from tests.conftest import FUSEKI_TEST_URL, FUSEKI_TEST_DATASET
+
+    endpoint = f"{FUSEKI_TEST_URL}/{FUSEKI_TEST_DATASET}/sparql"
+    async with httpx.AsyncClient() as client:
+        r = await client.post(
+            endpoint,
+            data={"query": query},
+            headers={"Accept": "application/sparql-results+json"},
+            timeout=10,
+        )
+    r.raise_for_status()
+    return r.json()["results"]["bindings"]
+
+
+# ---------------------------------------------------------------------------
+# create_discussion_thread
+# ---------------------------------------------------------------------------
+
+async def test_create_thread_retourneert_thread_id(ds_id):
+    thread_id = await create_discussion_thread(TESSERA_A, ds_id, USER_ID)
+    assert thread_id, "thread_id mag niet leeg zijn"
+    assert len(thread_id) == 36, "thread_id moet een UUID zijn"
+
+
+async def test_create_thread_schrijft_type_triple(ds_id):
+    thread_id = await create_discussion_thread(TESSERA_A, ds_id, USER_ID)
+    thread_uri = f"urn:valor:thread:{thread_id}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX disc: <{DISC_NS}>
+        SELECT ?thread WHERE {{
+          GRAPH <{graph}> {{
+            <{thread_uri}> a disc:DiscussionThread .
+            BIND(<{thread_uri}> AS ?thread)
+          }}
+        }}
+    """)
+    assert rows, "disc:DiscussionThread-triple ontbreekt in Fuseki"
+
+
+async def test_create_thread_schrijft_about_tessera(ds_id):
+    thread_id = await create_discussion_thread(TESSERA_A, ds_id, USER_ID)
+    thread_uri = f"urn:valor:thread:{thread_id}"
+    tessera_uri = f"urn:valor:tessera:{TESSERA_A}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX disc: <{DISC_NS}>
+        SELECT ?tessera WHERE {{
+          GRAPH <{graph}> {{
+            <{thread_uri}> disc:aboutTessera ?tessera .
+          }}
+        }}
+    """)
+    assert rows, "disc:aboutTessera-triple ontbreekt"
+    assert rows[0]["tessera"]["value"] == tessera_uri
+
+
+async def test_create_thread_schrijft_prov_triples(ds_id):
+    thread_id = await create_discussion_thread(TESSERA_A, ds_id, USER_ID)
+    thread_uri = f"urn:valor:thread:{thread_id}"
+    user_uri = f"urn:valor:user:{USER_ID}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX prov: <{PROV_NS}>
+        SELECT ?started_by ?started_at WHERE {{
+          GRAPH <{graph}> {{
+            <{thread_uri}> prov:wasStartedBy ?started_by ;
+                           prov:startedAtTime ?started_at .
+          }}
+        }}
+    """)
+    assert rows, "prov:wasStartedBy / prov:startedAtTime ontbreken"
+    assert rows[0]["started_by"]["value"] == user_uri
+    assert rows[0]["started_at"]["value"], "startedAtTime mag niet leeg zijn"
+
+
+# ---------------------------------------------------------------------------
+# get_threads_by_tessera
+# ---------------------------------------------------------------------------
+
+async def test_get_threads_retourneert_lege_lijst_zonder_data(ds_id):
+    result = await get_threads_by_tessera(TESSERA_A, ds_id)
+    assert result == []
+
+
+async def test_get_threads_retourneert_aangemaakte_thread(ds_id):
+    thread_id = await create_discussion_thread(TESSERA_A, ds_id, USER_ID)
+    result = await get_threads_by_tessera(TESSERA_A, ds_id)
+
+    assert len(result) == 1
+    assert result[0]["thread_id"] == thread_id
+    assert result[0]["tessera_id"] == TESSERA_A
+    assert result[0]["design_space_id"] == ds_id
+    assert result[0]["started_by"] == f"urn:valor:user:{USER_ID}"
+
+
+async def test_get_threads_retourneert_meerdere_threads(ds_id):
+    tid1 = await create_discussion_thread(TESSERA_A, ds_id, USER_ID)
+    tid2 = await create_discussion_thread(TESSERA_A, ds_id, USER_ID)
+
+    result = await get_threads_by_tessera(TESSERA_A, ds_id)
+    assert len(result) == 2
+    thread_ids = {r["thread_id"] for r in result}
+    assert tid1 in thread_ids
+    assert tid2 in thread_ids
+
+
+async def test_get_threads_isoleert_per_tessera(ds_id):
+    """Threads van tessera A mogen niet in resultaat van tessera B verschijnen."""
+    await create_discussion_thread(TESSERA_A, ds_id, USER_ID)
+
+    result_b = await get_threads_by_tessera(TESSERA_B, ds_id)
+    assert result_b == [], "Thread van tessera A mag niet verschijnen bij tessera B"


### PR DESCRIPTION
## Summary
- Vervangt Neo4j-backed `/threads` endpoints met Fuseki-implementatie
- `POST /threads` schrijft `disc:DiscussionThread` naar de named graph van de DesignSpace, met PROV-O traceerbaarheid (`prov:wasStartedBy`, `prov:startedAtTime`)
- `GET /threads?tessera_id=&design_space_id=` haalt threads op per Tessera
- RBAC: minimaal `MEMBER`-rol vereist (403 bij onvoldoende rechten)

## Bestanden
- `backend/app/db/disc.py` — nieuwe Fuseki DB-module voor disc-entiteiten
- `backend/app/routers/threads.py` — vervangen door Fuseki-backed router
- `backend/tests/integration/test_disc_threads.py` — 8 integratietests (allen groen)

## Test plan
- [x] `pytest tests/integration/test_disc_threads.py` — 8/8 groen tegen live Fuseki

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)