### PR TITLE
feat(disc): US-16.6 — ThreadResolutie vanuit FloatingThreadPanel

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -102,6 +102,13 @@ async def root():
     return {"message": "Welcome to CAUSA API", "status": "running"}
 
 
+@app.get("/ontology/epistemic-statuses")
+async def list_epistemic_statuses():
+    """Retourneert alle EpistemicStatus instanties met Engels en Nederlands label (uit VALOR-O ontologie)."""
+    from app.services.ontology_cache import get_epistemic_statuses
+    return get_epistemic_statuses()
+
+
 @app.get("/health")
 async def health_check():
     is_connected = await verify_connectivity()

--- a/backend/app/routers/designspace.py
+++ b/backend/app/routers/designspace.py
@@ -83,6 +83,17 @@ async def list_design_spaces_by_project(
     return get_design_spaces_by_project(project_id)
 
 
+@router.get("/{design_space_id}/can-resolve")
+async def can_resolve_thread(
+    design_space_id: str,
+    user: dict = Depends(get_current_user),
+) -> dict:
+    """Geeft terug of de huidige gebruiker een thread mag resolveren (MODERATOR-rol vereist)."""
+    user_id = user["id"]
+    can = await check_permission(user_id, design_space_id, Role.MODERATOR)
+    return {"can_resolve": can}
+
+
 @router.post("/{design_space_id}/alternative/", response_model=DesignAlternativeResponse, status_code=201)
 async def create_alternative(
     design_space_id: str,

--- a/backend/app/services/ontology_cache.py
+++ b/backend/app/services/ontology_cache.py
@@ -31,6 +31,7 @@ _participant_role_data: dict[str, dict] = {}
 # RBAC role weights derived from ontology: "admin" → 30
 _rbac_role_weights: dict[str, int] = {}
 _disc_contribution_type_label_to_uri: dict[str, str] = {}  # "Vraag" → URI
+_status_uri_to_nl_label: dict[str, str] = {}  # URI → "Betwist" etc.
 
 
 _DISC_GRAPH = f"{VALOR_NS}disc"
@@ -40,7 +41,7 @@ async def load_ontology_cache() -> None:
     global _evidence_label_to_uri, _status_label_to_uri, _status_uri_to_label
     global _valid_transitions, _requires_decision_episode, _argue_label_to_uri
     global _uncertainty_label_to_uri, _participant_role_data, _rbac_role_weights
-    global _disc_contribution_type_label_to_uri
+    global _disc_contribution_type_label_to_uri, _status_uri_to_nl_label
 
     logger.info("[ontology-cache] Ontologie-data laden van Fuseki...")
 
@@ -72,6 +73,20 @@ async def load_ontology_cache() -> None:
     _status_label_to_uri = {row["label"]: row["uri"] for row in status_rows}
     _status_uri_to_label = {v: k for k, v in _status_label_to_uri.items()}
     logger.info("[ontology-cache] Epistemic statuses: %s", list(_status_label_to_uri.keys()))
+
+    nl_status_rows = await sparql_select_global(f"""
+        PREFIX valor: <{VALOR_NS}>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        SELECT ?uri ?label WHERE {{
+          GRAPH <{_TESSERA_GRAPH}> {{
+            ?uri a valor:EpistemicStatus ;
+                 rdfs:label ?label .
+            FILTER(lang(?label) = "nl")
+          }}
+        }}
+    """)
+    _status_uri_to_nl_label = {row["uri"]: row["label"] for row in nl_status_rows}
+    logger.info("[ontology-cache] Epistemic statuses (nl): %s", list(_status_uri_to_nl_label.values()))
 
     transition_rows = await sparql_select_global(f"""
         PREFIX valor: <{VALOR_NS}>
@@ -237,6 +252,14 @@ def has_voting_right(valor_role_label: str) -> bool:
 
 def get_disc_contribution_type_label_to_uri() -> dict[str, str]:
     return _disc_contribution_type_label_to_uri
+
+
+def get_epistemic_statuses() -> list[dict]:
+    """Retourneert alle EpistemicStatus instanties met Engels en Nederlands label."""
+    return [
+        {"uri": uri, "label_en": label_en, "label_nl": _status_uri_to_nl_label.get(uri, label_en)}
+        for label_en, uri in _status_label_to_uri.items()
+    ]
 
 
 def rbac_to_valor_role(rbac_role: str) -> str:

--- a/frontend/src/components/Chat/FloatingThreadPanel.tsx
+++ b/frontend/src/components/Chat/FloatingThreadPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import { X, Send, MessageSquare } from 'lucide-react';
+import { X, Send, MessageSquare, Gavel } from 'lucide-react';
 import { api, type DiscThread, type DiscContribution } from '../../services/api';
+import { Textarea } from '../ui/textarea';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { ScrollArea } from '../ui/scroll-area';
@@ -44,6 +45,12 @@ function shortUri(uri: string): string {
     return uri.split(':').pop() ?? uri;
 }
 
+interface EpistemicStatus {
+    uri: string;
+    label_en: string;
+    label_nl: string;
+}
+
 interface FloatingThreadPanelProps {
     tesseraId: string;
     designSpaceId?: string;
@@ -52,6 +59,7 @@ interface FloatingThreadPanelProps {
     onThreadCreated?: () => void;
     position?: { x: number; y: number };
     readOnly?: boolean;
+    canResolve?: boolean;
 }
 
 export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
@@ -62,6 +70,7 @@ export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
     onThreadCreated,
     position,
     readOnly = false,
+    canResolve = false,
 }) => {
     const [view, setView] = useState<'list' | 'contributions'>('list');
     const [threads, setThreads] = useState<DiscThread[]>([]);
@@ -72,9 +81,22 @@ export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
     const [loading, setLoading] = useState(false);
     const [newTitle, setNewTitle] = useState('');
 
+    // Resolution state
+    const [epistemicStatuses, setEpistemicStatuses] = useState<EpistemicStatus[]>([]);
+    const [resolveOutcome, setResolveOutcome] = useState('');
+    const [resolveRationale, setResolveRationale] = useState('');
+    const [resolving, setResolving] = useState(false);
+    const [resolveResult, setResolveResult] = useState<{ label_nl: string } | null>(null);
+
     useEffect(() => {
         if (designSpaceId) loadThreads();
     }, [tesseraId, designSpaceId]);
+
+    useEffect(() => {
+        if (canResolve && view === 'contributions') {
+            api.getEpistemicStatuses().then(setEpistemicStatuses).catch(() => {});
+        }
+    }, [canResolve, view]);
 
     const loadThreads = async () => {
         if (!designSpaceId) return;
@@ -94,6 +116,9 @@ export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
 
     const openThread = async (thread: DiscThread) => {
         setActiveThread(thread);
+        setResolveResult(null);
+        setResolveOutcome('');
+        setResolveRationale('');
         setLoading(true);
         try {
             const data = await api.getDiscContributions(thread.thread_id, designSpaceId!);
@@ -139,13 +164,32 @@ export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
         }
     };
 
+    const handleResolve = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!activeThread || !resolveOutcome || !resolveRationale.trim()) return;
+        setResolving(true);
+        try {
+            await api.resolveDiscThread(activeThread.thread_id, {
+                design_space_id: designSpaceId!,
+                resolution_outcome: resolveOutcome,
+                resolution_rationale: resolveRationale.trim(),
+            });
+            const status = epistemicStatuses.find(s => s.label_en === resolveOutcome);
+            setResolveResult({ label_nl: status?.label_nl ?? resolveOutcome });
+        } catch (e) {
+            console.error('[FloatingThreadPanel] handleResolve:', e);
+        } finally {
+            setResolving(false);
+        }
+    };
+
     return (
         <Card
             className="fixed z-50 w-80 shadow-2xl flex flex-col overflow-hidden"
             style={{
                 left: position ? position.x : '50%',
                 top: position ? position.y : '50%',
-                maxHeight: '520px',
+                maxHeight: '560px',
                 transform: position ? 'none' : 'translate(-50%, -50%)',
             }}
         >
@@ -296,7 +340,16 @@ export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
                             </div>
                         </ScrollArea>
 
-                        {!readOnly && (
+                        {/* Resolution banner (na succesvolle resolve) */}
+                        {resolveResult && (
+                            <div className="px-3 py-2 bg-emerald-50 border-t border-emerald-200 text-xs text-emerald-800 flex items-center gap-1.5">
+                                <Gavel className="h-3.5 w-3.5 shrink-0" />
+                                <span>Thread afgesloten als <strong>{resolveResult.label_nl}</strong></span>
+                            </div>
+                        )}
+
+                        {/* Contribution form */}
+                        {!readOnly && !resolveResult && (
                             <form onSubmit={handleSendContribution} className="p-2 border-t space-y-2">
                                 <Select
                                     value={newType}
@@ -329,6 +382,48 @@ export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
                                         <Send className="h-3.5 w-3.5" />
                                     </Button>
                                 </div>
+                            </form>
+                        )}
+
+                        {/* Resolution form (alleen voor moderator) */}
+                        {canResolve && !resolveResult && (
+                            <form onSubmit={handleResolve} className="p-2 border-t space-y-2 bg-muted/10">
+                                <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground font-medium uppercase tracking-wide">
+                                    <Gavel className="h-3 w-3" />
+                                    Afsluiten
+                                </div>
+                                <Select
+                                    value={resolveOutcome}
+                                    onValueChange={setResolveOutcome}
+                                >
+                                    <SelectTrigger className="h-7 text-xs">
+                                        <SelectValue placeholder="Uitkomst kiezen..." />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {epistemicStatuses.map(s => (
+                                            <SelectItem key={s.uri} value={s.label_en} className="text-xs">
+                                                {s.label_nl}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                                <Textarea
+                                    value={resolveRationale}
+                                    onChange={e => setResolveRationale(e.target.value)}
+                                    placeholder="Motivatie voor afsluiting..."
+                                    className="text-xs min-h-[48px] resize-none"
+                                    rows={2}
+                                />
+                                <Button
+                                    type="submit"
+                                    size="sm"
+                                    variant="outline"
+                                    className="w-full h-7 text-xs"
+                                    disabled={!resolveOutcome || !resolveRationale.trim() || resolving}
+                                >
+                                    <Gavel className="h-3 w-3 mr-1.5" />
+                                    {resolving ? 'Bezig...' : 'Thread Afsluiten'}
+                                </Button>
                             </form>
                         )}
                     </>

--- a/frontend/src/components/Workspace/ValorWorkspace.tsx
+++ b/frontend/src/components/Workspace/ValorWorkspace.tsx
@@ -47,12 +47,17 @@ export const ValorWorkspace: React.FC<ValorWorkspaceProps> = ({ projectId, theme
 
     // DesignSpace voor disc threads
     const [activeDesignSpaceId, setActiveDesignSpaceId] = useState<string | undefined>(undefined);
+    const [userCanResolve, setUserCanResolve] = useState(false);
 
     useEffect(() => {
         api.getDesignSpacesByProject(projectId, themeId).then(spaces => {
             const active = spaces.find(s => s.status === 'active') ?? spaces[0];
-            if (active) setActiveDesignSpaceId(active.id);
-            else console.warn('[ValorWorkspace] Geen actieve DesignSpace gevonden voor project', projectId, spaces);
+            if (active) {
+                setActiveDesignSpaceId(active.id);
+                api.getCanResolveThread(active.id)
+                    .then(r => setUserCanResolve(r.can_resolve))
+                    .catch(() => setUserCanResolve(false));
+            } else console.warn('[ValorWorkspace] Geen actieve DesignSpace gevonden voor project', projectId, spaces);
         }).catch(err => console.error('[ValorWorkspace] Fout bij ophalen DesignSpaces:', err));
     }, [projectId, themeId]);
 
@@ -223,6 +228,7 @@ export const ValorWorkspace: React.FC<ValorWorkspaceProps> = ({ projectId, theme
                                 versionId={currentViewedVersion?.id}
                                 isReadOnly={isReadOnly}
                                 designSpaceId={activeDesignSpaceId}
+                                canResolveThread={userCanResolve}
                             />
                         </div>
                     </div>

--- a/frontend/src/perspectives/causa/Shell.tsx
+++ b/frontend/src/perspectives/causa/Shell.tsx
@@ -39,9 +39,10 @@ export interface CausaShellProps {
     versionId?: string;
     isReadOnly?: boolean;
     designSpaceId?: string;
+    canResolveThread?: boolean;
 }
 
-export const CausaShell = ({ themeId, websocket, currentUserId, onSelect, onOpenConversation, versionId, isReadOnly = false, designSpaceId }: CausaShellProps) => {
+export const CausaShell = ({ themeId, websocket, currentUserId, onSelect, onOpenConversation, versionId, isReadOnly = false, designSpaceId, canResolveThread = false }: CausaShellProps) => {
     const queryClient = useQueryClient();
     const themeState = useTheme();
 
@@ -331,6 +332,7 @@ export const CausaShell = ({ themeId, websocket, currentUserId, onSelect, onOpen
                 onConnect={effectiveIsReadOnly ? undefined : handleConnect}
                 isReadOnly={effectiveIsReadOnly}
                 designSpaceId={designSpaceId}
+                canResolveThread={canResolveThread}
             />
 
             {/* Modals */}

--- a/frontend/src/perspectives/causa/views/CLDView.tsx
+++ b/frontend/src/perspectives/causa/views/CLDView.tsx
@@ -40,6 +40,7 @@ interface CLDViewProps {
     onConnect?: (connection: Connection) => void;
     isReadOnly?: boolean;
     designSpaceId?: string;
+    canResolveThread?: boolean;
 }
 
 
@@ -68,6 +69,7 @@ export const CLDView: FunctionComponent<CLDViewProps> = ({
     onConnect,
     isReadOnly = false,
     designSpaceId,
+    canResolveThread = false,
 }) => {
     // React Flow State
     const [rfInstance, setRfInstance] = useState<any>(null);
@@ -450,6 +452,7 @@ export const CLDView: FunctionComponent<CLDViewProps> = ({
                     }}
                     onThreadCreated={fetchThreadStats}
                     readOnly={isReadOnly}
+                    canResolve={canResolveThread}
                 />
             )}
         </div >

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -554,7 +554,26 @@ export const api = {
         return response.data;
     },
 
+    // Ontologie endpoints
+    getEpistemicStatuses: async (): Promise<{ uri: string; label_en: string; label_nl: string }[]> => {
+        const response = await apiClient.get('/ontology/epistemic-statuses');
+        return response.data;
+    },
+
     // Threads (Fuseki-backed disc endpoints, Epic 16)
+    getCanResolveThread: async (designSpaceId: string): Promise<{ can_resolve: boolean }> => {
+        const response = await apiClient.get<{ can_resolve: boolean }>(`/designspace/${designSpaceId}/can-resolve`);
+        return response.data;
+    },
+
+    resolveDiscThread: async (
+        threadId: string,
+        body: { design_space_id: string; resolution_outcome: string; resolution_rationale: string }
+    ): Promise<{ resolution_id: string; thread_id: string; tessera_id: string; previous_status: string; new_status: string }> => {
+        const response = await apiClient.post(`/threads/${threadId}/resolve`, body);
+        return response.data;
+    },
+
     getDiscThreads: async (tesseraId: string, designSpaceId: string): Promise<DiscThread[]> => {
         const response = await apiClient.get<DiscThread[]>('/threads', {
             params: { tessera_id: tesseraId, design_space_id: designSpaceId },


### PR DESCRIPTION
## Summary
- Voegt resolution-sectie toe aan FloatingThreadPanel (alleen zichtbaar voor moderator/admin)
- Uitkomst-dropdown gevuld vanuit VALOR-O ontologie via nieuw endpoint `GET /ontology/epistemic-statuses` — geen hardcodering
- Na afsluiting: groene banner met uitkomst, bijdrageformulier verborgen
- Prop-chain `ValorWorkspace → CausaShell → CLDView → FloatingThreadPanel` voor `canResolve`

## Test plan
- [ ] Inloggen als moderator → FloatingThreadPanel openen → "Afsluiten" sectie zichtbaar onderaan
- [ ] Inloggen als member/viewer → "Afsluiten" sectie niet zichtbaar
- [ ] Uitkomst kiezen (dropdown toont Nederlandse labels uit ontologie) + motivatie invullen → "Thread Afsluiten" knop actief
- [ ] Na submit: groene banner toont uitkomst, bijdrageformulier verdwijnt
- [ ] `GET /ontology/epistemic-statuses` retourneert 5 statussen met `label_en` + `label_nl`

Closes #416

🤖 Generated with [Claude Code](https://claude.ai/claude-code)