### PR TITLE
fix(migration): HAS_VERSION én HAS_ACTIVE_VERSION — productiefix DesignSpace

### DIFF
--- a/backend/scripts/migrate_themeversions_to_designspaces.py
+++ b/backend/scripts/migrate_themeversions_to_designspaces.py
@@ -34,7 +34,7 @@ def _get_active_theme_versions(driver) -> list[dict]:
     """Geeft alle actieve ThemeVersions met hun ThemeBase en organisatiehiërarchie."""
     query = """
     MATCH (org:Organization)-[:OWNS]->(p:Project)-[:HAS_THEME]->(t:ThemeBase)
-    MATCH (t)-[:HAS_ACTIVE_VERSION]->(v:ThemeVersion)
+    MATCH (t)-[:HAS_ACTIVE_VERSION|HAS_VERSION]->(v:ThemeVersion)
     WHERE v.valid_to IS NULL
     RETURN
         t.id          AS theme_base_id,


### PR DESCRIPTION
## Hotfix productie

Corrigeert de migratiescriptfout waardoor in productie geen DesignSpaces werden aangemaakt, en de melding "Geen DesignSpace gekoppeld" verscheen.

**Rootcause:** `migrate_themeversions_to_designspaces.py` zocht alleen op `HAS_ACTIVE_VERSION`, maar productiedata heeft `HAS_VERSION` relaties (aangemaakt door de oude `migrate_space_to_version.py` migratie).

**Fix:** Query uitgebreid naar `HAS_ACTIVE_VERSION|HAS_VERSION`.

Bij de volgende deploy draait de migratie opnieuw (idempotent) en vindt nu wél de productie-ThemeVersions → DesignSpaces + Tesserae worden aangemaakt.