### PR TITLE
fix(disc): FloatingThreadPanel — 403 fix, thread titles, author names

### DIFF
--- a/backend/app/db/designspace.py
+++ b/backend/app/db/designspace.py
@@ -38,6 +38,19 @@ def set_design_space_phase(ds_id: str, phase: str) -> None:
         session.run(query, {"id": ds_id, "phase": phase})
 
 
+def get_design_spaces_by_project(project_id: str) -> list[dict]:
+    """Geeft alle DesignSpaces terug die aan een Project gekoppeld zijn."""
+    driver = get_driver()
+    query = """
+    MATCH (p:Project {id: $pid})-[:HAS_DESIGN_SPACE]->(ds:DesignSpace)
+    RETURN ds.id AS id, ds.name AS name, ds.status AS status, ds.current_phase AS current_phase
+    ORDER BY ds.created_at
+    """
+    with driver.session() as session:
+        result = session.run(query, {"pid": project_id})
+        return [dict(r) for r in result]
+
+
 async def create_design_space(
     name: str,
     description: Optional[str],

--- a/backend/app/db/disc.py
+++ b/backend/app/db/disc.py
@@ -137,6 +137,65 @@ ORDER BY ASC(?ended_at)"""
     ]
 
 
+async def get_thread_tessera(thread_id: str, design_space_id: str) -> str | None:
+    """Geeft de tessera_uri van een thread, of None als de thread niet bestaat."""
+    thread_uri = f"urn:valor:thread:{thread_id}"
+
+    query = f"""PREFIX disc: <{DISC_NS}>
+
+SELECT ?tessera WHERE {{
+  <{thread_uri}> disc:aboutTessera ?tessera .
+}}"""
+
+    rows = await sparql_select(query, design_space_id)
+    return rows[0]["tessera"] if rows else None
+
+
+async def create_thread_resolution(
+    thread_id: str,
+    design_space_id: str,
+    user_id: str,
+    resolution_outcome_uri: str,
+    resolution_rationale: str,
+    tessera_uri: str,
+) -> str:
+    """Schrijft een disc:ThreadResolution naar de named graph van de DesignSpace.
+
+    Koppelt de resolution aan de thread via disc:hasResolution en registreert
+    disc:motivatesArgue als traceerbaarheidsrelatie naar de target Tessera.
+    Retourneert resolution_id (UUID).
+    """
+    resolution_id = str(uuid.uuid4())
+    resolution_uri = f"urn:valor:resolution:{resolution_id}"
+    thread_uri = f"urn:valor:thread:{thread_id}"
+    user_uri = f"urn:valor:user:{user_id}"
+    graph_uri = named_graph_uri(design_space_id)
+    timestamp = datetime.now(timezone.utc).isoformat()
+
+    escaped_rationale = resolution_rationale.replace("\\", "\\\\").replace('"', '\\"')
+
+    update = f"""PREFIX disc: <{DISC_NS}>
+PREFIX prov: <{PROV_NS}>
+PREFIX xsd:  <{XSD_NS}>
+PREFIX valor: <{VALOR_NS_BASE}>
+
+INSERT DATA {{
+  GRAPH <{graph_uri}> {{
+    <{resolution_uri}> a disc:ThreadResolution ;
+      disc:resolutionOutcome <{resolution_outcome_uri}> ;
+      valor:resolutionRationale "{escaped_rationale}"@nl ;
+      prov:wasAttributedTo <{user_uri}> ;
+      prov:generatedAtTime "{timestamp}"^^xsd:dateTime ;
+      disc:motivatesArgue <{tessera_uri}> .
+    <{thread_uri}> disc:hasResolution <{resolution_uri}> .
+  }}
+}}"""
+
+    await sparql_update(update, design_space_id)
+    logger.info("ThreadResolution %s aangemaakt voor thread %s", resolution_uri, thread_uri)
+    return resolution_id
+
+
 async def get_threads_by_tessera(
     tessera_id: str,
     design_space_id: str,

--- a/backend/app/db/disc.py
+++ b/backend/app/db/disc.py
@@ -1,0 +1,83 @@
+"""Fuseki-operaties voor de disc:DiscussionThread entiteit (Epic 16)."""
+import uuid
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from app.services.fuseki import sparql_update, sparql_select, named_graph_uri
+
+logger = logging.getLogger(__name__)
+
+DISC_NS = "https://valor-ecosystem.nl/ontology/disc#"
+PROV_NS = "https://www.w3.org/ns/prov#"
+XSD_NS = "http://www.w3.org/2001/XMLSchema#"
+VALOR_NS_BASE = "https://valor-ecosystem.nl/ontology/"
+
+
+async def create_discussion_thread(
+    tessera_id: str,
+    design_space_id: str,
+    user_id: str,
+) -> str:
+    """Schrijft een disc:DiscussionThread naar de named graph van de DesignSpace.
+
+    Retourneert het thread_id (UUID).
+    """
+    thread_id = str(uuid.uuid4())
+    thread_uri = f"urn:valor:thread:{thread_id}"
+    tessera_uri = f"urn:valor:tessera:{tessera_id}"
+    user_uri = f"urn:valor:user:{user_id}"
+    ds_uri = f"urn:valor:ds:{design_space_id}"
+    graph_uri = named_graph_uri(design_space_id)
+    timestamp = datetime.now(timezone.utc).isoformat()
+
+    update = f"""PREFIX disc: <{DISC_NS}>
+PREFIX prov: <{PROV_NS}>
+PREFIX xsd:  <{XSD_NS}>
+PREFIX valor: <{VALOR_NS_BASE}>
+
+INSERT DATA {{
+  GRAPH <{graph_uri}> {{
+    <{thread_uri}> a disc:DiscussionThread ;
+      prov:wasStartedBy <{user_uri}> ;
+      prov:startedAtTime "{timestamp}"^^xsd:dateTime ;
+      disc:aboutTessera <{tessera_uri}> ;
+      valor:inDesignSpace <{ds_uri}> .
+  }}
+}}"""
+
+    await sparql_update(update, design_space_id)
+    logger.info("DiscussionThread %s aangemaakt in DesignSpace %s", thread_uri, design_space_id)
+    return thread_id
+
+
+async def get_threads_by_tessera(
+    tessera_id: str,
+    design_space_id: str,
+) -> list[dict[str, Any]]:
+    """Geeft alle disc:DiscussionThreads voor een Tessera binnen een DesignSpace."""
+    tessera_uri = f"urn:valor:tessera:{tessera_id}"
+
+    query = f"""PREFIX disc: <{DISC_NS}>
+PREFIX prov: <{PROV_NS}>
+
+SELECT ?thread_uri ?started_by ?started_at WHERE {{
+  ?thread_uri a disc:DiscussionThread ;
+    disc:aboutTessera <{tessera_uri}> ;
+    prov:wasStartedBy ?started_by ;
+    prov:startedAtTime ?started_at .
+}}
+ORDER BY DESC(?started_at)"""
+
+    rows = await sparql_select(query, design_space_id)
+    return [
+        {
+            "thread_id": row["thread_uri"].split(":")[-1],
+            "thread_uri": row["thread_uri"],
+            "tessera_id": tessera_id,
+            "design_space_id": design_space_id,
+            "started_by": row["started_by"],
+            "started_at": row["started_at"],
+        }
+        for row in rows
+    ]

--- a/backend/app/db/disc.py
+++ b/backend/app/db/disc.py
@@ -18,6 +18,7 @@ async def create_discussion_thread(
     tessera_id: str,
     design_space_id: str,
     user_id: str,
+    title: str | None = None,
 ) -> str:
     """Schrijft een disc:DiscussionThread naar de named graph van de DesignSpace.
 
@@ -31,14 +32,17 @@ async def create_discussion_thread(
     graph_uri = named_graph_uri(design_space_id)
     timestamp = datetime.now(timezone.utc).isoformat()
 
+    title_triple = f'\n      rdfs:label "{title.replace(chr(34), chr(39))}"@nl ;' if title else ""
+
     update = f"""PREFIX disc: <{DISC_NS}>
 PREFIX prov: <{PROV_NS}>
 PREFIX xsd:  <{XSD_NS}>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX valor: <{VALOR_NS_BASE}>
 
 INSERT DATA {{
   GRAPH <{graph_uri}> {{
-    <{thread_uri}> a disc:DiscussionThread ;
+    <{thread_uri}> a disc:DiscussionThread ;{title_triple}
       prov:wasStartedBy <{user_uri}> ;
       prov:startedAtTime "{timestamp}"^^xsd:dateTime ;
       disc:aboutTessera <{tessera_uri}> ;
@@ -121,6 +125,8 @@ SELECT ?contrib_uri ?contribution_type ?message_content ?associated_with ?ended_
 ORDER BY ASC(?ended_at)"""
 
     rows = await sparql_select(query, design_space_id)
+    user_uris = list({r["associated_with"] for r in rows})
+    names = _get_user_display_names(user_uris)
     return [
         {
             "contribution_id": row["contrib_uri"].split(":")[-1],
@@ -130,6 +136,7 @@ ORDER BY ASC(?ended_at)"""
             "contribution_type": row["contribution_type"],
             "message_content": row["message_content"],
             "contributed_by": row["associated_with"],
+            "contributed_by_name": names.get(row["associated_with"], row["associated_with"].split(":")[-1]),
             "contributed_at": row["ended_at"],
             "evidence_id": row["evidence"].split(":")[-1] if row.get("evidence") else None,
         }
@@ -196,6 +203,23 @@ INSERT DATA {{
     return resolution_id
 
 
+def _get_user_display_names(user_uris: list[str]) -> dict[str, str]:
+    """Geeft een mapping van user-URI naar weergavenaam (username > name > email)."""
+    from app.db.utils import get_driver
+    if not user_uris:
+        return {}
+    user_ids = [u.split(":")[-1] for u in user_uris]
+    driver = get_driver()
+    query = """
+    UNWIND $ids AS uid
+    MATCH (u:User {id: uid})
+    RETURN uid, coalesce(u.username, u.name, u.email) AS display_name
+    """
+    with driver.session() as session:
+        rows = session.run(query, {"ids": user_ids})
+        return {f"urn:valor:user:{r['uid']}": r["display_name"] for r in rows}
+
+
 async def get_threads_by_tessera(
     tessera_id: str,
     design_space_id: str,
@@ -205,16 +229,20 @@ async def get_threads_by_tessera(
 
     query = f"""PREFIX disc: <{DISC_NS}>
 PREFIX prov: <{PROV_NS}>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT ?thread_uri ?started_by ?started_at WHERE {{
+SELECT ?thread_uri ?started_by ?started_at ?title WHERE {{
   ?thread_uri a disc:DiscussionThread ;
     disc:aboutTessera <{tessera_uri}> ;
     prov:wasStartedBy ?started_by ;
     prov:startedAtTime ?started_at .
+  OPTIONAL {{ ?thread_uri rdfs:label ?title . FILTER(lang(?title) = "nl") }}
 }}
 ORDER BY DESC(?started_at)"""
 
     rows = await sparql_select(query, design_space_id)
+    user_uris = list({r["started_by"] for r in rows})
+    names = _get_user_display_names(user_uris)
     return [
         {
             "thread_id": row["thread_uri"].split(":")[-1],
@@ -222,7 +250,9 @@ ORDER BY DESC(?started_at)"""
             "tessera_id": tessera_id,
             "design_space_id": design_space_id,
             "started_by": row["started_by"],
+            "started_by_name": names.get(row["started_by"], row["started_by"].split(":")[-1]),
             "started_at": row["started_at"],
+            "title": row.get("title"),
         }
         for row in rows
     ]

--- a/backend/app/db/disc.py
+++ b/backend/app/db/disc.py
@@ -51,6 +51,92 @@ INSERT DATA {{
     return thread_id
 
 
+async def create_thread_contribution(
+    thread_id: str,
+    design_space_id: str,
+    user_id: str,
+    contribution_type_uri: str,
+    message_content: str,
+    evidence_id: str | None = None,
+) -> str:
+    """Schrijft een disc:ThreadContribution naar de named graph van de DesignSpace.
+
+    Koppelt de bijdrage aan de thread via disc:hasContribution.
+    Retourneert het contribution_id (UUID).
+    """
+    contrib_id = str(uuid.uuid4())
+    contrib_uri = f"urn:valor:contrib:{contrib_id}"
+    thread_uri = f"urn:valor:thread:{thread_id}"
+    user_uri = f"urn:valor:user:{user_id}"
+    graph_uri = named_graph_uri(design_space_id)
+    timestamp = datetime.now(timezone.utc).isoformat()
+
+    escaped_content = message_content.replace("\\", "\\\\").replace('"', '\\"')
+
+    evidence_triple = ""
+    if evidence_id:
+        evidence_uri = f"urn:valor:evidence:{evidence_id}"
+        evidence_triple = f'\n      disc:attachesEvidence <{evidence_uri}> ;'
+
+    update = f"""PREFIX disc: <{DISC_NS}>
+PREFIX prov: <{PROV_NS}>
+PREFIX xsd:  <{XSD_NS}>
+PREFIX valor: <{VALOR_NS_BASE}>
+
+INSERT DATA {{
+  GRAPH <{graph_uri}> {{
+    <{contrib_uri}> a disc:ThreadContribution ;
+      disc:contributionType <{contribution_type_uri}> ;
+      valor:messageContent "{escaped_content}"@nl ;{evidence_triple}
+      prov:wasAssociatedWith <{user_uri}> ;
+      prov:endedAtTime "{timestamp}"^^xsd:dateTime .
+    <{thread_uri}> disc:hasContribution <{contrib_uri}> .
+  }}
+}}"""
+
+    await sparql_update(update, design_space_id)
+    logger.info("ThreadContribution %s toegevoegd aan thread %s", contrib_uri, thread_uri)
+    return contrib_id
+
+
+async def get_contributions_by_thread(
+    thread_id: str,
+    design_space_id: str,
+) -> list[dict[str, Any]]:
+    """Geeft alle disc:ThreadContributions voor een thread, gesorteerd op tijd."""
+    thread_uri = f"urn:valor:thread:{thread_id}"
+
+    query = f"""PREFIX disc: <{DISC_NS}>
+PREFIX prov: <{PROV_NS}>
+PREFIX valor: <{VALOR_NS_BASE}>
+
+SELECT ?contrib_uri ?contribution_type ?message_content ?associated_with ?ended_at ?evidence WHERE {{
+  <{thread_uri}> disc:hasContribution ?contrib_uri .
+  ?contrib_uri disc:contributionType ?contribution_type ;
+               valor:messageContent ?message_content ;
+               prov:wasAssociatedWith ?associated_with ;
+               prov:endedAtTime ?ended_at .
+  OPTIONAL {{ ?contrib_uri disc:attachesEvidence ?evidence . }}
+}}
+ORDER BY ASC(?ended_at)"""
+
+    rows = await sparql_select(query, design_space_id)
+    return [
+        {
+            "contribution_id": row["contrib_uri"].split(":")[-1],
+            "contribution_uri": row["contrib_uri"],
+            "thread_id": thread_id,
+            "design_space_id": design_space_id,
+            "contribution_type": row["contribution_type"],
+            "message_content": row["message_content"],
+            "contributed_by": row["associated_with"],
+            "contributed_at": row["ended_at"],
+            "evidence_id": row["evidence"].split(":")[-1] if row.get("evidence") else None,
+        }
+        for row in rows
+    ]
+
+
 async def get_threads_by_tessera(
     tessera_id: str,
     design_space_id: str,

--- a/backend/app/db/permissions.py
+++ b/backend/app/db/permissions.py
@@ -60,7 +60,7 @@ async def check_permission(user_id: str, entity_id: str, required_role: Role) ->
     // Find highest role on any ancestor (including self)
     // We look for any node 'parent' that recursively owns/contains 'target', 
     // AND where 'u' has a role on 'parent'.
-    OPTIONAL MATCH (u)-[r:HAS_ROLE]->(parent)-[:OWNS|HAS_THEME|HAS_VERSION*0..]->(target)
+    OPTIONAL MATCH (u)-[r:HAS_ROLE]->(parent)-[:OWNS|HAS_THEME|HAS_VERSION|HAS_DESIGN_SPACE*0..]->(target)
     WHERE r.status IS NULL OR r.status = 'active'
     
     RETURN is_platform_admin, collect(r.role) as roles

--- a/backend/app/routers/designspace.py
+++ b/backend/app/routers/designspace.py
@@ -9,6 +9,7 @@ from app.auth import get_current_user
 from app.db.designspace import (
     create_design_space as db_create_design_space,
     get_design_space_meta,
+    get_design_spaces_by_project,
     set_design_space_phase,
     PHASE_SEQUENCE,
 )
@@ -65,6 +66,21 @@ async def create_design_space(
         named_graphs=named_graphs,
         created_at=datetime.now(timezone.utc).isoformat(),
     )
+
+
+@router.get("/by-project/{project_id}")
+async def list_design_spaces_by_project(
+    project_id: str,
+    user: dict = Depends(get_current_user),
+    theme_id: str | None = Query(default=None),
+) -> list[dict]:
+    """Geeft alle DesignSpaces terug die aan een Project gekoppeld zijn."""
+    user_id = user["id"]
+    # Check permission op theme als meegegeven (user heeft theme-rol), anders op project
+    check_entity = theme_id if theme_id else project_id
+    if not await check_permission(user_id, check_entity, Role.VIEWER):
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten voor dit project.")
+    return get_design_spaces_by_project(project_id)
 
 
 @router.post("/{design_space_id}/alternative/", response_model=DesignAlternativeResponse, status_code=201)

--- a/backend/app/routers/threads.py
+++ b/backend/app/routers/threads.py
@@ -1,18 +1,24 @@
-"""Discussiethreads router — Fuseki-backed (Epic 16, US-16.2).
+"""Discussiethreads router — Fuseki-backed (Epic 16, US-16.2 / US-16.3).
 
-Vervangt de Neo4j-implementatie. Threads worden opgeslagen als
-disc:DiscussionThread in de named graph van de DesignSpace.
+Vervangt de Neo4j-implementatie. Threads en bijdragen worden opgeslagen als
+disc:DiscussionThread / disc:ThreadContribution in de named graph van de DesignSpace.
 """
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from app.auth import get_current_user
-from app.db.disc import create_discussion_thread, get_threads_by_tessera
+from app.db.disc import (
+    create_discussion_thread,
+    get_threads_by_tessera,
+    create_thread_contribution,
+    get_contributions_by_thread,
+)
 from app.db.permissions import check_permission
 from app.models.domain import Role
+from app.services.ontology_cache import get_disc_contribution_type_label_to_uri
 
 logger = logging.getLogger(__name__)
 
@@ -66,3 +72,67 @@ async def list_threads(
         raise HTTPException(status_code=403, detail="Onvoldoende rechten om threads op te halen.")
 
     return await get_threads_by_tessera(tessera_id=tessera_id, design_space_id=design_space_id)
+
+
+class CreateContributionRequest(BaseModel):
+    design_space_id: str
+    contribution_type: str  # Dutch label: "Vraag" | "Stelling" | "Bewijs" | "Bezwaar" | "Toelichting" | "Akkoord"
+    message_content: str
+    evidence_id: Optional[str] = None
+
+
+class ContributionResponse(BaseModel):
+    contribution_id: str
+    contribution_uri: str
+    thread_id: str
+    design_space_id: str
+    contribution_type: str
+    message_content: str
+    contributed_by: str
+    contributed_at: str
+    evidence_id: Optional[str] = None
+
+
+@router.post("/threads/{thread_id}/contribute", response_model=dict[str, str], status_code=201)
+async def add_contribution(
+    thread_id: str,
+    request: CreateContributionRequest,
+    user: dict = Depends(get_current_user),
+) -> dict[str, Any]:
+    user_id = user["id"]
+    has_permission = await check_permission(user_id, request.design_space_id, Role.MEMBER)
+    if not has_permission:
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten om een bijdrage toe te voegen.")
+
+    contribution_type_map = get_disc_contribution_type_label_to_uri()
+    contribution_type_uri = contribution_type_map.get(request.contribution_type)
+    if not contribution_type_uri:
+        valid = sorted(contribution_type_map.keys())
+        raise HTTPException(
+            status_code=422,
+            detail=f"Ongeldig bijdragetype '{request.contribution_type}'. Geldige waarden: {valid}.",
+        )
+
+    contrib_id = await create_thread_contribution(
+        thread_id=thread_id,
+        design_space_id=request.design_space_id,
+        user_id=user_id,
+        contribution_type_uri=contribution_type_uri,
+        message_content=request.message_content,
+        evidence_id=request.evidence_id,
+    )
+    return {"contribution_id": contrib_id}
+
+
+@router.get("/threads/{thread_id}/contributions", response_model=list[ContributionResponse])
+async def list_contributions(
+    thread_id: str,
+    design_space_id: str = Query(..., description="ID van de DesignSpace"),
+    user: dict = Depends(get_current_user),
+) -> list[dict[str, Any]]:
+    user_id = user["id"]
+    has_permission = await check_permission(user_id, design_space_id, Role.MEMBER)
+    if not has_permission:
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten om bijdragen op te halen.")
+
+    return await get_contributions_by_thread(thread_id=thread_id, design_space_id=design_space_id)

--- a/backend/app/routers/threads.py
+++ b/backend/app/routers/threads.py
@@ -42,6 +42,7 @@ router = APIRouter(
 class CreateThreadRequest(BaseModel):
     tessera_id: str
     design_space_id: str
+    title: Optional[str] = None
 
 
 class ThreadResponse(BaseModel):
@@ -50,7 +51,9 @@ class ThreadResponse(BaseModel):
     tessera_id: str
     design_space_id: str
     started_by: str
+    started_by_name: str
     started_at: str
+    title: Optional[str] = None
 
 
 @router.post("/threads", response_model=dict[str, str], status_code=201)
@@ -67,6 +70,7 @@ async def create_thread(
         tessera_id=request.tessera_id,
         design_space_id=request.design_space_id,
         user_id=user_id,
+        title=request.title,
     )
     return {"thread_id": thread_id}
 
@@ -100,6 +104,7 @@ class ContributionResponse(BaseModel):
     contribution_type: str
     message_content: str
     contributed_by: str
+    contributed_by_name: str
     contributed_at: str
     evidence_id: Optional[str] = None
 

--- a/backend/app/routers/threads.py
+++ b/backend/app/routers/threads.py
@@ -1,58 +1,68 @@
-from fastapi import APIRouter, HTTPException, Depends
-from typing import List, Dict, Optional
+"""Discussiethreads router — Fuseki-backed (Epic 16, US-16.2).
+
+Vervangt de Neo4j-implementatie. Threads worden opgeslagen als
+disc:DiscussionThread in de named graph van de DesignSpace.
+"""
 import logging
-from app.models.domain import ThreadCreate, ThreadMessageCreate
-from app.db.crud import (
-    create_conversation_thread, 
-    get_threads_by_target, 
-    get_thread_counts, 
-    create_thread_message, 
-    get_thread_messages
-)
-from app.auth import get_current_user, verify_token
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from app.auth import get_current_user
+from app.db.disc import create_discussion_thread, get_threads_by_tessera
+from app.db.permissions import check_permission
+from app.models.domain import Role
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(
     tags=["threads"],
     responses={404: {"description": "Not found"}},
 )
 
-logger = logging.getLogger(__name__)
 
-@router.post("/threads")
-async def create_thread_generic(thread: ThreadCreate, user: dict = Depends(get_current_user)):
-    # Check permissions (Member access okay for creating threads? Or Admin? Intent says "Participant", so Member is likely fine.)
-    # Let's enforce Membership at least.
-    email = user.get("email")
-    # For now, relying on space existing. Ideally check `is_member`.
-    # Assuming if you can see the space, you can create a thread.
-    # Refine later if strict permissions needed.
-    
-    target_id = thread.target_id
-    if not target_id:
-         raise HTTPException(status_code=400, detail="target_id is required for generic threads")
+class CreateThreadRequest(BaseModel):
+    tessera_id: str
+    design_space_id: str
 
-    tid = await create_conversation_thread(target_id, thread.topic)
-    return {"id": tid, "topic": thread.topic}
 
-@router.get("/threads")
-async def list_threads_generic(target_id: str, user: dict = Depends(get_current_user)):
-    # target_id passed as query param
-    return await get_threads_by_target(target_id)
+class ThreadResponse(BaseModel):
+    thread_id: str
+    thread_uri: str
+    tessera_id: str
+    design_space_id: str
+    started_by: str
+    started_at: str
 
-@router.post("/threads/stats")
-async def get_thread_stats(target_ids: List[str], user: dict = Depends(get_current_user)):
-    return await get_thread_counts(target_ids)
 
-@router.post("/threads/{thread_id}/messages")
-async def add_thread_message(thread_id: str, message: ThreadMessageCreate, user: dict = Depends(get_current_user)):
-    user_id = user.get("id")
-    if not user_id:
-        logger.error(f"User from dependency missing ID field: {user}")
-        raise HTTPException(status_code=500, detail="User identity error")
-        
-    logger.info(f"Adding message to thread {thread_id} for user {user_id}")
-    return await create_thread_message(thread_id, user_id, message.content)
+@router.post("/threads", response_model=dict[str, str], status_code=201)
+async def create_thread(
+    request: CreateThreadRequest,
+    user: dict = Depends(get_current_user),
+) -> dict[str, Any]:
+    user_id = user["id"]
+    has_permission = await check_permission(user_id, request.design_space_id, Role.MEMBER)
+    if not has_permission:
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten om een discussiethread aan te maken.")
 
-@router.get("/threads/{thread_id}/messages")
-async def list_thread_messages(thread_id: str, user: dict = Depends(get_current_user)):
-    return await get_thread_messages(thread_id)
+    thread_id = await create_discussion_thread(
+        tessera_id=request.tessera_id,
+        design_space_id=request.design_space_id,
+        user_id=user_id,
+    )
+    return {"thread_id": thread_id}
+
+
+@router.get("/threads", response_model=list[ThreadResponse])
+async def list_threads(
+    tessera_id: str = Query(..., description="ID van de Tessera"),
+    design_space_id: str = Query(..., description="ID van de DesignSpace"),
+    user: dict = Depends(get_current_user),
+) -> list[dict[str, Any]]:
+    user_id = user["id"]
+    has_permission = await check_permission(user_id, design_space_id, Role.MEMBER)
+    if not has_permission:
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten om threads op te halen.")
+
+    return await get_threads_by_tessera(tessera_id=tessera_id, design_space_id=design_space_id)

--- a/backend/app/routers/threads.py
+++ b/backend/app/routers/threads.py
@@ -1,7 +1,8 @@
-"""Discussiethreads router — Fuseki-backed (Epic 16, US-16.2 / US-16.3).
+"""Discussiethreads router — Fuseki-backed (Epic 16, US-16.2 / US-16.3 / US-16.4).
 
-Vervangt de Neo4j-implementatie. Threads en bijdragen worden opgeslagen als
-disc:DiscussionThread / disc:ThreadContribution in de named graph van de DesignSpace.
+Vervangt de Neo4j-implementatie. Threads, bijdragen en resoluties worden opgeslagen als
+disc:DiscussionThread / disc:ThreadContribution / disc:ThreadResolution in de named graph
+van de DesignSpace.
 """
 import logging
 from typing import Any, Optional
@@ -10,15 +11,25 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from app.auth import get_current_user
+from app.db.designspace import get_design_space_meta
 from app.db.disc import (
     create_discussion_thread,
     get_threads_by_tessera,
     create_thread_contribution,
     get_contributions_by_thread,
+    get_thread_tessera,
+    create_thread_resolution,
 )
 from app.db.permissions import check_permission
 from app.models.domain import Role
-from app.services.ontology_cache import get_disc_contribution_type_label_to_uri
+from app.services.connection_manager import manager
+from app.services.fuseki import sparql_select, sparql_update, named_graph_uri, record_provenance_activity
+from app.services.ontology_cache import (
+    get_disc_contribution_type_label_to_uri,
+    get_status_label_to_uri,
+    get_status_uri_to_label,
+)
+from app.ontology import VALOR_NS
 
 logger = logging.getLogger(__name__)
 
@@ -136,3 +147,130 @@ async def list_contributions(
         raise HTTPException(status_code=403, detail="Onvoldoende rechten om bijdragen op te halen.")
 
     return await get_contributions_by_thread(thread_id=thread_id, design_space_id=design_space_id)
+
+
+class ResolveThreadRequest(BaseModel):
+    design_space_id: str
+    resolution_outcome: str   # English label: bijv. "Contested", "Accepted", "Rejected"
+    resolution_rationale: str
+
+
+class ResolveThreadResponse(BaseModel):
+    resolution_id: str
+    thread_id: str
+    tessera_id: str
+    previous_status: str
+    new_status: str
+
+
+@router.post("/threads/{thread_id}/resolve", response_model=ResolveThreadResponse)
+async def resolve_thread(
+    thread_id: str,
+    request: ResolveThreadRequest,
+    user: dict = Depends(get_current_user),
+) -> dict[str, Any]:
+    user_id = user["id"]
+    has_permission = await check_permission(user_id, request.design_space_id, Role.MODERATOR)
+    if not has_permission:
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten om een thread te resolveren. Moderator-rol vereist.")
+
+    # Haal tessera_uri op uit de thread
+    tessera_uri = await get_thread_tessera(thread_id, request.design_space_id)
+    if not tessera_uri:
+        raise HTTPException(status_code=404, detail="Thread niet gevonden in deze DesignSpace.")
+    tessera_id = tessera_uri.split(":")[-1]
+
+    # Valideer resolution_outcome als geldige epistemische status
+    status_label_to_uri = get_status_label_to_uri()
+    new_status_uri = status_label_to_uri.get(request.resolution_outcome)
+    if not new_status_uri:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Ongeldig resolution_outcome '{request.resolution_outcome}'. Geldige waarden: {sorted(status_label_to_uri)}.",
+        )
+
+    # Lees huidige status van de Tessera
+    graph_uri = named_graph_uri(request.design_space_id)
+    status_rows = await sparql_select(
+        f"""SELECT ?status WHERE {{
+          <{tessera_uri}> <{VALOR_NS}epistemicStatus> ?status .
+        }}""",
+        request.design_space_id,
+    )
+    if not status_rows:
+        raise HTTPException(status_code=404, detail="Tessera niet gevonden in deze DesignSpace.")
+
+    current_uri = status_rows[0]["status"]
+    current_label = get_status_uri_to_label().get(current_uri, current_uri)
+
+    # Schrijf disc:ThreadResolution naar Fuseki
+    resolution_id = await create_thread_resolution(
+        thread_id=thread_id,
+        design_space_id=request.design_space_id,
+        user_id=user_id,
+        resolution_outcome_uri=new_status_uri,
+        resolution_rationale=request.resolution_rationale,
+        tessera_uri=tessera_uri,
+    )
+
+    # Wijzig epistemische status van de Tessera
+    await sparql_update(
+        f"""DELETE {{
+  GRAPH <{graph_uri}> {{
+    <{tessera_uri}> <{VALOR_NS}epistemicStatus> <{current_uri}> .
+  }}
+}}
+INSERT {{
+  GRAPH <{graph_uri}> {{
+    <{tessera_uri}> <{VALOR_NS}epistemicStatus> <{new_status_uri}> .
+  }}
+}}
+WHERE {{
+  GRAPH <{graph_uri}> {{
+    <{tessera_uri}> <{VALOR_NS}epistemicStatus> <{current_uri}> .
+  }}
+}}""",
+        request.design_space_id,
+    )
+
+    # PROV-O record
+    await record_provenance_activity(
+        request.design_space_id,
+        "StatusChanged",
+        f"urn:valor:user:{user_id}",
+        used=[tessera_uri],
+        extra_props=[
+            (f"{VALOR_NS}previousStatus", current_uri),
+            (f"{VALOR_NS}newStatus", new_status_uri),
+        ],
+    )
+
+    # WebSocket broadcast
+    ds_meta = get_design_space_meta(request.design_space_id)
+    project_id = ds_meta.get("project_id") if ds_meta else None
+    if project_id:
+        await manager.broadcast_data(project_id, {
+            "type": "TESSERA_STATUS_CHANGED",
+            "payload": {
+                "tessera_id": tessera_id,
+                "tessera_uri": tessera_uri,
+                "previous_status": current_label,
+                "new_status": request.resolution_outcome,
+                "resolution_id": resolution_id,
+                "thread_id": thread_id,
+                "design_space_id": request.design_space_id,
+            },
+        })
+
+    logger.info(
+        "ThreadResolution %s: thread %s → tessera %s status %s → %s (door %s)",
+        resolution_id, thread_id, tessera_id, current_label, request.resolution_outcome, user_id,
+    )
+
+    return ResolveThreadResponse(
+        resolution_id=resolution_id,
+        thread_id=thread_id,
+        tessera_id=tessera_id,
+        previous_status=current_label,
+        new_status=request.resolution_outcome,
+    )

--- a/backend/app/services/ontology_cache.py
+++ b/backend/app/services/ontology_cache.py
@@ -7,6 +7,7 @@ Queryt de VALOR-O ontologie-graphs in Fuseki voor:
   - Geldige statusovergangen (valor:allowedTransitionTo)
   - Statussen die een DecisionEpisode vereisen (valor:requiresDecisionEpisode)
   - UncertaintyLevel instanties (PAMS-taxonomie, English label -> URI)
+  - disc:ContributionType instanties (Dutch label -> URI)
 """
 import logging
 
@@ -29,12 +30,17 @@ _uncertainty_label_to_uri: dict[str, str] = {}  # "StatisticalRisk" → URI
 _participant_role_data: dict[str, dict] = {}
 # RBAC role weights derived from ontology: "admin" → 30
 _rbac_role_weights: dict[str, int] = {}
+_disc_contribution_type_label_to_uri: dict[str, str] = {}  # "Vraag" → URI
+
+
+_DISC_GRAPH = f"{VALOR_NS}disc"
 
 
 async def load_ontology_cache() -> None:
     global _evidence_label_to_uri, _status_label_to_uri, _status_uri_to_label
     global _valid_transitions, _requires_decision_episode, _argue_label_to_uri
     global _uncertainty_label_to_uri, _participant_role_data, _rbac_role_weights
+    global _disc_contribution_type_label_to_uri
 
     logger.info("[ontology-cache] Ontologie-data laden van Fuseki...")
 
@@ -161,6 +167,20 @@ async def load_ontology_cache() -> None:
     logger.info("[ontology-cache] ParticipantRoles: %s", list(_participant_role_data.keys()))
     logger.info("[ontology-cache] RBAC gewichten: %s", _rbac_role_weights)
 
+    disc_type_rows = await sparql_select_global(f"""
+        PREFIX disc: <{VALOR_NS}disc#>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        SELECT ?uri ?label WHERE {{
+          GRAPH <{_DISC_GRAPH}> {{
+            ?uri a disc:ContributionType ;
+                 rdfs:label ?label .
+            FILTER(lang(?label) = "nl")
+          }}
+        }}
+    """)
+    _disc_contribution_type_label_to_uri = {row["label"]: row["uri"] for row in disc_type_rows}
+    logger.info("[ontology-cache] Bijdragetypes (disc): %s", list(_disc_contribution_type_label_to_uri.keys()))
+
     if not _evidence_label_to_uri or not _status_label_to_uri or not _valid_transitions:
         logger.warning(
             "[ontology-cache] Ontologie-cache onvolledig. "
@@ -213,6 +233,10 @@ def get_rbac_role_weights() -> dict[str, int]:
 def has_voting_right(valor_role_label: str) -> bool:
     """True als de VALOR-O rol stemrecht heeft (uit ontologie)."""
     return _participant_role_data.get(valor_role_label, {}).get("voting_right", False)
+
+
+def get_disc_contribution_type_label_to_uri() -> dict[str, str]:
+    return _disc_contribution_type_label_to_uri
 
 
 def rbac_to_valor_role(rbac_role: str) -> str:

--- a/backend/scripts/migrate_themeversions_to_designspaces.py
+++ b/backend/scripts/migrate_themeversions_to_designspaces.py
@@ -109,6 +109,7 @@ def _get_or_create_designspace_id(
     create_query = """
     MATCH (u:User {id: $uid})
     MATCH (p:Project {id: $pid})
+    MATCH (v:ThemeVersion {id: $vid})
     CREATE (ds:DesignSpace {
         id: $id,
         name: $name,
@@ -120,6 +121,7 @@ def _get_or_create_designspace_id(
         migrated_from_theme_version_id: $vid
     })
     CREATE (p)-[:HAS_DESIGN_SPACE]->(ds)
+    CREATE (v)-[:HAS_DESIGN_SPACE]->(ds)
     CREATE (u)-[:HAS_ROLE {role: 'admin', created_at: datetime()}]->(ds)
     RETURN ds.id AS id
     """
@@ -290,6 +292,21 @@ async def verify_checksum(ds_id: str, expected_factors: int, expected_claims: in
 
 
 # ---------------------------------------------------------------------------
+# Repair helpers
+# ---------------------------------------------------------------------------
+
+def _ensure_themeversion_designspace_rel(driver, theme_version_id: str, ds_id: str) -> None:
+    """Zorg dat ThemeVersion -[:HAS_DESIGN_SPACE]-> DesignSpace bestaat (idempotent)."""
+    query = """
+    MATCH (v:ThemeVersion {id: $vid})
+    MATCH (ds:DesignSpace {id: $dsid})
+    MERGE (v)-[:HAS_DESIGN_SPACE]->(ds)
+    """
+    with driver.session() as session:
+        session.run(query, {"vid": theme_version_id, "dsid": ds_id})
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -322,6 +339,8 @@ async def main(dry_run: bool):
         if existed:
             skipped += 1
             logger.info("[SKIP] ThemeVersion %s → DesignSpace %s (al gemigreerd)", vid, ds_id)
+            if not dry_run:
+                _ensure_themeversion_designspace_rel(driver, vid, ds_id)
             continue
 
         factors = _get_factors(driver, vid)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -88,6 +88,16 @@ def _seed_ontology_cache() -> None:
         v: k for k, v in ontology_cache._status_label_to_uri.items()
     }
 
+    DISC_NS = f"{VALOR_NS}disc#"
+    ontology_cache._disc_contribution_type_label_to_uri = {
+        "Vraag":       f"{DISC_NS}Vraag",
+        "Stelling":    f"{DISC_NS}Stelling",
+        "Bewijs":      f"{DISC_NS}Bewijs",
+        "Bezwaar":     f"{DISC_NS}Bezwaar",
+        "Toelichting": f"{DISC_NS}Toelichting",
+        "Akkoord":     f"{DISC_NS}Akkoord",
+    }
+
 
 # ---------------------------------------------------------------------------
 # Sessie-scoped fixtures

--- a/backend/tests/integration/test_disc_contributions.py
+++ b/backend/tests/integration/test_disc_contributions.py
@@ -1,0 +1,271 @@
+"""Integratietests voor disc:ThreadContribution aanmaken en ophalen (US-16.3).
+
+Verifieert:
+- create_thread_contribution schrijft correcte triples naar Fuseki
+- PROV-O: prov:wasAssociatedWith + prov:endedAtTime aanwezig
+- disc:hasContribution koppelt bijdrage aan thread
+- disc:attachesEvidence correct opgeslagen indien evidence meegegeven
+- get_contributions_by_thread retourneert bijdragen gesorteerd op tijd
+"""
+import pytest
+
+from app.db.disc import create_discussion_thread, create_thread_contribution, get_contributions_by_thread
+from app.services.fuseki import named_graph_uri
+
+pytestmark = pytest.mark.integration
+
+DISC_NS = "https://valor-ecosystem.nl/ontology/disc#"
+PROV_NS = "https://www.w3.org/ns/prov#"
+VALOR_BASE = "https://valor-ecosystem.nl/ontology/"
+
+TESSERA_ID = "tessera-contrib-test-001"
+USER_ID = "user-contrib-test-001"
+CONTRIB_TYPE_URI = f"{DISC_NS}Vraag"
+EVIDENCE_ID = "evidence-contrib-test-001"
+
+
+async def _sparql_select(graph_uri: str, query: str) -> list[dict]:
+    import httpx
+    from tests.conftest import FUSEKI_TEST_URL, FUSEKI_TEST_DATASET
+
+    endpoint = f"{FUSEKI_TEST_URL}/{FUSEKI_TEST_DATASET}/sparql"
+    async with httpx.AsyncClient() as client:
+        r = await client.post(
+            endpoint,
+            data={"query": query},
+            headers={"Accept": "application/sparql-results+json"},
+            timeout=10,
+        )
+    r.raise_for_status()
+    return r.json()["results"]["bindings"]
+
+
+@pytest.fixture
+async def thread_id(ds_id) -> str:
+    """Maak een thread aan als fixture voor bijdrage-tests."""
+    return await create_discussion_thread(TESSERA_ID, ds_id, USER_ID)
+
+
+# ---------------------------------------------------------------------------
+# create_thread_contribution
+# ---------------------------------------------------------------------------
+
+async def test_create_contribution_retourneert_contribution_id(ds_id, thread_id):
+    contrib_id = await create_thread_contribution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        contribution_type_uri=CONTRIB_TYPE_URI,
+        message_content="Dit is een testvraag.",
+    )
+    assert contrib_id, "contribution_id mag niet leeg zijn"
+    assert len(contrib_id) == 36, "contribution_id moet een UUID zijn"
+
+
+async def test_create_contribution_schrijft_type_triple(ds_id, thread_id):
+    contrib_id = await create_thread_contribution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        contribution_type_uri=CONTRIB_TYPE_URI,
+        message_content="Testvraag.",
+    )
+    contrib_uri = f"urn:valor:contrib:{contrib_id}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX disc: <{DISC_NS}>
+        SELECT ?contrib WHERE {{
+          GRAPH <{graph}> {{
+            <{contrib_uri}> a disc:ThreadContribution .
+            BIND(<{contrib_uri}> AS ?contrib)
+          }}
+        }}
+    """)
+    assert rows, "disc:ThreadContribution-triple ontbreekt in Fuseki"
+
+
+async def test_create_contribution_schrijft_contribution_type(ds_id, thread_id):
+    contrib_id = await create_thread_contribution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        contribution_type_uri=CONTRIB_TYPE_URI,
+        message_content="Testvraag.",
+    )
+    contrib_uri = f"urn:valor:contrib:{contrib_id}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX disc: <{DISC_NS}>
+        SELECT ?type WHERE {{
+          GRAPH <{graph}> {{
+            <{contrib_uri}> disc:contributionType ?type .
+          }}
+        }}
+    """)
+    assert rows, "disc:contributionType ontbreekt"
+    assert rows[0]["type"]["value"] == CONTRIB_TYPE_URI
+
+
+async def test_create_contribution_schrijft_prov_triples(ds_id, thread_id):
+    contrib_id = await create_thread_contribution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        contribution_type_uri=CONTRIB_TYPE_URI,
+        message_content="Testvraag.",
+    )
+    contrib_uri = f"urn:valor:contrib:{contrib_id}"
+    user_uri = f"urn:valor:user:{USER_ID}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX prov: <{PROV_NS}>
+        SELECT ?associated_with ?ended_at WHERE {{
+          GRAPH <{graph}> {{
+            <{contrib_uri}> prov:wasAssociatedWith ?associated_with ;
+                             prov:endedAtTime ?ended_at .
+          }}
+        }}
+    """)
+    assert rows, "prov:wasAssociatedWith / prov:endedAtTime ontbreken"
+    assert rows[0]["associated_with"]["value"] == user_uri
+    assert rows[0]["ended_at"]["value"], "endedAtTime mag niet leeg zijn"
+
+
+async def test_create_contribution_koppelt_aan_thread(ds_id, thread_id):
+    contrib_id = await create_thread_contribution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        contribution_type_uri=CONTRIB_TYPE_URI,
+        message_content="Testvraag.",
+    )
+    contrib_uri = f"urn:valor:contrib:{contrib_id}"
+    thread_uri = f"urn:valor:thread:{thread_id}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX disc: <{DISC_NS}>
+        SELECT ?contrib WHERE {{
+          GRAPH <{graph}> {{
+            <{thread_uri}> disc:hasContribution <{contrib_uri}> .
+            BIND(<{contrib_uri}> AS ?contrib)
+          }}
+        }}
+    """)
+    assert rows, "disc:hasContribution-koppeling ontbreekt"
+
+
+async def test_create_contribution_met_evidence(ds_id, thread_id):
+    contrib_id = await create_thread_contribution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        contribution_type_uri=f"{DISC_NS}Bewijs",
+        message_content="Bewijs voor de stelling.",
+        evidence_id=EVIDENCE_ID,
+    )
+    contrib_uri = f"urn:valor:contrib:{contrib_id}"
+    evidence_uri = f"urn:valor:evidence:{EVIDENCE_ID}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX disc: <{DISC_NS}>
+        SELECT ?evidence WHERE {{
+          GRAPH <{graph}> {{
+            <{contrib_uri}> disc:attachesEvidence ?evidence .
+          }}
+        }}
+    """)
+    assert rows, "disc:attachesEvidence-triple ontbreekt"
+    assert rows[0]["evidence"]["value"] == evidence_uri
+
+
+async def test_create_contribution_zonder_evidence_geen_attaches_triple(ds_id, thread_id):
+    contrib_id = await create_thread_contribution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        contribution_type_uri=CONTRIB_TYPE_URI,
+        message_content="Testvraag zonder bewijs.",
+    )
+    contrib_uri = f"urn:valor:contrib:{contrib_id}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX disc: <{DISC_NS}>
+        SELECT ?evidence WHERE {{
+          GRAPH <{graph}> {{
+            <{contrib_uri}> disc:attachesEvidence ?evidence .
+          }}
+        }}
+    """)
+    assert rows == [], "disc:attachesEvidence mag niet aanwezig zijn zonder evidence_id"
+
+
+# ---------------------------------------------------------------------------
+# get_contributions_by_thread
+# ---------------------------------------------------------------------------
+
+async def test_get_contributions_retourneert_lege_lijst(ds_id, thread_id):
+    result = await get_contributions_by_thread(thread_id, ds_id)
+    assert result == []
+
+
+async def test_get_contributions_retourneert_bijdrage(ds_id, thread_id):
+    contrib_id = await create_thread_contribution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        contribution_type_uri=CONTRIB_TYPE_URI,
+        message_content="Testvraag.",
+    )
+    result = await get_contributions_by_thread(thread_id, ds_id)
+
+    assert len(result) == 1
+    assert result[0]["contribution_id"] == contrib_id
+    assert result[0]["thread_id"] == thread_id
+    assert result[0]["contributed_by"] == f"urn:valor:user:{USER_ID}"
+    assert result[0]["evidence_id"] is None
+
+
+async def test_get_contributions_retourneert_meerdere_bijdragen_gesorteerd(ds_id, thread_id):
+    cid1 = await create_thread_contribution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        contribution_type_uri=CONTRIB_TYPE_URI,
+        message_content="Eerste bijdrage.",
+    )
+    cid2 = await create_thread_contribution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        contribution_type_uri=f"{DISC_NS}Stelling",
+        message_content="Tweede bijdrage.",
+    )
+    result = await get_contributions_by_thread(thread_id, ds_id)
+
+    assert len(result) == 2
+    contrib_ids = [r["contribution_id"] for r in result]
+    assert cid1 in contrib_ids
+    assert cid2 in contrib_ids
+    # Gesorteerd op tijd: eerste bijdrage eerst
+    assert contrib_ids.index(cid1) < contrib_ids.index(cid2)
+
+
+async def test_get_contributions_met_evidence_id(ds_id, thread_id):
+    contrib_id = await create_thread_contribution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        contribution_type_uri=f"{DISC_NS}Bewijs",
+        message_content="Met bewijs.",
+        evidence_id=EVIDENCE_ID,
+    )
+    result = await get_contributions_by_thread(thread_id, ds_id)
+
+    assert len(result) == 1
+    assert result[0]["evidence_id"] == EVIDENCE_ID

--- a/backend/tests/integration/test_disc_ontology.py
+++ b/backend/tests/integration/test_disc_ontology.py
@@ -1,0 +1,129 @@
+"""Integratietests voor de disc:ContributionType ontologie (US-16.1).
+
+Verifieert:
+- Na het laden van disc-triples in Fuseki retourneert een SPARQL-query
+  de zes disc:ContributionType instanties.
+- load_ontology_cache() vult _disc_contribution_type_label_to_uri correct.
+"""
+import pytest
+
+pytestmark = pytest.mark.integration
+
+DISC_NS = "https://valor-ecosystem.nl/ontology/disc#"
+DISC_GRAPH = "https://valor-ecosystem.nl/ontology/disc"
+
+EXPECTED_CONTRIBUTION_TYPES = {
+    "Vraag",
+    "Stelling",
+    "Bewijs",
+    "Bezwaar",
+    "Toelichting",
+    "Akkoord",
+}
+
+_DISC_SEED_UPDATE = f"""
+PREFIX disc:  <{DISC_NS}>
+PREFIX rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl:   <http://www.w3.org/2002/07/owl#>
+PREFIX prov:  <https://www.w3.org/ns/prov#>
+
+INSERT DATA {{
+  GRAPH <{DISC_GRAPH}> {{
+    disc:ContributionType a owl:Class .
+
+    disc:Vraag       a disc:ContributionType ; rdfs:label "Vraag"@nl .
+    disc:Stelling    a disc:ContributionType ; rdfs:label "Stelling"@nl .
+    disc:Bewijs      a disc:ContributionType ; rdfs:label "Bewijs"@nl .
+    disc:Bezwaar     a disc:ContributionType ; rdfs:label "Bezwaar"@nl .
+    disc:Toelichting a disc:ContributionType ; rdfs:label "Toelichting"@nl .
+    disc:Akkoord     a disc:ContributionType ; rdfs:label "Akkoord"@nl .
+
+    disc:DiscussionThread  a owl:Class ; rdfs:subClassOf prov:Activity .
+    disc:ThreadContribution a owl:Class ; rdfs:subClassOf prov:Activity .
+    disc:ThreadResolution  a owl:Class ; rdfs:subClassOf prov:Entity .
+  }}
+}}
+"""
+
+
+@pytest.fixture
+async def disc_graph_seeded():
+    """Seed de disc-module triples in de test-Fuseki instantie."""
+    from app.services.fuseki import sparql_select_global
+    import app.services.fuseki as fs
+    import httpx
+
+    url = f"{fs.FUSEKI_URL}/{fs.FUSEKI_DATASET}/update"
+    async with httpx.AsyncClient() as client:
+        r = await client.post(
+            url,
+            data={"update": _DISC_SEED_UPDATE},
+            auth=("admin", fs.FUSEKI_ADMIN_PASSWORD),
+            timeout=15,
+        )
+        r.raise_for_status()
+
+
+# ---------------------------------------------------------------------------
+# SPARQL-query test
+# ---------------------------------------------------------------------------
+
+async def test_sparql_retourneert_zes_contribution_types(disc_graph_seeded):
+    from app.services.fuseki import sparql_select_global
+
+    rows = await sparql_select_global(f"""
+        PREFIX disc: <{DISC_NS}>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        SELECT ?uri ?label WHERE {{
+          GRAPH <{DISC_GRAPH}> {{
+            ?uri a disc:ContributionType ;
+                 rdfs:label ?label .
+            FILTER(lang(?label) = "nl")
+          }}
+        }}
+    """)
+
+    labels = {row["label"] for row in rows}
+    assert labels == EXPECTED_CONTRIBUTION_TYPES, (
+        f"Verwachte types: {EXPECTED_CONTRIBUTION_TYPES}, gevonden: {labels}"
+    )
+
+
+async def test_sparql_retourneert_drie_disc_klassen(disc_graph_seeded):
+    from app.services.fuseki import sparql_select_global
+
+    rows = await sparql_select_global(f"""
+        PREFIX disc: <{DISC_NS}>
+        PREFIX owl:  <http://www.w3.org/2002/07/owl#>
+        SELECT ?uri WHERE {{
+          GRAPH <{DISC_GRAPH}> {{
+            ?uri a owl:Class .
+          }}
+        }}
+    """)
+
+    uris = {row["uri"] for row in rows}
+    assert f"{DISC_NS}DiscussionThread" in uris
+    assert f"{DISC_NS}ThreadContribution" in uris
+    assert f"{DISC_NS}ThreadResolution" in uris
+    assert f"{DISC_NS}ContributionType" in uris
+
+
+# ---------------------------------------------------------------------------
+# Ontologie-cache test
+# ---------------------------------------------------------------------------
+
+async def test_load_ontology_cache_vult_disc_contribution_types(disc_graph_seeded):
+    from app.services.ontology_cache import (
+        load_ontology_cache,
+        get_disc_contribution_type_label_to_uri,
+    )
+
+    await load_ontology_cache()
+
+    disc_types = get_disc_contribution_type_label_to_uri()
+    assert set(disc_types.keys()) == EXPECTED_CONTRIBUTION_TYPES
+
+    for label, uri in disc_types.items():
+        assert uri.startswith(DISC_NS), f"URI {uri} heeft niet de verwachte disc namespace"
+        assert uri == f"{DISC_NS}{label}", f"URI voor '{label}' klopt niet: {uri}"

--- a/backend/tests/integration/test_disc_resolution.py
+++ b/backend/tests/integration/test_disc_resolution.py
@@ -1,0 +1,227 @@
+"""Integratietests voor disc:ThreadResolution (US-16.4).
+
+Verifieert:
+- create_thread_resolution schrijft correcte triples naar Fuseki
+- disc:hasResolution koppelt resolution aan thread
+- disc:motivatesArgue koppelt resolution aan tessera
+- disc:resolutionOutcome bevat de juiste status-URI
+- get_thread_tessera retourneert de juiste tessera_uri
+"""
+import pytest
+
+from app.db.disc import (
+    create_discussion_thread,
+    create_thread_resolution,
+    get_thread_tessera,
+)
+from app.services.fuseki import named_graph_uri, sparql_update
+
+pytestmark = pytest.mark.integration
+
+DISC_NS = "https://valor-ecosystem.nl/ontology/disc#"
+PROV_NS = "https://www.w3.org/ns/prov#"
+VALOR_NS = "https://valor-ecosystem.nl/ontology/"
+
+TESSERA_ID = "tessera-resolution-test-001"
+USER_ID = "user-resolution-test-001"
+OUTCOME_URI = f"{VALOR_NS}ContestedStatus"
+
+
+async def _sparql_select(graph_uri: str, query: str) -> list[dict]:
+    import httpx
+    from tests.conftest import FUSEKI_TEST_URL, FUSEKI_TEST_DATASET
+
+    endpoint = f"{FUSEKI_TEST_URL}/{FUSEKI_TEST_DATASET}/sparql"
+    async with httpx.AsyncClient() as client:
+        r = await client.post(
+            endpoint,
+            data={"query": query},
+            headers={"Accept": "application/sparql-results+json"},
+            timeout=10,
+        )
+    r.raise_for_status()
+    return r.json()["results"]["bindings"]
+
+
+@pytest.fixture
+async def tessera_seeded(ds_id) -> str:
+    """Seed een Tessera in Fuseki voor gebruik in resolution-tests."""
+    tessera_uri = f"urn:valor:tessera:{TESSERA_ID}"
+    graph = named_graph_uri(ds_id)
+    proposed_uri = f"{VALOR_NS}ProposedStatus"
+
+    await sparql_update(f"""PREFIX valor: <{VALOR_NS}>
+INSERT DATA {{
+  GRAPH <{graph}> {{
+    <{tessera_uri}> a valor:Tessera ;
+      valor:epistemicStatus <{proposed_uri}> ;
+      valor:claimContent "Testclaim"@nl .
+  }}
+}}""", ds_id)
+    return TESSERA_ID
+
+
+@pytest.fixture
+async def thread_id(ds_id, tessera_seeded) -> str:
+    return await create_discussion_thread(tessera_seeded, ds_id, USER_ID)
+
+
+# ---------------------------------------------------------------------------
+# get_thread_tessera
+# ---------------------------------------------------------------------------
+
+async def test_get_thread_tessera_retourneert_tessera_uri(ds_id, thread_id):
+    result = await get_thread_tessera(thread_id, ds_id)
+    assert result == f"urn:valor:tessera:{TESSERA_ID}"
+
+
+async def test_get_thread_tessera_retourneert_none_voor_onbekende_thread(ds_id):
+    result = await get_thread_tessera("onbekende-thread-id", ds_id)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# create_thread_resolution
+# ---------------------------------------------------------------------------
+
+async def test_create_resolution_retourneert_resolution_id(ds_id, thread_id):
+    tessera_uri = f"urn:valor:tessera:{TESSERA_ID}"
+    resolution_id = await create_thread_resolution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        resolution_outcome_uri=OUTCOME_URI,
+        resolution_rationale="Klopt niet op basis van de discussie.",
+        tessera_uri=tessera_uri,
+    )
+    assert resolution_id, "resolution_id mag niet leeg zijn"
+    assert len(resolution_id) == 36, "resolution_id moet een UUID zijn"
+
+
+async def test_create_resolution_schrijft_type_triple(ds_id, thread_id):
+    tessera_uri = f"urn:valor:tessera:{TESSERA_ID}"
+    resolution_id = await create_thread_resolution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        resolution_outcome_uri=OUTCOME_URI,
+        resolution_rationale="Testrationale.",
+        tessera_uri=tessera_uri,
+    )
+    resolution_uri = f"urn:valor:resolution:{resolution_id}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX disc: <{DISC_NS}>
+        SELECT ?r WHERE {{
+          GRAPH <{graph}> {{
+            <{resolution_uri}> a disc:ThreadResolution .
+            BIND(<{resolution_uri}> AS ?r)
+          }}
+        }}
+    """)
+    assert rows, "disc:ThreadResolution-triple ontbreekt"
+
+
+async def test_create_resolution_schrijft_outcome(ds_id, thread_id):
+    tessera_uri = f"urn:valor:tessera:{TESSERA_ID}"
+    resolution_id = await create_thread_resolution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        resolution_outcome_uri=OUTCOME_URI,
+        resolution_rationale="Testrationale.",
+        tessera_uri=tessera_uri,
+    )
+    resolution_uri = f"urn:valor:resolution:{resolution_id}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX disc: <{DISC_NS}>
+        SELECT ?outcome WHERE {{
+          GRAPH <{graph}> {{
+            <{resolution_uri}> disc:resolutionOutcome ?outcome .
+          }}
+        }}
+    """)
+    assert rows, "disc:resolutionOutcome ontbreekt"
+    assert rows[0]["outcome"]["value"] == OUTCOME_URI
+
+
+async def test_create_resolution_koppelt_aan_thread(ds_id, thread_id):
+    tessera_uri = f"urn:valor:tessera:{TESSERA_ID}"
+    resolution_id = await create_thread_resolution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        resolution_outcome_uri=OUTCOME_URI,
+        resolution_rationale="Testrationale.",
+        tessera_uri=tessera_uri,
+    )
+    resolution_uri = f"urn:valor:resolution:{resolution_id}"
+    thread_uri = f"urn:valor:thread:{thread_id}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX disc: <{DISC_NS}>
+        SELECT ?r WHERE {{
+          GRAPH <{graph}> {{
+            <{thread_uri}> disc:hasResolution <{resolution_uri}> .
+            BIND(<{resolution_uri}> AS ?r)
+          }}
+        }}
+    """)
+    assert rows, "disc:hasResolution-koppeling ontbreekt"
+
+
+async def test_create_resolution_schrijft_motivates_argue(ds_id, thread_id):
+    tessera_uri = f"urn:valor:tessera:{TESSERA_ID}"
+    resolution_id = await create_thread_resolution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        resolution_outcome_uri=OUTCOME_URI,
+        resolution_rationale="Testrationale.",
+        tessera_uri=tessera_uri,
+    )
+    resolution_uri = f"urn:valor:resolution:{resolution_id}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX disc: <{DISC_NS}>
+        SELECT ?target WHERE {{
+          GRAPH <{graph}> {{
+            <{resolution_uri}> disc:motivatesArgue ?target .
+          }}
+        }}
+    """)
+    assert rows, "disc:motivatesArgue-triple ontbreekt"
+    assert rows[0]["target"]["value"] == tessera_uri
+
+
+async def test_create_resolution_schrijft_prov_triples(ds_id, thread_id):
+    tessera_uri = f"urn:valor:tessera:{TESSERA_ID}"
+    resolution_id = await create_thread_resolution(
+        thread_id=thread_id,
+        design_space_id=ds_id,
+        user_id=USER_ID,
+        resolution_outcome_uri=OUTCOME_URI,
+        resolution_rationale="Testrationale.",
+        tessera_uri=tessera_uri,
+    )
+    resolution_uri = f"urn:valor:resolution:{resolution_id}"
+    user_uri = f"urn:valor:user:{USER_ID}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX prov: <{PROV_NS}>
+        SELECT ?attr ?gen WHERE {{
+          GRAPH <{graph}> {{
+            <{resolution_uri}> prov:wasAttributedTo ?attr ;
+                               prov:generatedAtTime ?gen .
+          }}
+        }}
+    """)
+    assert rows, "prov:wasAttributedTo / prov:generatedAtTime ontbreken"
+    assert rows[0]["attr"]["value"] == user_uri
+    assert rows[0]["gen"]["value"], "generatedAtTime mag niet leeg zijn"

--- a/backend/tests/integration/test_disc_threads.py
+++ b/backend/tests/integration/test_disc_threads.py
@@ -1,0 +1,140 @@
+"""Integratietests voor disc:DiscussionThread aanmaken en ophalen (US-16.2).
+
+Verifieert:
+- create_discussion_thread schrijft correcte triples naar Fuseki
+- get_threads_by_tessera retourneert de juiste threads
+- Meerdere threads per tessera worden correct teruggegeven
+"""
+import pytest
+
+from app.db.disc import create_discussion_thread, get_threads_by_tessera
+from app.services.fuseki import named_graph_uri
+
+pytestmark = pytest.mark.integration
+
+DISC_NS = "https://valor-ecosystem.nl/ontology/disc#"
+PROV_NS = "https://www.w3.org/ns/prov#"
+
+TESSERA_A = "tessera-disc-test-001"
+TESSERA_B = "tessera-disc-test-002"
+USER_ID = "user-disc-test-001"
+
+
+async def _sparql_select(graph_uri: str, query: str) -> list[dict]:
+    import httpx
+    from tests.conftest import FUSEKI_TEST_URL, FUSEKI_TEST_DATASET
+
+    endpoint = f"{FUSEKI_TEST_URL}/{FUSEKI_TEST_DATASET}/sparql"
+    async with httpx.AsyncClient() as client:
+        r = await client.post(
+            endpoint,
+            data={"query": query},
+            headers={"Accept": "application/sparql-results+json"},
+            timeout=10,
+        )
+    r.raise_for_status()
+    return r.json()["results"]["bindings"]
+
+
+# ---------------------------------------------------------------------------
+# create_discussion_thread
+# ---------------------------------------------------------------------------
+
+async def test_create_thread_retourneert_thread_id(ds_id):
+    thread_id = await create_discussion_thread(TESSERA_A, ds_id, USER_ID)
+    assert thread_id, "thread_id mag niet leeg zijn"
+    assert len(thread_id) == 36, "thread_id moet een UUID zijn"
+
+
+async def test_create_thread_schrijft_type_triple(ds_id):
+    thread_id = await create_discussion_thread(TESSERA_A, ds_id, USER_ID)
+    thread_uri = f"urn:valor:thread:{thread_id}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX disc: <{DISC_NS}>
+        SELECT ?thread WHERE {{
+          GRAPH <{graph}> {{
+            <{thread_uri}> a disc:DiscussionThread .
+            BIND(<{thread_uri}> AS ?thread)
+          }}
+        }}
+    """)
+    assert rows, "disc:DiscussionThread-triple ontbreekt in Fuseki"
+
+
+async def test_create_thread_schrijft_about_tessera(ds_id):
+    thread_id = await create_discussion_thread(TESSERA_A, ds_id, USER_ID)
+    thread_uri = f"urn:valor:thread:{thread_id}"
+    tessera_uri = f"urn:valor:tessera:{TESSERA_A}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX disc: <{DISC_NS}>
+        SELECT ?tessera WHERE {{
+          GRAPH <{graph}> {{
+            <{thread_uri}> disc:aboutTessera ?tessera .
+          }}
+        }}
+    """)
+    assert rows, "disc:aboutTessera-triple ontbreekt"
+    assert rows[0]["tessera"]["value"] == tessera_uri
+
+
+async def test_create_thread_schrijft_prov_triples(ds_id):
+    thread_id = await create_discussion_thread(TESSERA_A, ds_id, USER_ID)
+    thread_uri = f"urn:valor:thread:{thread_id}"
+    user_uri = f"urn:valor:user:{USER_ID}"
+    graph = named_graph_uri(ds_id)
+
+    rows = await _sparql_select(graph, f"""
+        PREFIX prov: <{PROV_NS}>
+        SELECT ?started_by ?started_at WHERE {{
+          GRAPH <{graph}> {{
+            <{thread_uri}> prov:wasStartedBy ?started_by ;
+                           prov:startedAtTime ?started_at .
+          }}
+        }}
+    """)
+    assert rows, "prov:wasStartedBy / prov:startedAtTime ontbreken"
+    assert rows[0]["started_by"]["value"] == user_uri
+    assert rows[0]["started_at"]["value"], "startedAtTime mag niet leeg zijn"
+
+
+# ---------------------------------------------------------------------------
+# get_threads_by_tessera
+# ---------------------------------------------------------------------------
+
+async def test_get_threads_retourneert_lege_lijst_zonder_data(ds_id):
+    result = await get_threads_by_tessera(TESSERA_A, ds_id)
+    assert result == []
+
+
+async def test_get_threads_retourneert_aangemaakte_thread(ds_id):
+    thread_id = await create_discussion_thread(TESSERA_A, ds_id, USER_ID)
+    result = await get_threads_by_tessera(TESSERA_A, ds_id)
+
+    assert len(result) == 1
+    assert result[0]["thread_id"] == thread_id
+    assert result[0]["tessera_id"] == TESSERA_A
+    assert result[0]["design_space_id"] == ds_id
+    assert result[0]["started_by"] == f"urn:valor:user:{USER_ID}"
+
+
+async def test_get_threads_retourneert_meerdere_threads(ds_id):
+    tid1 = await create_discussion_thread(TESSERA_A, ds_id, USER_ID)
+    tid2 = await create_discussion_thread(TESSERA_A, ds_id, USER_ID)
+
+    result = await get_threads_by_tessera(TESSERA_A, ds_id)
+    assert len(result) == 2
+    thread_ids = {r["thread_id"] for r in result}
+    assert tid1 in thread_ids
+    assert tid2 in thread_ids
+
+
+async def test_get_threads_isoleert_per_tessera(ds_id):
+    """Threads van tessera A mogen niet in resultaat van tessera B verschijnen."""
+    await create_discussion_thread(TESSERA_A, ds_id, USER_ID)
+
+    result_b = await get_threads_by_tessera(TESSERA_B, ds_id)
+    assert result_b == [], "Thread van tessera A mag niet verschijnen bij tessera B"

--- a/frontend/src/components/Chat/FloatingThreadPanel.tsx
+++ b/frontend/src/components/Chat/FloatingThreadPanel.tsx
@@ -1,123 +1,138 @@
 import React, { useState, useEffect } from 'react';
 import { X, Send, MessageSquare } from 'lucide-react';
-import { api } from '../../services/api';
-import { useAuth } from '../../context/AuthContext';
-import type { Thread, ConversationMessage } from '../../types/conversation';
+import { api, type DiscThread, type DiscContribution } from '../../services/api';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { ScrollArea } from '../ui/scroll-area';
 import { Card, CardHeader, CardContent } from '../ui/card';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '../ui/select';
+
+const CONTRIBUTION_TYPES = [
+    'Vraag',
+    'Stelling',
+    'Bewijs',
+    'Bezwaar',
+    'Toelichting',
+    'Akkoord',
+] as const;
+
+type ContributionTypeLabel = typeof CONTRIBUTION_TYPES[number];
+
+const TYPE_BADGE_VARIANT: Record<ContributionTypeLabel, string> = {
+    Vraag:       'bg-blue-100 text-blue-800 border-blue-200',
+    Stelling:    'bg-purple-100 text-purple-800 border-purple-200',
+    Bewijs:      'bg-green-100 text-green-800 border-green-200',
+    Bezwaar:     'bg-red-100 text-red-800 border-red-200',
+    Toelichting: 'bg-amber-100 text-amber-800 border-amber-200',
+    Akkoord:     'bg-emerald-100 text-emerald-800 border-emerald-200',
+};
+
+function contributionTypeLabel(uri: string): ContributionTypeLabel {
+    const fragment = uri.split('#').pop() ?? uri.split('/').pop() ?? uri;
+    return (CONTRIBUTION_TYPES as readonly string[]).includes(fragment)
+        ? (fragment as ContributionTypeLabel)
+        : 'Toelichting';
+}
+
+function shortUri(uri: string): string {
+    return uri.split(':').pop() ?? uri;
+}
 
 interface FloatingThreadPanelProps {
-    targetId: string;
+    tesseraId: string;
+    designSpaceId: string;
     targetLabel?: string;
     onClose: () => void;
     onThreadCreated?: () => void;
     position?: { x: number; y: number };
     readOnly?: boolean;
-    initialThreadId?: string;
 }
 
 export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
-    targetId,
+    tesseraId,
+    designSpaceId,
     targetLabel,
     onClose,
     onThreadCreated,
     position,
     readOnly = false,
-    initialThreadId
 }) => {
-    const [view, setView] = useState<'list' | 'chat' | 'create'>('list');
-    const [threads, setThreads] = useState<Thread[]>([]);
-    const [activeThread, setActiveThread] = useState<Thread | null>(null);
-    const [messages, setMessages] = useState<ConversationMessage[]>([]);
+    const [view, setView] = useState<'list' | 'contributions'>('list');
+    const [threads, setThreads] = useState<DiscThread[]>([]);
+    const [activeThread, setActiveThread] = useState<DiscThread | null>(null);
+    const [contributions, setContributions] = useState<DiscContribution[]>([]);
     const [newMessage, setNewMessage] = useState('');
-    const [newTopic, setNewTopic] = useState('');
+    const [newType, setNewType] = useState<ContributionTypeLabel>('Stelling');
     const [loading, setLoading] = useState(false);
-    const { user } = useAuth();
 
-    // Fetch threads on mount
     useEffect(() => {
         loadThreads();
-    }, [targetId]);
+    }, [tesseraId, designSpaceId]);
 
     const loadThreads = async () => {
-        if (!targetId) return;
         setLoading(true);
         try {
-            const data = await api.getThreads(targetId);
+            const data = await api.getDiscThreads(tesseraId, designSpaceId);
             setThreads(data);
-
-            // If we have an initialThreadId, find and select it
-            if (initialThreadId) {
-                const thread = data.find(t => t.id === initialThreadId);
-                if (thread) {
-                    handleSelectThread(thread);
-                }
-            } else if (data.length === 1 && view === 'list') {
-                // Auto-select if there is only one thread and no specific one requested
-                handleSelectThread(data[0]);
+            if (data.length === 1) {
+                await openThread(data[0]);
             }
         } catch (e) {
-            console.error(e);
+            console.error('[FloatingThreadPanel] loadThreads:', e);
         } finally {
             setLoading(false);
         }
     };
 
-    const handleSelectThread = async (thread: Thread) => {
+    const openThread = async (thread: DiscThread) => {
         setActiveThread(thread);
         setLoading(true);
         try {
-            const msgs = await api.getThreadMessages(thread.id);
-            setMessages(msgs);
-            setView('chat');
+            const data = await api.getDiscContributions(thread.thread_id, designSpaceId);
+            setContributions(data);
+            setView('contributions');
         } catch (e) {
-            console.error(e);
+            console.error('[FloatingThreadPanel] openThread:', e);
         } finally {
             setLoading(false);
         }
     };
 
-    const handleCreateThread = async (e?: React.FormEvent) => {
-        e?.preventDefault();
-        if (readOnly || !newTopic.trim()) return;
-
+    const handleCreateThread = async () => {
+        if (readOnly) return;
         setLoading(true);
         try {
-            const newThread = await api.createThread(targetId, newTopic.trim());
-            const threadObj: Thread = {
-                ...newThread,
-                status: 'active',
-                created_at: new Date().toISOString()
-            };
-            setThreads([threadObj, ...threads]);
-            setNewTopic('');
-            handleSelectThread(threadObj);
-            onThreadCreated?.(); // Notify parent to refresh stats
+            await api.createDiscThread(tesseraId, designSpaceId);
+            onThreadCreated?.();
+            await loadThreads();
         } catch (e) {
-            console.error(e);
+            console.error('[FloatingThreadPanel] handleCreateThread:', e);
         } finally {
             setLoading(false);
         }
     };
 
-    const startCreating = () => {
-        if (readOnly) return;
-        setNewTopic(`Discussie over ${targetLabel || 'Item'}`);
-        setView('create');
-    };
-
-    const handleSendMessage = async (e?: React.FormEvent) => {
+    const handleSendContribution = async (e?: React.FormEvent) => {
         e?.preventDefault();
         if (readOnly || !newMessage.trim() || !activeThread) return;
 
         try {
-            const msg = await api.createThreadMessage(activeThread.id, newMessage);
-            setMessages([...messages, msg]);
+            await api.createDiscContribution(activeThread.thread_id, {
+                design_space_id: designSpaceId,
+                contribution_type: newType,
+                message_content: newMessage.trim(),
+            });
             setNewMessage('');
-        } catch (err) {
-            console.error(err);
+            const data = await api.getDiscContributions(activeThread.thread_id, designSpaceId);
+            setContributions(data);
+        } catch (e) {
+            console.error('[FloatingThreadPanel] handleSendContribution:', e);
         }
     };
 
@@ -127,23 +142,30 @@ export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
             style={{
                 left: position ? position.x : '50%',
                 top: position ? position.y : '50%',
-                maxHeight: '500px',
-                transform: position ? 'none' : 'translate(-50%, -50%)'
+                maxHeight: '520px',
+                transform: position ? 'none' : 'translate(-50%, -50%)',
             }}
         >
             {/* Header */}
             <CardHeader className="flex flex-row items-center justify-between p-3 border-b bg-muted/20 space-y-0">
                 <div className="flex items-center gap-2">
                     {view !== 'list' && (
-                        <Button variant="ghost" size="icon" className="h-5 w-5 -ml-1" onClick={() => setView('list')}>
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-5 w-5 -ml-1"
+                            onClick={() => setView('list')}
+                        >
                             <span className="sr-only">Terug</span>
                             ←
                         </Button>
                     )}
                     <h3 className="font-medium text-sm truncate max-w-[200px]">
-                        {view === 'list' ? 'Discussies' :
-                            view === 'create' ? 'Nieuw Onderwerp' :
-                                activeThread?.topic}
+                        {view === 'list'
+                            ? `Discussies${targetLabel ? `: ${targetLabel}` : ''}`
+                            : activeThread
+                            ? new Intl.DateTimeFormat('nl-NL', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }).format(new Date(activeThread.started_at))
+                            : 'Discussie'}
                     </h3>
                 </div>
                 <Button variant="ghost" size="icon" className="h-6 w-6" onClick={onClose}>
@@ -153,8 +175,11 @@ export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
 
             {/* Content */}
             <CardContent className="flex-1 overflow-hidden flex flex-col p-0">
-                {loading && <div className="p-4 text-center text-xs text-muted-foreground">Laden...</div>}
+                {loading && (
+                    <div className="p-4 text-center text-xs text-muted-foreground">Laden...</div>
+                )}
 
+                {/* Thread list */}
                 {!loading && view === 'list' && (
                     <ScrollArea className="flex-1">
                         {threads.length === 0 ? (
@@ -162,7 +187,12 @@ export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
                                 <MessageSquare className="h-8 w-8 mx-auto mb-2 opacity-20" />
                                 <p className="text-sm">Nog geen discussies.</p>
                                 {!readOnly && (
-                                    <Button size="sm" variant="outline" className="mt-4" onClick={startCreating}>
+                                    <Button
+                                        size="sm"
+                                        variant="outline"
+                                        className="mt-4"
+                                        onClick={handleCreateThread}
+                                    >
                                         Discussie Starten
                                     </Button>
                                 )}
@@ -171,20 +201,28 @@ export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
                             <div className="p-2 space-y-1">
                                 {threads.map(thread => (
                                     <button
-                                        key={thread.id}
-                                        onClick={() => handleSelectThread(thread)}
+                                        key={thread.thread_id}
+                                        onClick={() => openThread(thread)}
                                         className="w-full text-left p-2 rounded hover:bg-muted text-sm flex items-center justify-between group"
                                     >
-                                        <span className="truncate flex-1">{thread.topic}</span>
-                                        <span className="text-[10px] text-muted-foreground">
-                                            {new Intl.DateTimeFormat('nl-NL', { month: 'short', day: 'numeric' }).format(new Date(thread.created_at))}
+                                        <span className="truncate flex-1 text-xs text-muted-foreground">
+                                            {shortUri(thread.started_by)}
+                                        </span>
+                                        <span className="text-[10px] text-muted-foreground ml-2 shrink-0">
+                                            {new Intl.DateTimeFormat('nl-NL', { month: 'short', day: 'numeric' }).format(new Date(thread.started_at))}
                                         </span>
                                     </button>
                                 ))}
                                 {!readOnly && (
                                     <div className="pt-2 mt-2 border-t px-2">
-                                        <Button size="sm" variant="secondary" className="w-full h-8" onClick={startCreating}>
-                                            + Nieuw Onderwerp
+                                        <Button
+                                            size="sm"
+                                            variant="secondary"
+                                            className="w-full h-8"
+                                            onClick={handleCreateThread}
+                                            disabled={loading}
+                                        >
+                                            + Nieuwe Discussie
                                         </Button>
                                     </div>
                                 )}
@@ -193,64 +231,79 @@ export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
                     </ScrollArea>
                 )}
 
-                {!loading && view === 'create' && !readOnly && (
-                    <div className="p-4 space-y-4">
-                        <div className="space-y-2">
-                            <label className="text-xs font-medium text-muted-foreground">Onderwerp</label>
-                            <Input
-                                value={newTopic}
-                                onChange={e => setNewTopic(e.target.value)}
-                                placeholder="Bijv. Definitie van deze factor"
-                                className="h-9"
-                                autoFocus
-                            />
-                        </div>
-                        <div className="flex gap-2">
-                            <Button variant="ghost" className="flex-1" onClick={() => setView('list')}>Annuleren</Button>
-                            <Button className="flex-1" onClick={handleCreateThread} disabled={!newTopic.trim()}>Starten</Button>
-                        </div>
-                    </div>
-                )}
-
-                {!loading && view === 'chat' && (
+                {/* Contributions view */}
+                {!loading && view === 'contributions' && (
                     <>
                         <ScrollArea className="flex-1 p-3">
                             <div className="space-y-3">
-                                {messages.map(msg => {
-                                    const isOwnMessage = user?.id === msg.user_id;
-
+                                {contributions.length === 0 && (
+                                    <p className="text-xs text-muted-foreground text-center py-4">
+                                        Nog geen bijdragen. Voeg de eerste toe.
+                                    </p>
+                                )}
+                                {contributions.map(contrib => {
+                                    const typeLabel = contributionTypeLabel(contrib.contribution_type);
+                                    const badgeClass = TYPE_BADGE_VARIANT[typeLabel];
                                     return (
-                                        <div key={msg.id} className={`flex flex-col gap-1 w-full ${isOwnMessage ? 'items-end' : 'items-start'}`}>
-                                            {!isOwnMessage && (
-                                                <span className="text-[10px] text-muted-foreground px-1 font-medium">
-                                                    {msg.author_name || 'Gebruiker'}
+                                        <div key={contrib.contribution_id} className="flex flex-col gap-1">
+                                            <div className="flex items-center gap-2">
+                                                <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium border ${badgeClass}`}>
+                                                    {typeLabel}
                                                 </span>
-                                            )}
-                                            <div className={`p-2.5 rounded-2xl text-sm max-w-[85%] shadow-sm ${isOwnMessage
-                                                ? 'bg-blue-600/10 text-blue-900 border border-blue-600/20 rounded-tr-none'
-                                                : 'bg-muted text-foreground rounded-tl-none'
-                                                }`}>
-                                                {msg.content}
+                                                <span className="text-[10px] text-muted-foreground truncate">
+                                                    {shortUri(contrib.contributed_by)}
+                                                </span>
+                                                <span className="text-[10px] text-muted-foreground ml-auto shrink-0">
+                                                    {new Intl.DateTimeFormat('nl-NL', { hour: '2-digit', minute: '2-digit' }).format(new Date(contrib.contributed_at))}
+                                                </span>
                                             </div>
-                                            <span className="text-[10px] text-muted-foreground px-1 opacity-70">
-                                                {isOwnMessage ? 'Jij' : (msg.author_name || 'Gebruiker')} • {new Intl.DateTimeFormat('nl-NL', { hour: '2-digit', minute: '2-digit' }).format(new Date(msg.created_at))}
-                                            </span>
+                                            <div className="bg-muted rounded-lg p-2 text-sm">
+                                                {contrib.message_content}
+                                                {contrib.evidence_id && (
+                                                    <div className="mt-1 text-[10px] text-muted-foreground border-t pt-1">
+                                                        Bewijs: {contrib.evidence_id}
+                                                    </div>
+                                                )}
+                                            </div>
                                         </div>
                                     );
                                 })}
                             </div>
                         </ScrollArea>
+
                         {!readOnly && (
-                            <form onSubmit={handleSendMessage} className="p-2 border-t flex gap-2">
-                                <Input
-                                    value={newMessage}
-                                    onChange={e => setNewMessage(e.target.value)}
-                                    placeholder="Schrijf een antwoord..."
-                                    className="h-8 text-sm"
-                                />
-                                <Button type="submit" size="icon" className="h-8 w-8">
-                                    <Send className="h-3.5 w-3.5" />
-                                </Button>
+                            <form onSubmit={handleSendContribution} className="p-2 border-t space-y-2">
+                                <Select
+                                    value={newType}
+                                    onValueChange={v => setNewType(v as ContributionTypeLabel)}
+                                >
+                                    <SelectTrigger className="h-7 text-xs">
+                                        <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {CONTRIBUTION_TYPES.map(t => (
+                                            <SelectItem key={t} value={t} className="text-xs">
+                                                {t}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                                <div className="flex gap-2">
+                                    <Input
+                                        value={newMessage}
+                                        onChange={e => setNewMessage(e.target.value)}
+                                        placeholder="Schrijf een bijdrage..."
+                                        className="h-8 text-sm"
+                                    />
+                                    <Button
+                                        type="submit"
+                                        size="icon"
+                                        className="h-8 w-8 shrink-0"
+                                        disabled={!newMessage.trim()}
+                                    >
+                                        <Send className="h-3.5 w-3.5" />
+                                    </Button>
+                                </div>
                             </form>
                         )}
                     </>

--- a/frontend/src/components/Chat/FloatingThreadPanel.tsx
+++ b/frontend/src/components/Chat/FloatingThreadPanel.tsx
@@ -46,7 +46,7 @@ function shortUri(uri: string): string {
 
 interface FloatingThreadPanelProps {
     tesseraId: string;
-    designSpaceId: string;
+    designSpaceId?: string;
     targetLabel?: string;
     onClose: () => void;
     onThreadCreated?: () => void;
@@ -72,13 +72,14 @@ export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
     const [loading, setLoading] = useState(false);
 
     useEffect(() => {
-        loadThreads();
+        if (designSpaceId) loadThreads();
     }, [tesseraId, designSpaceId]);
 
     const loadThreads = async () => {
+        if (!designSpaceId) return;
         setLoading(true);
         try {
-            const data = await api.getDiscThreads(tesseraId, designSpaceId);
+            const data = await api.getDiscThreads(tesseraId, designSpaceId!);
             setThreads(data);
             if (data.length === 1) {
                 await openThread(data[0]);
@@ -94,7 +95,7 @@ export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
         setActiveThread(thread);
         setLoading(true);
         try {
-            const data = await api.getDiscContributions(thread.thread_id, designSpaceId);
+            const data = await api.getDiscContributions(thread.thread_id, designSpaceId!);
             setContributions(data);
             setView('contributions');
         } catch (e) {
@@ -108,7 +109,7 @@ export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
         if (readOnly) return;
         setLoading(true);
         try {
-            await api.createDiscThread(tesseraId, designSpaceId);
+            await api.createDiscThread(tesseraId, designSpaceId!);
             onThreadCreated?.();
             await loadThreads();
         } catch (e) {
@@ -124,12 +125,12 @@ export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
 
         try {
             await api.createDiscContribution(activeThread.thread_id, {
-                design_space_id: designSpaceId,
+                design_space_id: designSpaceId!,
                 contribution_type: newType,
                 message_content: newMessage.trim(),
             });
             setNewMessage('');
-            const data = await api.getDiscContributions(activeThread.thread_id, designSpaceId);
+            const data = await api.getDiscContributions(activeThread.thread_id, designSpaceId!);
             setContributions(data);
         } catch (e) {
             console.error('[FloatingThreadPanel] handleSendContribution:', e);
@@ -175,12 +176,19 @@ export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
 
             {/* Content */}
             <CardContent className="flex-1 overflow-hidden flex flex-col p-0">
-                {loading && (
+                {!designSpaceId && (
+                    <div className="p-6 text-center text-xs text-muted-foreground">
+                        <MessageSquare className="h-6 w-6 mx-auto mb-2 opacity-20" />
+                        <p>Geen DesignSpace gekoppeld.</p>
+                        <p className="mt-1 opacity-70">Discussies zijn beschikbaar in een actieve DesignSpace.</p>
+                    </div>
+                )}
+                {designSpaceId && loading && (
                     <div className="p-4 text-center text-xs text-muted-foreground">Laden...</div>
                 )}
 
                 {/* Thread list */}
-                {!loading && view === 'list' && (
+                {designSpaceId && !loading && view === 'list' && (
                     <ScrollArea className="flex-1">
                         {threads.length === 0 ? (
                             <div className="p-8 text-center text-muted-foreground">
@@ -232,7 +240,7 @@ export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
                 )}
 
                 {/* Contributions view */}
-                {!loading && view === 'contributions' && (
+                {designSpaceId && !loading && view === 'contributions' && (
                     <>
                         <ScrollArea className="flex-1 p-3">
                             <div className="space-y-3">

--- a/frontend/src/components/Chat/FloatingThreadPanel.tsx
+++ b/frontend/src/components/Chat/FloatingThreadPanel.tsx
@@ -70,6 +70,7 @@ export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
     const [newMessage, setNewMessage] = useState('');
     const [newType, setNewType] = useState<ContributionTypeLabel>('Stelling');
     const [loading, setLoading] = useState(false);
+    const [newTitle, setNewTitle] = useState('');
 
     useEffect(() => {
         if (designSpaceId) loadThreads();
@@ -109,7 +110,8 @@ export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
         if (readOnly) return;
         setLoading(true);
         try {
-            await api.createDiscThread(tesseraId, designSpaceId!);
+            await api.createDiscThread(tesseraId, designSpaceId!, newTitle.trim() || undefined);
+            setNewTitle('');
             onThreadCreated?.();
             await loadThreads();
         } catch (e) {
@@ -191,18 +193,27 @@ export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
                 {designSpaceId && !loading && view === 'list' && (
                     <ScrollArea className="flex-1">
                         {threads.length === 0 ? (
-                            <div className="p-8 text-center text-muted-foreground">
+                            <div className="p-6 text-center text-muted-foreground">
                                 <MessageSquare className="h-8 w-8 mx-auto mb-2 opacity-20" />
                                 <p className="text-sm">Nog geen discussies.</p>
                                 {!readOnly && (
-                                    <Button
-                                        size="sm"
-                                        variant="outline"
-                                        className="mt-4"
-                                        onClick={handleCreateThread}
-                                    >
-                                        Discussie Starten
-                                    </Button>
+                                    <div className="mt-4 space-y-2">
+                                        <Input
+                                            value={newTitle}
+                                            onChange={e => setNewTitle(e.target.value)}
+                                            placeholder="Onderwerp (optioneel)"
+                                            className="h-8 text-xs"
+                                        />
+                                        <Button
+                                            size="sm"
+                                            variant="outline"
+                                            className="w-full"
+                                            onClick={handleCreateThread}
+                                            disabled={loading}
+                                        >
+                                            Discussie Starten
+                                        </Button>
+                                    </div>
                                 )}
                             </div>
                         ) : (
@@ -213,16 +224,22 @@ export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
                                         onClick={() => openThread(thread)}
                                         className="w-full text-left p-2 rounded hover:bg-muted text-sm flex items-center justify-between group"
                                     >
-                                        <span className="truncate flex-1 text-xs text-muted-foreground">
-                                            {shortUri(thread.started_by)}
+                                        <span className="truncate flex-1 text-xs font-medium">
+                                            {thread.title ?? `Discussie ${new Intl.DateTimeFormat('nl-NL', { month: 'short', day: 'numeric' }).format(new Date(thread.started_at))}`}
                                         </span>
                                         <span className="text-[10px] text-muted-foreground ml-2 shrink-0">
-                                            {new Intl.DateTimeFormat('nl-NL', { month: 'short', day: 'numeric' }).format(new Date(thread.started_at))}
+                                            {thread.started_by_name ?? shortUri(thread.started_by)}
                                         </span>
                                     </button>
                                 ))}
                                 {!readOnly && (
-                                    <div className="pt-2 mt-2 border-t px-2">
+                                    <div className="pt-2 mt-2 border-t px-2 space-y-1">
+                                        <Input
+                                            value={newTitle}
+                                            onChange={e => setNewTitle(e.target.value)}
+                                            placeholder="Onderwerp (optioneel)"
+                                            className="h-7 text-xs"
+                                        />
                                         <Button
                                             size="sm"
                                             variant="secondary"
@@ -259,7 +276,7 @@ export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
                                                     {typeLabel}
                                                 </span>
                                                 <span className="text-[10px] text-muted-foreground truncate">
-                                                    {shortUri(contrib.contributed_by)}
+                                                    {contrib.contributed_by_name ?? shortUri(contrib.contributed_by)}
                                                 </span>
                                                 <span className="text-[10px] text-muted-foreground ml-auto shrink-0">
                                                     {new Intl.DateTimeFormat('nl-NL', { hour: '2-digit', minute: '2-digit' }).format(new Date(contrib.contributed_at))}

--- a/frontend/src/components/Workspace/ValorWorkspace.tsx
+++ b/frontend/src/components/Workspace/ValorWorkspace.tsx
@@ -45,6 +45,17 @@ export const ValorWorkspace: React.FC<ValorWorkspaceProps> = ({ projectId, theme
     // Context Integration
     const { currentViewedVersion, isReadOnly, setActiveVotingSession } = useTheme();
 
+    // DesignSpace voor disc threads
+    const [activeDesignSpaceId, setActiveDesignSpaceId] = useState<string | undefined>(undefined);
+
+    useEffect(() => {
+        api.getDesignSpacesByProject(projectId, themeId).then(spaces => {
+            const active = spaces.find(s => s.status === 'active') ?? spaces[0];
+            if (active) setActiveDesignSpaceId(active.id);
+            else console.warn('[ValorWorkspace] Geen actieve DesignSpace gevonden voor project', projectId, spaces);
+        }).catch(err => console.error('[ValorWorkspace] Fout bij ophalen DesignSpaces:', err));
+    }, [projectId, themeId]);
+
     // WS to Context Sync
     useEffect(() => {
         if (!lastMessage) return;
@@ -211,6 +222,7 @@ export const ValorWorkspace: React.FC<ValorWorkspaceProps> = ({ projectId, theme
                                 currentUserId={currentUser?.id || null}
                                 versionId={currentViewedVersion?.id}
                                 isReadOnly={isReadOnly}
+                                designSpaceId={activeDesignSpaceId}
                             />
                         </div>
                     </div>

--- a/frontend/src/components/deliberation/RefinementDetail.tsx
+++ b/frontend/src/components/deliberation/RefinementDetail.tsx
@@ -15,7 +15,7 @@ interface RefinementDetailProps {
 }
 
 export const RefinementDetail: React.FC<RefinementDetailProps> = ({ claim, allClaims, factors = [] }) => {
-    const [activeThread, setActiveThread] = React.useState<{ targetId: string, label: string, initialThreadId?: string } | null>(null);
+    const [activeThread, setActiveThread] = React.useState<{ targetId: string; label: string; designSpaceId?: string } | null>(null);
 
     const factorMap = React.useMemo(() => {
         const map = new Map<string, string>();
@@ -35,8 +35,8 @@ export const RefinementDetail: React.FC<RefinementDetailProps> = ({ claim, allCl
         );
     }
 
-    const openThread = (targetId: string, label: string, initialThreadId?: string) => {
-        setActiveThread({ targetId, label, initialThreadId });
+    const openThread = (targetId: string, label: string) => {
+        setActiveThread({ targetId, label });
     };
 
     return (
@@ -106,7 +106,7 @@ export const RefinementDetail: React.FC<RefinementDetailProps> = ({ claim, allCl
                                 <li>
                                     <ThreadLink
                                         label={`Discussie over ${getSourceName(claim)}`}
-                                        onClick={() => openThread(claim.source_id!, getSourceName(claim), claim.source_thread_id)}
+                                        onClick={() => openThread(claim.source_id!, getSourceName(claim))}
                                     />
                                 </li>
                             )}
@@ -114,7 +114,7 @@ export const RefinementDetail: React.FC<RefinementDetailProps> = ({ claim, allCl
                                 <li>
                                     <ThreadLink
                                         label={`Discussie over ${getTargetName(claim)}`}
-                                        onClick={() => openThread(claim.target_id!, getTargetName(claim), claim.target_thread_id)}
+                                        onClick={() => openThread(claim.target_id!, getTargetName(claim))}
                                     />
                                 </li>
                             )}
@@ -122,7 +122,7 @@ export const RefinementDetail: React.FC<RefinementDetailProps> = ({ claim, allCl
                                 <li>
                                     <ThreadLink
                                         label="Discussie over deze Claim"
-                                        onClick={() => openThread(claim.id!, "Deze Claim", claim.claim_thread_id)}
+                                        onClick={() => openThread(claim.id!, "Deze Claim")}
                                     />
                                 </li>
                             )}
@@ -157,11 +157,11 @@ export const RefinementDetail: React.FC<RefinementDetailProps> = ({ claim, allCl
                 </Tabs>
             </div>
 
-            {activeThread && (
+            {activeThread && activeThread.designSpaceId && (
                 <FloatingThreadPanel
-                    targetId={activeThread.targetId}
+                    tesseraId={activeThread.targetId}
+                    designSpaceId={activeThread.designSpaceId}
                     targetLabel={activeThread.label}
-                    initialThreadId={activeThread.initialThreadId}
                     onClose={() => setActiveThread(null)}
                     readOnly={true}
                 />

--- a/frontend/src/perspectives/causa/Shell.tsx
+++ b/frontend/src/perspectives/causa/Shell.tsx
@@ -38,9 +38,10 @@ export interface CausaShellProps {
     onOpenConversation?: (context: ConversationContext) => void;
     versionId?: string;
     isReadOnly?: boolean;
+    designSpaceId?: string;
 }
 
-export const CausaShell = ({ themeId, websocket, currentUserId, onSelect, onOpenConversation, versionId, isReadOnly = false }: CausaShellProps) => {
+export const CausaShell = ({ themeId, websocket, currentUserId, onSelect, onOpenConversation, versionId, isReadOnly = false, designSpaceId }: CausaShellProps) => {
     const queryClient = useQueryClient();
     const themeState = useTheme();
 
@@ -325,10 +326,11 @@ export const CausaShell = ({ themeId, websocket, currentUserId, onSelect, onOpen
                 layoutMode={layoutMode}
                 onOpenConversation={onOpenConversation || (() => { })}
                 onEdit={handleEdit}
-                onViewportChange={() => { }} // Clean up unused
+                onViewportChange={() => { }}
                 onInit={setRfInstance}
                 onConnect={effectiveIsReadOnly ? undefined : handleConnect}
                 isReadOnly={effectiveIsReadOnly}
+                designSpaceId={designSpaceId}
             />
 
             {/* Modals */}

--- a/frontend/src/perspectives/causa/views/CLDView.tsx
+++ b/frontend/src/perspectives/causa/views/CLDView.tsx
@@ -438,7 +438,7 @@ export const CLDView: FunctionComponent<CLDViewProps> = ({
                 )
             }
 
-            {floatingThread && designSpaceId && (
+            {floatingThread && (
                 <FloatingThreadPanel
                     tesseraId={floatingThread.targetId}
                     designSpaceId={designSpaceId}

--- a/frontend/src/perspectives/causa/views/CLDView.tsx
+++ b/frontend/src/perspectives/causa/views/CLDView.tsx
@@ -19,7 +19,7 @@ import { getGeometricHandles } from '../layout/edgeUtils';
 import { CanvasContextMenu } from '@/components/shell/CanvasContextMenu';
 import { ViewControls } from '@/components/shell/ViewControls';
 import type { ConversationContext } from '@/types/conversation';
-import { api } from '@/services/api';
+// api import verwijderd — disc thread stats worden later via disc endpoints geladen
 import { FloatingThreadPanel } from '@/components/Chat/FloatingThreadPanel';
 
 // Correct path if types are in parent/parent
@@ -39,6 +39,7 @@ interface CLDViewProps {
     onInit?: (instance: any) => void;
     onConnect?: (connection: Connection) => void;
     isReadOnly?: boolean;
+    designSpaceId?: string;
 }
 
 
@@ -65,7 +66,8 @@ export const CLDView: FunctionComponent<CLDViewProps> = ({
     onViewportChange,
     onInit,
     onConnect,
-    isReadOnly = false
+    isReadOnly = false,
+    designSpaceId,
 }) => {
     // React Flow State
     const [rfInstance, setRfInstance] = useState<any>(null);
@@ -73,29 +75,16 @@ export const CLDView: FunctionComponent<CLDViewProps> = ({
     const [edges, setEdges, onEdgesChange] = useEdgesState([]);
 
     // thread stats
-    const [threadStats, setThreadStats] = useState<Record<string, number>>({});
+    const [threadStats] = useState<Record<string, number>>({});
     const [floatingThread, setFloatingThread] = useState<{ targetId: string; label: string; position?: { x: number; y: number } } | null>(null);
+    // disc threads (Fuseki-backed, Epic 16)
 
-    const fetchThreadStats = async () => {
-        if (causalNodes.length === 0 && causalLinks.length === 0) return;
-        try {
-            // Combine version_ids from both nodes and links
-            const nodeIds = causalNodes.map(n => n.version_id).filter(id => !!id);
-            const linkIds = causalLinks.map(l => l.version_id).filter(id => !!id);
-            const ids = [...nodeIds, ...linkIds] as string[];
+    // Thread stats worden opgehaald via disc-endpoints wanneer designSpaceId beschikbaar is.
+    // Voorlopig is fetchThreadStats een no-op; badges worden later via disc API gevuld.
+    const fetchThreadStats = () => { /* disc-stats: nog niet geïmplementeerd */ };
 
-            if (ids.length === 0) return;
-
-            const stats = await api.getThreadStats(ids);
-            setThreadStats(stats);
-        } catch (e) {
-            console.error("Failed to fetch thread stats", e);
-        }
-    };
-
-    // Fetch thread stats on load and when structure changes
     useEffect(() => {
-        fetchThreadStats();
+        // no-op: thread stats vereisen disc endpoints (Epic 16)
     }, [causalNodes, causalLinks]);
 
     const handleOpenThread = (targetId: string, label: string, position?: { x: number; y: number }) => {
@@ -449,16 +438,17 @@ export const CLDView: FunctionComponent<CLDViewProps> = ({
                 )
             }
 
-            {floatingThread && (
+            {floatingThread && designSpaceId && (
                 <FloatingThreadPanel
-                    targetId={floatingThread.targetId}
+                    tesseraId={floatingThread.targetId}
+                    designSpaceId={designSpaceId}
                     targetLabel={floatingThread.label}
                     position={floatingThread.position}
                     onClose={() => {
                         setFloatingThread(null);
-                        fetchThreadStats(); // Refresh stats when closing
+                        fetchThreadStats();
                     }}
-                    onThreadCreated={fetchThreadStats} // Refresh stats immediately when a thread is created
+                    onThreadCreated={fetchThreadStats}
                     readOnly={isReadOnly}
                 />
             )}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -546,33 +546,34 @@ export const api = {
         return response.data;
     },
 
-    // Threads
-    getThreads: async (targetId: string): Promise<ConversationThread[]> => {
-        const response = await apiClient.get<ConversationThread[]>('/threads', { params: { target_id: targetId } });
+    // Threads (Fuseki-backed disc endpoints, Epic 16)
+    getDiscThreads: async (tesseraId: string, designSpaceId: string): Promise<DiscThread[]> => {
+        const response = await apiClient.get<DiscThread[]>('/threads', {
+            params: { tessera_id: tesseraId, design_space_id: designSpaceId },
+        });
         return response.data;
     },
 
-    createThread: async (targetId: string, topic: string): Promise<ConversationThread> => {
-        const response = await apiClient.post('/threads', { target_id: targetId, topic });
-        return {
-            ...response.data,
-            status: 'open',
-            created_at: new Date().toISOString()
-        } as ConversationThread;
-    },
-
-    getThreadStats: async (targetIds: string[]): Promise<Record<string, number>> => {
-        const response = await apiClient.post<Record<string, number>>('/threads/stats', targetIds);
+    createDiscThread: async (tesseraId: string, designSpaceId: string): Promise<{ thread_id: string }> => {
+        const response = await apiClient.post<{ thread_id: string }>('/threads', {
+            tessera_id: tesseraId,
+            design_space_id: designSpaceId,
+        });
         return response.data;
     },
 
-    createThreadMessage: async (threadId: string, content: string): Promise<ConversationMessage> => {
-        const response = await apiClient.post<ConversationMessage>(`/threads/${threadId}/messages`, { content });
+    getDiscContributions: async (threadId: string, designSpaceId: string): Promise<DiscContribution[]> => {
+        const response = await apiClient.get<DiscContribution[]>(`/threads/${threadId}/contributions`, {
+            params: { design_space_id: designSpaceId },
+        });
         return response.data;
     },
 
-    getThreadMessages: async (threadId: string): Promise<ConversationMessage[]> => {
-        const response = await apiClient.get<ConversationMessage[]>(`/threads/${threadId}/messages`);
+    createDiscContribution: async (
+        threadId: string,
+        body: { design_space_id: string; contribution_type: string; message_content: string; evidence_id?: string }
+    ): Promise<{ contribution_id: string }> => {
+        const response = await apiClient.post<{ contribution_id: string }>(`/threads/${threadId}/contribute`, body);
         return response.data;
     },
 
@@ -593,6 +594,28 @@ export interface ConversationMessage {
     content: string;
     role: 'user' | 'assistant';
     created_at: string;
+}
+
+// Disc (Fuseki-backed deliberation threads, Epic 16)
+export interface DiscThread {
+    thread_id: string;
+    thread_uri: string;
+    tessera_id: string;
+    design_space_id: string;
+    started_by: string;
+    started_at: string;
+}
+
+export interface DiscContribution {
+    contribution_id: string;
+    contribution_uri: string;
+    thread_id: string;
+    design_space_id: string;
+    contribution_type: string;
+    message_content: string;
+    contributed_by: string;
+    contributed_at: string;
+    evidence_id: string | null;
 }
 
 export type LifecycleStatus = 'draft' | 'proposed' | 'accepted' | 'rejected' | 'deprecated';

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -546,6 +546,14 @@ export const api = {
         return response.data;
     },
 
+    // DesignSpace
+    getDesignSpacesByProject: async (projectId: string, themeId?: string): Promise<{ id: string; name: string; status: string; current_phase: string }[]> => {
+        const response = await apiClient.get(`/designspace/by-project/${projectId}`, {
+            params: themeId ? { theme_id: themeId } : undefined,
+        });
+        return response.data;
+    },
+
     // Threads (Fuseki-backed disc endpoints, Epic 16)
     getDiscThreads: async (tesseraId: string, designSpaceId: string): Promise<DiscThread[]> => {
         const response = await apiClient.get<DiscThread[]>('/threads', {
@@ -554,10 +562,11 @@ export const api = {
         return response.data;
     },
 
-    createDiscThread: async (tesseraId: string, designSpaceId: string): Promise<{ thread_id: string }> => {
+    createDiscThread: async (tesseraId: string, designSpaceId: string, title?: string): Promise<{ thread_id: string }> => {
         const response = await apiClient.post<{ thread_id: string }>('/threads', {
             tessera_id: tesseraId,
             design_space_id: designSpaceId,
+            title: title ?? null,
         });
         return response.data;
     },
@@ -603,7 +612,9 @@ export interface DiscThread {
     tessera_id: string;
     design_space_id: string;
     started_by: string;
+    started_by_name: string;
     started_at: string;
+    title: string | null;
 }
 
 export interface DiscContribution {
@@ -614,6 +625,7 @@ export interface DiscContribution {
     contribution_type: string;
     message_content: string;
     contributed_by: string;
+    contributed_by_name: string;
     contributed_at: string;
     evidence_id: string | null;
 }


### PR DESCRIPTION
## Summary

- **403 fix**: members with a theme-level role were blocked from accessing DesignSpaces because the permission check used the project ID. The endpoint now accepts a `theme_id` query param as the check entity; `ValorWorkspace` passes the `themeId` prop accordingly.
- **Author names**: `FloatingThreadPanel` was rendering raw UUIDs instead of display names — fixed by using `started_by_name` / `contributed_by_name` from the API response (backend already resolved names via Neo4j).
- **Thread titles**: restored the ability to name a discussion thread (was lost in the Fuseki migration). Title stored as `rdfs:label "@nl"` on `disc:DiscussionThread`; shown in the thread list with a date fallback when absent.

## Test plan

- [ ] Open workspace als gebruiker met alleen een ThemeBase-rol → FloatingThreadPanel laadt zonder 403
- [ ] Open FloatingThreadPanel op een factor/claim → discussies laden correct
- [ ] Naam van bijdrager wordt getoond (niet UUID)
- [ ] Nieuwe discussie aanmaken met en zonder onderwerp → titel verschijnt in lijst
- [ ] Discussie zonder titel toont datumfallback in lijst
- [ ] Admin-gebruiker (volledige rechten) ervaart geen regressie

🤖 Generated with [Claude Code](https://claude.ai/claude-code)