### PR TITLE
feat(disc): US-16.3 — Backend: ThreadContribution schrijven naar Fuseki met PROV-O

### DIFF
--- a/backend/app/db/disc.py
+++ b/backend/app/db/disc.py
@@ -51,6 +51,92 @@ INSERT DATA {{
     return thread_id
 
 
+async def create_thread_contribution(
+    thread_id: str,
+    design_space_id: str,
+    user_id: str,
+    contribution_type_uri: str,
+    message_content: str,
+    evidence_id: str | None = None,
+) -> str:
+    """Schrijft een disc:ThreadContribution naar de named graph van de DesignSpace.
+
+    Koppelt de bijdrage aan de thread via disc:hasContribution.
+    Retourneert het contribution_id (UUID).
+    """
+    contrib_id = str(uuid.uuid4())
+    contrib_uri = f"urn:valor:contrib:{contrib_id}"
+    thread_uri = f"urn:valor:thread:{thread_id}"
+    user_uri = f"urn:valor:user:{user_id}"
+    graph_uri = named_graph_uri(design_space_id)
+    timestamp = datetime.now(timezone.utc).isoformat()
+
+    escaped_content = message_content.replace("\\", "\\\\").replace('"', '\\"')
+
+    evidence_triple = ""
+    if evidence_id:
+        evidence_uri = f"urn:valor:evidence:{evidence_id}"
+        evidence_triple = f'\n      disc:attachesEvidence <{evidence_uri}> ;'
+
+    update = f"""PREFIX disc: <{DISC_NS}>
+PREFIX prov: <{PROV_NS}>
+PREFIX xsd:  <{XSD_NS}>
+PREFIX valor: <{VALOR_NS_BASE}>
+
+INSERT DATA {{
+  GRAPH <{graph_uri}> {{
+    <{contrib_uri}> a disc:ThreadContribution ;
+      disc:contributionType <{contribution_type_uri}> ;
+      valor:messageContent "{escaped_content}"@nl ;{evidence_triple}
+      prov:wasAssociatedWith <{user_uri}> ;
+      prov:endedAtTime "{timestamp}"^^xsd:dateTime .
+    <{thread_uri}> disc:hasContribution <{contrib_uri}> .
+  }}
+}}"""
+
+    await sparql_update(update, design_space_id)
+    logger.info("ThreadContribution %s toegevoegd aan thread %s", contrib_uri, thread_uri)
+    return contrib_id
+
+
+async def get_contributions_by_thread(
+    thread_id: str,
+    design_space_id: str,
+) -> list[dict[str, Any]]:
+    """Geeft alle disc:ThreadContributions voor een thread, gesorteerd op tijd."""
+    thread_uri = f"urn:valor:thread:{thread_id}"
+
+    query = f"""PREFIX disc: <{DISC_NS}>
+PREFIX prov: <{PROV_NS}>
+PREFIX valor: <{VALOR_NS_BASE}>
+
+SELECT ?contrib_uri ?contribution_type ?message_content ?associated_with ?ended_at ?evidence WHERE {{
+  <{thread_uri}> disc:hasContribution ?contrib_uri .
+  ?contrib_uri disc:contributionType ?contribution_type ;
+               valor:messageContent ?message_content ;
+               prov:wasAssociatedWith ?associated_with ;
+               prov:endedAtTime ?ended_at .
+  OPTIONAL {{ ?contrib_uri disc:attachesEvidence ?evidence . }}
+}}
+ORDER BY ASC(?ended_at)"""
+
+    rows = await sparql_select(query, design_space_id)
+    return [
+        {
+            "contribution_id": row["contrib_uri"].split(":")[-1],
+            "contribution_uri": row["contrib_uri"],
+            "thread_id": thread_id,
+            "design_space_id": design_space_id,
+            "contribution_type": row["contribution_type"],
+            "message_content": row["message_content"],
+            "contributed_by": row["associated_with"],
+            "contributed_at": row["ended_at"],
+            "evidence_id": row["evidence"].split(":")[-1] if row.get("evidence") else None,
+        }
+        for row in rows
+    ]
+
+
 async def get_threads_by_tessera(
     tessera_id: str,
     design_space_id: str,

--- a/backend/app/routers/threads.py
+++ b/backend/app/routers/threads.py
@@ -1,18 +1,24 @@
-"""Discussiethreads router — Fuseki-backed (Epic 16, US-16.2).
+"""Discussiethreads router — Fuseki-backed (Epic 16, US-16.2 / US-16.3).
 
-Vervangt de Neo4j-implementatie. Threads worden opgeslagen als
-disc:DiscussionThread in de named graph van de DesignSpace.
+Vervangt de Neo4j-implementatie. Threads en bijdragen worden opgeslagen als
+disc:DiscussionThread / disc:ThreadContribution in de named graph van de DesignSpace.
 """
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from app.auth import get_current_user
-from app.db.disc import create_discussion_thread, get_threads_by_tessera
+from app.db.disc import (
+    create_discussion_thread,
+    get_threads_by_tessera,
+    create_thread_contribution,
+    get_contributions_by_thread,
+)
 from app.db.permissions import check_permission
 from app.models.domain import Role
+from app.services.ontology_cache import get_disc_contribution_type_label_to_uri
 
 logger = logging.getLogger(__name__)
 
@@ -66,3 +72,67 @@ async def list_threads(
         raise HTTPException(status_code=403, detail="Onvoldoende rechten om threads op te halen.")
 
     return await get_threads_by_tessera(tessera_id=tessera_id, design_space_id=design_space_id)
+
+
+class CreateContributionRequest(BaseModel):
+    design_space_id: str
+    contribution_type: str  # Dutch label: "Vraag" | "Stelling" | "Bewijs" | "Bezwaar" | "Toelichting" | "Akkoord"
+    message_content: str
+    evidence_id: Optional[str] = None
+
+
+class ContributionResponse(BaseModel):
+    contribution_id: str
+    contribution_uri: str
+    thread_id: str
+    design_space_id: str
+    contribution_type: str
+    message_content: str
+    contributed_by: str
+    contributed_at: str
+    evidence_id: Optional[str] = None
+
+
+@router.post("/threads/{thread_id}/contribute", response_model=dict[str, str], status_code=201)
+async def add_contribution(
+    thread_id: str,
+    request: CreateContributionRequest,
+    user: dict = Depends(get_current_user),
+) -> dict[str, Any]:
+    user_id = user["id"]
+    has_permission = await check_permission(user_id, request.design_space_id, Role.MEMBER)
+    if not has_permission:
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten om een bijdrage toe te voegen.")
+
+    contribution_type_map = get_disc_contribution_type_label_to_uri()
+    contribution_type_uri = contribution_type_map.get(request.contribution_type)
+    if not contribution_type_uri:
+        valid = sorted(contribution_type_map.keys())
+        raise HTTPException(
+            status_code=422,
+            detail=f"Ongeldig bijdragetype '{request.contribution_type}'. Geldige waarden: {valid}.",
+        )
+
+    contrib_id = await create_thread_contribution(
+        thread_id=thread_id,
+        design_space_id=request.design_space_id,
+        user_id=user_id,
+        contribution_type_uri=contribution_type_uri,
+        message_content=request.message_content,
+        evidence_id=request.evidence_id,
+    )
+    return {"contribution_id": contrib_id}
+
+
+@router.get("/threads/{thread_id}/contributions", response_model=list[ContributionResponse])
+async def list_contributions(
+    thread_id: str,
+    design_space_id: str = Query(..., description="ID van de DesignSpace"),
+    user: dict = Depends(get_current_user),
+) -> list[dict[str, Any]]:
+    user_id = user["id"]
+    has_permission = await check_permission(user_id, design_space_id, Role.MEMBER)
+    if not has_permission:
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten om bijdragen op te halen.")
+
+    return await get_contributions_by_thread(thread_id=thread_id, design_space_id=design_space_id)

--- a/backend/tests/integration/test_disc_contributions.py
+++ b/backend/tests/integration/test_disc_contributions.py
@@ -1,0 +1,271 @@
+"""Integratietests voor disc:ThreadContribution aanmaken en ophalen (US-16.3).
+
+Verifieert:
+- create_thread_contribution schrijft correcte triples naar Fuseki
+- PROV-O: prov:wasAssociatedWith + prov:endedAtTime aanwezig
+- disc:hasContribution koppelt bijdrage aan thread
+- disc:attachesEvidence correct opgeslagen indien evidence meegegeven
+- get_contributions_by_thread retourneert bijdragen gesorteerd op tijd
+"""
+import pytest
+
+from app.db.disc import create_discussion_thread, create_thread_contribution, get_contributions_by_thread
+from app.services.fuseki import named_graph_uri
+
+pytestmark = pytest.mark.integration
+
+DISC_NS = "https://valor-ecosystem.nl/ontology/disc#"
+PROV_NS = "https://www.w3.org/ns/prov#"
+VALOR_BASE = "https://valor-ecosystem.nl/ontology/"
+
+TESSERA_ID = "tessera-contrib-test-001"
+USER_ID = "user-contrib-test-001"
+CONTRIB_TYPE_URI = f"{DISC_NS}Vraag"
+EVIDENCE_ID = "evidence-contrib-test-001"
+
+
+async def _sparql_select(graph_uri: str, query: str) -> list[dict]:
+    import httpx
+    from tests.conftest import FUSEKI_TEST_URL, FUSEKI_TEST_DATASET
+
+    endpoint = f"{FUSEKI_TEST_URL}/{FUSEKI_TEST_DATASET}/sparql"
+    async with httpx.AsyncClient() as client:
+        r = await client.post(
+            endpoint,
+            data={"query": query},
+            headers={"Accept": "application/sparql-results+json"},
+            timeout=10,
+        )
+    r.raise_for_status()
+    return r.json()["results"]["bindings"]
+
+
+@pytest.fixture
+async def thread_id(ds_id) -> str:
+    """Maak een thread aan als fixture voor bijdrage-tests."""
+    return await create_discussion_thread(TESSERA_ID, ds_id, USER_ID)
+
+
+# ---------------------------------------------------------------------------
+# create_thread_contribution
+# ---------------------------------------------------------------------------
+
+async def test_create_contribution_retourneert_contribution_id(ds_id, thread_id):
+    contrib_id = await create_thread_contribution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        contribution_type_uri=CONTRIB_TYPE_URI,
+        message_content="Dit is een testvraag.",
+    )
+    assert contrib_id, "contribution_id mag niet leeg zijn"
+    assert len(contrib_id) == 36, "contribution_id moet een UUID zijn"
+
+
+async def test_create_contribution_schrijft_type_triple(ds_id, thread_id):
+    contrib_id = await create_thread_contribution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        contribution_type_uri=CONTRIB_TYPE_URI,
+        message_content="Testvraag.",
+    )
+    contrib_uri = f"urn:valor:contrib:{contrib_id}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX disc: <{DISC_NS}>
+        SELECT ?contrib WHERE {{
+          GRAPH <{graph}> {{
+            <{contrib_uri}> a disc:ThreadContribution .
+            BIND(<{contrib_uri}> AS ?contrib)
+          }}
+        }}
+    """)
+    assert rows, "disc:ThreadContribution-triple ontbreekt in Fuseki"
+
+
+async def test_create_contribution_schrijft_contribution_type(ds_id, thread_id):
+    contrib_id = await create_thread_contribution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        contribution_type_uri=CONTRIB_TYPE_URI,
+        message_content="Testvraag.",
+    )
+    contrib_uri = f"urn:valor:contrib:{contrib_id}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX disc: <{DISC_NS}>
+        SELECT ?type WHERE {{
+          GRAPH <{graph}> {{
+            <{contrib_uri}> disc:contributionType ?type .
+          }}
+        }}
+    """)
+    assert rows, "disc:contributionType ontbreekt"
+    assert rows[0]["type"]["value"] == CONTRIB_TYPE_URI
+
+
+async def test_create_contribution_schrijft_prov_triples(ds_id, thread_id):
+    contrib_id = await create_thread_contribution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        contribution_type_uri=CONTRIB_TYPE_URI,
+        message_content="Testvraag.",
+    )
+    contrib_uri = f"urn:valor:contrib:{contrib_id}"
+    user_uri = f"urn:valor:user:{USER_ID}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX prov: <{PROV_NS}>
+        SELECT ?associated_with ?ended_at WHERE {{
+          GRAPH <{graph}> {{
+            <{contrib_uri}> prov:wasAssociatedWith ?associated_with ;
+                             prov:endedAtTime ?ended_at .
+          }}
+        }}
+    """)
+    assert rows, "prov:wasAssociatedWith / prov:endedAtTime ontbreken"
+    assert rows[0]["associated_with"]["value"] == user_uri
+    assert rows[0]["ended_at"]["value"], "endedAtTime mag niet leeg zijn"
+
+
+async def test_create_contribution_koppelt_aan_thread(ds_id, thread_id):
+    contrib_id = await create_thread_contribution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        contribution_type_uri=CONTRIB_TYPE_URI,
+        message_content="Testvraag.",
+    )
+    contrib_uri = f"urn:valor:contrib:{contrib_id}"
+    thread_uri = f"urn:valor:thread:{thread_id}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX disc: <{DISC_NS}>
+        SELECT ?contrib WHERE {{
+          GRAPH <{graph}> {{
+            <{thread_uri}> disc:hasContribution <{contrib_uri}> .
+            BIND(<{contrib_uri}> AS ?contrib)
+          }}
+        }}
+    """)
+    assert rows, "disc:hasContribution-koppeling ontbreekt"
+
+
+async def test_create_contribution_met_evidence(ds_id, thread_id):
+    contrib_id = await create_thread_contribution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        contribution_type_uri=f"{DISC_NS}Bewijs",
+        message_content="Bewijs voor de stelling.",
+        evidence_id=EVIDENCE_ID,
+    )
+    contrib_uri = f"urn:valor:contrib:{contrib_id}"
+    evidence_uri = f"urn:valor:evidence:{EVIDENCE_ID}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX disc: <{DISC_NS}>
+        SELECT ?evidence WHERE {{
+          GRAPH <{graph}> {{
+            <{contrib_uri}> disc:attachesEvidence ?evidence .
+          }}
+        }}
+    """)
+    assert rows, "disc:attachesEvidence-triple ontbreekt"
+    assert rows[0]["evidence"]["value"] == evidence_uri
+
+
+async def test_create_contribution_zonder_evidence_geen_attaches_triple(ds_id, thread_id):
+    contrib_id = await create_thread_contribution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        contribution_type_uri=CONTRIB_TYPE_URI,
+        message_content="Testvraag zonder bewijs.",
+    )
+    contrib_uri = f"urn:valor:contrib:{contrib_id}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX disc: <{DISC_NS}>
+        SELECT ?evidence WHERE {{
+          GRAPH <{graph}> {{
+            <{contrib_uri}> disc:attachesEvidence ?evidence .
+          }}
+        }}
+    """)
+    assert rows == [], "disc:attachesEvidence mag niet aanwezig zijn zonder evidence_id"
+
+
+# ---------------------------------------------------------------------------
+# get_contributions_by_thread
+# ---------------------------------------------------------------------------
+
+async def test_get_contributions_retourneert_lege_lijst(ds_id, thread_id):
+    result = await get_contributions_by_thread(thread_id, ds_id)
+    assert result == []
+
+
+async def test_get_contributions_retourneert_bijdrage(ds_id, thread_id):
+    contrib_id = await create_thread_contribution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        contribution_type_uri=CONTRIB_TYPE_URI,
+        message_content="Testvraag.",
+    )
+    result = await get_contributions_by_thread(thread_id, ds_id)
+
+    assert len(result) == 1
+    assert result[0]["contribution_id"] == contrib_id
+    assert result[0]["thread_id"] == thread_id
+    assert result[0]["contributed_by"] == f"urn:valor:user:{USER_ID}"
+    assert result[0]["evidence_id"] is None
+
+
+async def test_get_contributions_retourneert_meerdere_bijdragen_gesorteerd(ds_id, thread_id):
+    cid1 = await create_thread_contribution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        contribution_type_uri=CONTRIB_TYPE_URI,
+        message_content="Eerste bijdrage.",
+    )
+    cid2 = await create_thread_contribution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        contribution_type_uri=f"{DISC_NS}Stelling",
+        message_content="Tweede bijdrage.",
+    )
+    result = await get_contributions_by_thread(thread_id, ds_id)
+
+    assert len(result) == 2
+    contrib_ids = [r["contribution_id"] for r in result]
+    assert cid1 in contrib_ids
+    assert cid2 in contrib_ids
+    # Gesorteerd op tijd: eerste bijdrage eerst
+    assert contrib_ids.index(cid1) < contrib_ids.index(cid2)
+
+
+async def test_get_contributions_met_evidence_id(ds_id, thread_id):
+    contrib_id = await create_thread_contribution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        contribution_type_uri=f"{DISC_NS}Bewijs",
+        message_content="Met bewijs.",
+        evidence_id=EVIDENCE_ID,
+    )
+    result = await get_contributions_by_thread(thread_id, ds_id)
+
+    assert len(result) == 1
+    assert result[0]["evidence_id"] == EVIDENCE_ID


### PR DESCRIPTION
## Summary
- `POST /threads/{thread_id}/contribute` schrijft `disc:ThreadContribution` naar Fuseki
- Bijdragetype gevalideerd via ontologie-cache (`Vraag | Stelling | Bewijs | Bezwaar | Toelichting | Akkoord`)
- PROV-O: `prov:wasAssociatedWith` (user) + `prov:endedAtTime`
- Optionele `disc:attachesEvidence` koppeling naar `causa:Evidence`
- `disc:hasContribution` koppelt bijdrage aan de thread
- `GET /threads/{thread_id}/contributions?design_space_id=` geeft gesorteerde bijdragen terug
- RBAC: minimaal `MEMBER`-rol vereist

## Bestanden
- `backend/app/db/disc.py` — `create_thread_contribution` + `get_contributions_by_thread`
- `backend/app/routers/threads.py` — twee nieuwe endpoints toegevoegd
- `backend/tests/integration/test_disc_contributions.py` — 11 integratietests

## Test plan
- [x] `pytest tests/integration/test_disc_contributions.py` — 11/11 groen
- [x] `pytest tests/integration/` — 57/57 groen

Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)