### PR TITLE
feat(disc): US-16.4 — Backend: ThreadResolution formaliseren → argue + epistemische statuswijziging

### DIFF
--- a/backend/app/db/disc.py
+++ b/backend/app/db/disc.py
@@ -137,6 +137,65 @@ ORDER BY ASC(?ended_at)"""
     ]
 
 
+async def get_thread_tessera(thread_id: str, design_space_id: str) -> str | None:
+    """Geeft de tessera_uri van een thread, of None als de thread niet bestaat."""
+    thread_uri = f"urn:valor:thread:{thread_id}"
+
+    query = f"""PREFIX disc: <{DISC_NS}>
+
+SELECT ?tessera WHERE {{
+  <{thread_uri}> disc:aboutTessera ?tessera .
+}}"""
+
+    rows = await sparql_select(query, design_space_id)
+    return rows[0]["tessera"] if rows else None
+
+
+async def create_thread_resolution(
+    thread_id: str,
+    design_space_id: str,
+    user_id: str,
+    resolution_outcome_uri: str,
+    resolution_rationale: str,
+    tessera_uri: str,
+) -> str:
+    """Schrijft een disc:ThreadResolution naar de named graph van de DesignSpace.
+
+    Koppelt de resolution aan de thread via disc:hasResolution en registreert
+    disc:motivatesArgue als traceerbaarheidsrelatie naar de target Tessera.
+    Retourneert resolution_id (UUID).
+    """
+    resolution_id = str(uuid.uuid4())
+    resolution_uri = f"urn:valor:resolution:{resolution_id}"
+    thread_uri = f"urn:valor:thread:{thread_id}"
+    user_uri = f"urn:valor:user:{user_id}"
+    graph_uri = named_graph_uri(design_space_id)
+    timestamp = datetime.now(timezone.utc).isoformat()
+
+    escaped_rationale = resolution_rationale.replace("\\", "\\\\").replace('"', '\\"')
+
+    update = f"""PREFIX disc: <{DISC_NS}>
+PREFIX prov: <{PROV_NS}>
+PREFIX xsd:  <{XSD_NS}>
+PREFIX valor: <{VALOR_NS_BASE}>
+
+INSERT DATA {{
+  GRAPH <{graph_uri}> {{
+    <{resolution_uri}> a disc:ThreadResolution ;
+      disc:resolutionOutcome <{resolution_outcome_uri}> ;
+      valor:resolutionRationale "{escaped_rationale}"@nl ;
+      prov:wasAttributedTo <{user_uri}> ;
+      prov:generatedAtTime "{timestamp}"^^xsd:dateTime ;
+      disc:motivatesArgue <{tessera_uri}> .
+    <{thread_uri}> disc:hasResolution <{resolution_uri}> .
+  }}
+}}"""
+
+    await sparql_update(update, design_space_id)
+    logger.info("ThreadResolution %s aangemaakt voor thread %s", resolution_uri, thread_uri)
+    return resolution_id
+
+
 async def get_threads_by_tessera(
     tessera_id: str,
     design_space_id: str,

--- a/backend/app/routers/threads.py
+++ b/backend/app/routers/threads.py
@@ -1,7 +1,8 @@
-"""Discussiethreads router — Fuseki-backed (Epic 16, US-16.2 / US-16.3).
+"""Discussiethreads router — Fuseki-backed (Epic 16, US-16.2 / US-16.3 / US-16.4).
 
-Vervangt de Neo4j-implementatie. Threads en bijdragen worden opgeslagen als
-disc:DiscussionThread / disc:ThreadContribution in de named graph van de DesignSpace.
+Vervangt de Neo4j-implementatie. Threads, bijdragen en resoluties worden opgeslagen als
+disc:DiscussionThread / disc:ThreadContribution / disc:ThreadResolution in de named graph
+van de DesignSpace.
 """
 import logging
 from typing import Any, Optional
@@ -10,15 +11,25 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from app.auth import get_current_user
+from app.db.designspace import get_design_space_meta
 from app.db.disc import (
     create_discussion_thread,
     get_threads_by_tessera,
     create_thread_contribution,
     get_contributions_by_thread,
+    get_thread_tessera,
+    create_thread_resolution,
 )
 from app.db.permissions import check_permission
 from app.models.domain import Role
-from app.services.ontology_cache import get_disc_contribution_type_label_to_uri
+from app.services.connection_manager import manager
+from app.services.fuseki import sparql_select, sparql_update, named_graph_uri, record_provenance_activity
+from app.services.ontology_cache import (
+    get_disc_contribution_type_label_to_uri,
+    get_status_label_to_uri,
+    get_status_uri_to_label,
+)
+from app.ontology import VALOR_NS
 
 logger = logging.getLogger(__name__)
 
@@ -136,3 +147,130 @@ async def list_contributions(
         raise HTTPException(status_code=403, detail="Onvoldoende rechten om bijdragen op te halen.")
 
     return await get_contributions_by_thread(thread_id=thread_id, design_space_id=design_space_id)
+
+
+class ResolveThreadRequest(BaseModel):
+    design_space_id: str
+    resolution_outcome: str   # English label: bijv. "Contested", "Accepted", "Rejected"
+    resolution_rationale: str
+
+
+class ResolveThreadResponse(BaseModel):
+    resolution_id: str
+    thread_id: str
+    tessera_id: str
+    previous_status: str
+    new_status: str
+
+
+@router.post("/threads/{thread_id}/resolve", response_model=ResolveThreadResponse)
+async def resolve_thread(
+    thread_id: str,
+    request: ResolveThreadRequest,
+    user: dict = Depends(get_current_user),
+) -> dict[str, Any]:
+    user_id = user["id"]
+    has_permission = await check_permission(user_id, request.design_space_id, Role.MODERATOR)
+    if not has_permission:
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten om een thread te resolveren. Moderator-rol vereist.")
+
+    # Haal tessera_uri op uit de thread
+    tessera_uri = await get_thread_tessera(thread_id, request.design_space_id)
+    if not tessera_uri:
+        raise HTTPException(status_code=404, detail="Thread niet gevonden in deze DesignSpace.")
+    tessera_id = tessera_uri.split(":")[-1]
+
+    # Valideer resolution_outcome als geldige epistemische status
+    status_label_to_uri = get_status_label_to_uri()
+    new_status_uri = status_label_to_uri.get(request.resolution_outcome)
+    if not new_status_uri:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Ongeldig resolution_outcome '{request.resolution_outcome}'. Geldige waarden: {sorted(status_label_to_uri)}.",
+        )
+
+    # Lees huidige status van de Tessera
+    graph_uri = named_graph_uri(request.design_space_id)
+    status_rows = await sparql_select(
+        f"""SELECT ?status WHERE {{
+          <{tessera_uri}> <{VALOR_NS}epistemicStatus> ?status .
+        }}""",
+        request.design_space_id,
+    )
+    if not status_rows:
+        raise HTTPException(status_code=404, detail="Tessera niet gevonden in deze DesignSpace.")
+
+    current_uri = status_rows[0]["status"]
+    current_label = get_status_uri_to_label().get(current_uri, current_uri)
+
+    # Schrijf disc:ThreadResolution naar Fuseki
+    resolution_id = await create_thread_resolution(
+        thread_id=thread_id,
+        design_space_id=request.design_space_id,
+        user_id=user_id,
+        resolution_outcome_uri=new_status_uri,
+        resolution_rationale=request.resolution_rationale,
+        tessera_uri=tessera_uri,
+    )
+
+    # Wijzig epistemische status van de Tessera
+    await sparql_update(
+        f"""DELETE {{
+  GRAPH <{graph_uri}> {{
+    <{tessera_uri}> <{VALOR_NS}epistemicStatus> <{current_uri}> .
+  }}
+}}
+INSERT {{
+  GRAPH <{graph_uri}> {{
+    <{tessera_uri}> <{VALOR_NS}epistemicStatus> <{new_status_uri}> .
+  }}
+}}
+WHERE {{
+  GRAPH <{graph_uri}> {{
+    <{tessera_uri}> <{VALOR_NS}epistemicStatus> <{current_uri}> .
+  }}
+}}""",
+        request.design_space_id,
+    )
+
+    # PROV-O record
+    await record_provenance_activity(
+        request.design_space_id,
+        "StatusChanged",
+        f"urn:valor:user:{user_id}",
+        used=[tessera_uri],
+        extra_props=[
+            (f"{VALOR_NS}previousStatus", current_uri),
+            (f"{VALOR_NS}newStatus", new_status_uri),
+        ],
+    )
+
+    # WebSocket broadcast
+    ds_meta = get_design_space_meta(request.design_space_id)
+    project_id = ds_meta.get("project_id") if ds_meta else None
+    if project_id:
+        await manager.broadcast_data(project_id, {
+            "type": "TESSERA_STATUS_CHANGED",
+            "payload": {
+                "tessera_id": tessera_id,
+                "tessera_uri": tessera_uri,
+                "previous_status": current_label,
+                "new_status": request.resolution_outcome,
+                "resolution_id": resolution_id,
+                "thread_id": thread_id,
+                "design_space_id": request.design_space_id,
+            },
+        })
+
+    logger.info(
+        "ThreadResolution %s: thread %s → tessera %s status %s → %s (door %s)",
+        resolution_id, thread_id, tessera_id, current_label, request.resolution_outcome, user_id,
+    )
+
+    return ResolveThreadResponse(
+        resolution_id=resolution_id,
+        thread_id=thread_id,
+        tessera_id=tessera_id,
+        previous_status=current_label,
+        new_status=request.resolution_outcome,
+    )

--- a/backend/tests/integration/test_disc_resolution.py
+++ b/backend/tests/integration/test_disc_resolution.py
@@ -1,0 +1,227 @@
+"""Integratietests voor disc:ThreadResolution (US-16.4).
+
+Verifieert:
+- create_thread_resolution schrijft correcte triples naar Fuseki
+- disc:hasResolution koppelt resolution aan thread
+- disc:motivatesArgue koppelt resolution aan tessera
+- disc:resolutionOutcome bevat de juiste status-URI
+- get_thread_tessera retourneert de juiste tessera_uri
+"""
+import pytest
+
+from app.db.disc import (
+    create_discussion_thread,
+    create_thread_resolution,
+    get_thread_tessera,
+)
+from app.services.fuseki import named_graph_uri, sparql_update
+
+pytestmark = pytest.mark.integration
+
+DISC_NS = "https://valor-ecosystem.nl/ontology/disc#"
+PROV_NS = "https://www.w3.org/ns/prov#"
+VALOR_NS = "https://valor-ecosystem.nl/ontology/"
+
+TESSERA_ID = "tessera-resolution-test-001"
+USER_ID = "user-resolution-test-001"
+OUTCOME_URI = f"{VALOR_NS}ContestedStatus"
+
+
+async def _sparql_select(graph_uri: str, query: str) -> list[dict]:
+    import httpx
+    from tests.conftest import FUSEKI_TEST_URL, FUSEKI_TEST_DATASET
+
+    endpoint = f"{FUSEKI_TEST_URL}/{FUSEKI_TEST_DATASET}/sparql"
+    async with httpx.AsyncClient() as client:
+        r = await client.post(
+            endpoint,
+            data={"query": query},
+            headers={"Accept": "application/sparql-results+json"},
+            timeout=10,
+        )
+    r.raise_for_status()
+    return r.json()["results"]["bindings"]
+
+
+@pytest.fixture
+async def tessera_seeded(ds_id) -> str:
+    """Seed een Tessera in Fuseki voor gebruik in resolution-tests."""
+    tessera_uri = f"urn:valor:tessera:{TESSERA_ID}"
+    graph = named_graph_uri(ds_id)
+    proposed_uri = f"{VALOR_NS}ProposedStatus"
+
+    await sparql_update(f"""PREFIX valor: <{VALOR_NS}>
+INSERT DATA {{
+  GRAPH <{graph}> {{
+    <{tessera_uri}> a valor:Tessera ;
+      valor:epistemicStatus <{proposed_uri}> ;
+      valor:claimContent "Testclaim"@nl .
+  }}
+}}""", ds_id)
+    return TESSERA_ID
+
+
+@pytest.fixture
+async def thread_id(ds_id, tessera_seeded) -> str:
+    return await create_discussion_thread(tessera_seeded, ds_id, USER_ID)
+
+
+# ---------------------------------------------------------------------------
+# get_thread_tessera
+# ---------------------------------------------------------------------------
+
+async def test_get_thread_tessera_retourneert_tessera_uri(ds_id, thread_id):
+    result = await get_thread_tessera(thread_id, ds_id)
+    assert result == f"urn:valor:tessera:{TESSERA_ID}"
+
+
+async def test_get_thread_tessera_retourneert_none_voor_onbekende_thread(ds_id):
+    result = await get_thread_tessera("onbekende-thread-id", ds_id)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# create_thread_resolution
+# ---------------------------------------------------------------------------
+
+async def test_create_resolution_retourneert_resolution_id(ds_id, thread_id):
+    tessera_uri = f"urn:valor:tessera:{TESSERA_ID}"
+    resolution_id = await create_thread_resolution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        resolution_outcome_uri=OUTCOME_URI,
+        resolution_rationale="Klopt niet op basis van de discussie.",
+        tessera_uri=tessera_uri,
+    )
+    assert resolution_id, "resolution_id mag niet leeg zijn"
+    assert len(resolution_id) == 36, "resolution_id moet een UUID zijn"
+
+
+async def test_create_resolution_schrijft_type_triple(ds_id, thread_id):
+    tessera_uri = f"urn:valor:tessera:{TESSERA_ID}"
+    resolution_id = await create_thread_resolution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        resolution_outcome_uri=OUTCOME_URI,
+        resolution_rationale="Testrationale.",
+        tessera_uri=tessera_uri,
+    )
+    resolution_uri = f"urn:valor:resolution:{resolution_id}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX disc: <{DISC_NS}>
+        SELECT ?r WHERE {{
+          GRAPH <{graph}> {{
+            <{resolution_uri}> a disc:ThreadResolution .
+            BIND(<{resolution_uri}> AS ?r)
+          }}
+        }}
+    """)
+    assert rows, "disc:ThreadResolution-triple ontbreekt"
+
+
+async def test_create_resolution_schrijft_outcome(ds_id, thread_id):
+    tessera_uri = f"urn:valor:tessera:{TESSERA_ID}"
+    resolution_id = await create_thread_resolution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        resolution_outcome_uri=OUTCOME_URI,
+        resolution_rationale="Testrationale.",
+        tessera_uri=tessera_uri,
+    )
+    resolution_uri = f"urn:valor:resolution:{resolution_id}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX disc: <{DISC_NS}>
+        SELECT ?outcome WHERE {{
+          GRAPH <{graph}> {{
+            <{resolution_uri}> disc:resolutionOutcome ?outcome .
+          }}
+        }}
+    """)
+    assert rows, "disc:resolutionOutcome ontbreekt"
+    assert rows[0]["outcome"]["value"] == OUTCOME_URI
+
+
+async def test_create_resolution_koppelt_aan_thread(ds_id, thread_id):
+    tessera_uri = f"urn:valor:tessera:{TESSERA_ID}"
+    resolution_id = await create_thread_resolution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        resolution_outcome_uri=OUTCOME_URI,
+        resolution_rationale="Testrationale.",
+        tessera_uri=tessera_uri,
+    )
+    resolution_uri = f"urn:valor:resolution:{resolution_id}"
+    thread_uri = f"urn:valor:thread:{thread_id}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX disc: <{DISC_NS}>
+        SELECT ?r WHERE {{
+          GRAPH <{graph}> {{
+            <{thread_uri}> disc:hasResolution <{resolution_uri}> .
+            BIND(<{resolution_uri}> AS ?r)
+          }}
+        }}
+    """)
+    assert rows, "disc:hasResolution-koppeling ontbreekt"
+
+
+async def test_create_resolution_schrijft_motivates_argue(ds_id, thread_id):
+    tessera_uri = f"urn:valor:tessera:{TESSERA_ID}"
+    resolution_id = await create_thread_resolution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        resolution_outcome_uri=OUTCOME_URI,
+        resolution_rationale="Testrationale.",
+        tessera_uri=tessera_uri,
+    )
+    resolution_uri = f"urn:valor:resolution:{resolution_id}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX disc: <{DISC_NS}>
+        SELECT ?target WHERE {{
+          GRAPH <{graph}> {{
+            <{resolution_uri}> disc:motivatesArgue ?target .
+          }}
+        }}
+    """)
+    assert rows, "disc:motivatesArgue-triple ontbreekt"
+    assert rows[0]["target"]["value"] == tessera_uri
+
+
+async def test_create_resolution_schrijft_prov_triples(ds_id, thread_id):
+    tessera_uri = f"urn:valor:tessera:{TESSERA_ID}"
+    resolution_id = await create_thread_resolution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        resolution_outcome_uri=OUTCOME_URI,
+        resolution_rationale="Testrationale.",
+        tessera_uri=tessera_uri,
+    )
+    resolution_uri = f"urn:valor:resolution:{resolution_id}"
+    user_uri = f"urn:valor:user:{USER_ID}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX prov: <{PROV_NS}>
+        SELECT ?attr ?gen WHERE {{
+          GRAPH <{graph}> {{
+            <{resolution_uri}> prov:wasAttributedTo ?attr ;
+                               prov:generatedAtTime ?gen .
+          }}
+        }}
+    """)
+    assert rows, "prov:wasAttributedTo / prov:generatedAtTime ontbreken"
+    assert rows[0]["attr"]["value"] == user_uri
+    assert rows[0]["gen"]["value"], "generatedAtTime mag niet leeg zijn"


### PR DESCRIPTION
## Summary
- `POST /threads/{thread_id}/resolve` — MODERATOR-rol vereist
- Schrijft `disc:ThreadResolution` naar Fuseki met `disc:resolutionOutcome`, rationale, PROV-O
- `disc:hasResolution` koppelt resolution aan de thread
- `disc:motivatesArgue` legt traceerbaarheidsrelatie vast naar de doelTessera
- Epistemische status van de Tessera wordt direct gewijzigd conform `resolution_outcome`
- PROV-O `StatusChanged` record
- WebSocket broadcast `TESSERA_STATUS_CHANGED` naar alle project-clients

## Bestanden
- `backend/app/db/disc.py` — `get_thread_tessera` + `create_thread_resolution`
- `backend/app/routers/threads.py` — `POST /threads/{id}/resolve` endpoint
- `backend/tests/integration/test_disc_resolution.py` — 8 integratietests

## Test plan
- [x] `pytest tests/integration/test_disc_resolution.py` — 8/8 groen
- [x] `pytest tests/integration/` — 65/65 groen

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)