### PR TITLE
fix(deploy): correcte migratieketen bij opstarten

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,4 +20,4 @@ EXPOSE 8000
 # Command to run the application in production mode (no reload)
 # Command to run the application in production mode (no reload)
 # Use shell execution to expand PORT environment variable (default 8000)
-CMD ["sh", "-c", "python scripts/migrate_space_to_version.py && python scripts/migrate_neo4j_threads_to_fuseki.py && uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]
+CMD ["sh", "-c", "python scripts/migrate_themeversions_to_designspaces.py && python scripts/migrate_neo4j_threads_to_fuseki.py && uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]


### PR DESCRIPTION
## Hotfix — migratieketen

Corrigeert de Dockerfile CMD:

- **Verwijderd:** `migrate_space_to_version.py` (verouderd, al lang uitgevoerd in productie)
- **Toegevoegd:** `migrate_themeversions_to_designspaces.py` — migreert alle ThemeVersions inclusief Factors en Claims als Tesserae naar Fuseki DesignSpaces
- **Volgorde gewaarborgd:** DesignSpaces worden aangemaakt vóór de thread-migratie (threads vereisen een bestaande DesignSpace)

Nieuwe opstartketen:
1. `migrate_themeversions_to_designspaces.py` — Factors + Claims → Fuseki
2. `migrate_neo4j_threads_to_fuseki.py` — ConversationThreads → Fuseki
3. `uvicorn` opstarten