### PR TITLE
fix(migration): HAS_VERSION én HAS_ACTIVE_VERSION ondersteunen in DesignSpace-migratie

### DIFF
--- a/backend/scripts/migrate_themeversions_to_designspaces.py
+++ b/backend/scripts/migrate_themeversions_to_designspaces.py
@@ -34,7 +34,7 @@ def _get_active_theme_versions(driver) -> list[dict]:
     """Geeft alle actieve ThemeVersions met hun ThemeBase en organisatiehiërarchie."""
     query = """
     MATCH (org:Organization)-[:OWNS]->(p:Project)-[:HAS_THEME]->(t:ThemeBase)
-    MATCH (t)-[:HAS_ACTIVE_VERSION]->(v:ThemeVersion)
+    MATCH (t)-[:HAS_ACTIVE_VERSION|HAS_VERSION]->(v:ThemeVersion)
     WHERE v.valid_to IS NULL
     RETURN
         t.id          AS theme_base_id,


### PR DESCRIPTION
## Rootcause

In productie zijn ThemeVersions via `HAS_VERSION` aan ThemeBase gekoppeld (aangemaakt door de oude `migrate_space_to_version.py` migratie). De `migrate_themeversions_to_designspaces.py` zocht alleen op `HAS_ACTIVE_VERSION` → vond 0 ThemeVersions → geen DesignSpaces aangemaakt → "Geen DesignSpace gekoppeld" in FloatingThreadPanel.

Bewijs: `sessions.py` gebruikt `(v)<-[:HAS_VERSION]-(t:ThemeBase)`, de nieuwe code gebruikt `HAS_ACTIVE_VERSION`.

## Fix

```cypher
-- Oud
MATCH (t)-[:HAS_ACTIVE_VERSION]->(v:ThemeVersion)

-- Nieuw
MATCH (t)-[:HAS_ACTIVE_VERSION|HAS_VERSION]->(v:ThemeVersion)
```

Bij de volgende deploy draait de migratie opnieuw (idempotent) en vindt nu wél de productie-ThemeVersions.