### PR TITLE
feat(US-11.2): Neo4j kennisroutes uitschakelen, Fuseki als enige kennisbron

### DIFF
--- a/backend/app/db/fuseki_knowledge.py
+++ b/backend/app/db/fuseki_knowledge.py
@@ -1,0 +1,446 @@
+"""SPARQL-gebaseerde lees- en schrijffuncties voor Factors en Claims in Fuseki.
+
+Vervangt de Neo4j knowledge-laag (app/db/knowledge.py) voor inhoudelijke kennisdata.
+
+Architectuur na US-11.2:
+- Neo4j : User, Org, Project, Theme, ThemeVersion, DesignSpace — identiteit + RBAC
+- Fuseki: Factors, Claims als valor:Tessera — alle inhoudelijke kennisdata
+
+Elke Tessera heeft een `valor:baseId` property (plain string UUID).
+Dit is de canonieke `id` die de API teruggeeft, ongeacht de URI-structuur.
+"""
+import asyncio
+import uuid
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+from app.ontology import VALOR_NS
+from app.db.utils import get_driver
+from app.services.fuseki import sparql_select_global, sparql_update
+
+logger = logging.getLogger(__name__)
+
+_XSD = "http://www.w3.org/2001/XMLSchema#"
+_TESSERA_PREFIX = "urn:valor:tessera:"
+
+
+# ---------------------------------------------------------------------------
+# URI helpers
+# ---------------------------------------------------------------------------
+
+def _tessera_uri(tessera_id: str) -> str:
+    return f"{_TESSERA_PREFIX}{tessera_id}"
+
+
+def _ds_asis_graph(ds_id: str) -> str:
+    return f"urn:valor:ds:{ds_id}/asis"
+
+
+def _escape(text: str) -> str:
+    return text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "")
+
+
+# ---------------------------------------------------------------------------
+# Neo4j hiërarchie-lookups (geen kennisdata)
+# ---------------------------------------------------------------------------
+
+def _get_designspace_id_for_version_sync(version_id: str) -> Optional[str]:
+    driver = get_driver()
+    with driver.session() as s:
+        r = s.run(
+            "MATCH (v:ThemeVersion {id: $vid})-[:HAS_DESIGN_SPACE]->(ds:DesignSpace) RETURN ds.id AS ds_id",
+            {"vid": version_id},
+        ).single()
+    return r["ds_id"] if r else None
+
+
+def _get_active_version_id_for_theme_sync(theme_id: str) -> Optional[str]:
+    driver = get_driver()
+    with driver.session() as s:
+        r = s.run(
+            """MATCH (t:ThemeBase {id: $tid})-[:HAS_VERSION]->(v:ThemeVersion)
+               WHERE v.valid_to IS NULL RETURN v.id AS vid""",
+            {"tid": theme_id},
+        ).single()
+    return r["vid"] if r else None
+
+
+def _get_project_id_for_designspace_sync(ds_id: str) -> Optional[str]:
+    driver = get_driver()
+    with driver.session() as s:
+        r = s.run(
+            "MATCH (p:Project)-[:HAS_DESIGN_SPACE]->(ds:DesignSpace {id: $ds_id}) RETURN p.id AS pid",
+            {"ds_id": ds_id},
+        ).single()
+    return r["pid"] if r else None
+
+
+async def get_designspace_id_for_version(version_id: str) -> Optional[str]:
+    return await asyncio.to_thread(_get_designspace_id_for_version_sync, version_id)
+
+
+async def get_project_id_for_designspace(ds_id: str) -> Optional[str]:
+    return await asyncio.to_thread(_get_project_id_for_designspace_sync, ds_id)
+
+
+# ---------------------------------------------------------------------------
+# Fuseki context-lookups
+# ---------------------------------------------------------------------------
+
+async def get_designspace_id_for_tessera(tessera_id: str) -> Optional[str]:
+    """Zoekt de DesignSpace ID voor een Tessera via Fuseki SPARQL (valor:inDesignSpace)."""
+    tessera_uri = _tessera_uri(tessera_id)
+    rows = await sparql_select_global(
+        f"SELECT ?ds WHERE {{ GRAPH ?g {{ <{tessera_uri}> <{VALOR_NS}inDesignSpace> ?ds }} }}"
+    )
+    if not rows:
+        return None
+    ds_uri = rows[0]["ds"]
+    prefix = "urn:valor:ds:"
+    return ds_uri[len(prefix):] if ds_uri.startswith(prefix) else ds_uri
+
+
+async def _find_tessera_uri_by_base_id(ds_id: str, base_id: str) -> Optional[str]:
+    """Vindt de werkelijke tessera-URI voor een base_id in de asis-graph (voor claim-schrijven)."""
+    asis_graph = _ds_asis_graph(ds_id)
+    rows = await sparql_select_global(
+        f'SELECT ?t WHERE {{ GRAPH <{asis_graph}> {{ ?t <{VALOR_NS}baseId> "{base_id}" }} }}'
+    )
+    return rows[0]["t"] if rows else _tessera_uri(base_id)
+
+
+# ---------------------------------------------------------------------------
+# Factor reads (SPARQL)
+# ---------------------------------------------------------------------------
+
+async def get_factors_for_version(version_id: str) -> list[dict]:
+    ds_id = await get_designspace_id_for_version(version_id)
+    if not ds_id:
+        return []
+    return await _sparql_get_factors(ds_id)
+
+
+async def get_factors_for_theme(theme_id: str) -> list[dict]:
+    version_id = await asyncio.to_thread(_get_active_version_id_for_theme_sync, theme_id)
+    if not version_id:
+        return []
+    return await get_factors_for_version(version_id)
+
+
+async def _sparql_get_factors(ds_id: str) -> list[dict]:
+    asis_graph = _ds_asis_graph(ds_id)
+    rows = await sparql_select_global(f"""
+SELECT ?tessera ?baseId ?name ?role ?description WHERE {{
+  GRAPH <{asis_graph}> {{
+    ?tessera a <{VALOR_NS}Tessera> ;
+             <{VALOR_NS}baseId> ?baseId ;
+             <{VALOR_NS}claimContent> ?name ;
+             <{VALOR_NS}factorRole> ?role .
+    OPTIONAL {{ ?tessera <{VALOR_NS}description> ?description }}
+    FILTER NOT EXISTS {{ ?tessera <{VALOR_NS}fromFactor> ?x }}
+  }}
+}}
+""")
+    return [
+        {
+            "id": row["baseId"],
+            "version_id": row["baseId"],
+            "name": row["name"],
+            "description": row.get("description"),
+            "type": row.get("role"),
+            "theme_id": None,
+            "thread_id": None,
+        }
+        for row in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Factor writes (SPARQL)
+# ---------------------------------------------------------------------------
+
+async def create_factor_fuseki(
+    ds_id: str,
+    name: str,
+    role: str,
+    user_id: str,
+    description: Optional[str] = None,
+) -> str:
+    """Maakt een nieuwe Factor-Tessera aan in Fuseki. Retourneert de base_id."""
+    base_id = str(uuid.uuid4())
+    tessera_uri = _tessera_uri(base_id)
+    asis_graph = _ds_asis_graph(ds_id)
+    user_uri = f"urn:valor:user:{user_id}"
+    claimed_at = datetime.now(timezone.utc).isoformat()
+    proposed_uri = f"{VALOR_NS}ProposedStatus"
+    as_is_uri = f"{VALOR_NS}AsIsType"
+    desc_triple = (
+        f'<{tessera_uri}> <{VALOR_NS}description> "{_escape(description)}"@nl .'
+        if description else ""
+    )
+
+    sparql = f"""INSERT DATA {{
+  GRAPH <{asis_graph}> {{
+    <{tessera_uri}> a <{VALOR_NS}Tessera> ;
+      <{VALOR_NS}baseId> "{base_id}" ;
+      <{VALOR_NS}claimContent> "{_escape(name)}"@nl ;
+      <{VALOR_NS}factorRole> "{_escape(role)}" ;
+      <{VALOR_NS}claimType> <{as_is_uri}> ;
+      <{VALOR_NS}epistemicStatus> <{proposed_uri}> ;
+      <{VALOR_NS}claimedBy> <{user_uri}> ;
+      <{VALOR_NS}claimedAt> "{claimed_at}"^^<{_XSD}dateTime> ;
+      <{VALOR_NS}inDesignSpace> <urn:valor:ds:{ds_id}> .
+    {desc_triple}
+  }}
+}}"""
+    await sparql_update(sparql, ds_id)
+    return base_id
+
+
+async def update_factor_fuseki(
+    tessera_id: str,
+    ds_id: str,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    role: Optional[str] = None,
+) -> None:
+    """Werkt een bestaande Factor-Tessera bij in Fuseki (alleen opgegeven velden)."""
+    tessera_uri = _tessera_uri(tessera_id)
+    asis_graph = _ds_asis_graph(ds_id)
+
+    deletes, inserts, optionals = [], [], []
+
+    if name is not None:
+        deletes.append(f"<{tessera_uri}> <{VALOR_NS}claimContent> ?oldName .")
+        inserts.append(f'<{tessera_uri}> <{VALOR_NS}claimContent> "{_escape(name)}"@nl .')
+        optionals.append(f"OPTIONAL {{ <{tessera_uri}> <{VALOR_NS}claimContent> ?oldName }}")
+
+    if role is not None:
+        deletes.append(f"<{tessera_uri}> <{VALOR_NS}factorRole> ?oldRole .")
+        inserts.append(f'<{tessera_uri}> <{VALOR_NS}factorRole> "{_escape(role)}" .')
+        optionals.append(f"OPTIONAL {{ <{tessera_uri}> <{VALOR_NS}factorRole> ?oldRole }}")
+
+    if description is not None:
+        deletes.append(f"<{tessera_uri}> <{VALOR_NS}description> ?oldDesc .")
+        inserts.append(f'<{tessera_uri}> <{VALOR_NS}description> "{_escape(description)}"@nl .')
+        optionals.append(f"OPTIONAL {{ <{tessera_uri}> <{VALOR_NS}description> ?oldDesc }}")
+
+    if not deletes:
+        return
+
+    sparql = f"""DELETE {{
+  GRAPH <{asis_graph}> {{
+    {" ".join(deletes)}
+  }}
+}}
+INSERT {{
+  GRAPH <{asis_graph}> {{
+    {" ".join(inserts)}
+  }}
+}}
+WHERE {{
+  GRAPH <{asis_graph}> {{
+    <{tessera_uri}> a <{VALOR_NS}Tessera> .
+    {" ".join(optionals)}
+  }}
+}}"""
+    await sparql_update(sparql, ds_id)
+
+
+async def delete_factor_fuseki(tessera_id: str, ds_id: str) -> None:
+    """Verwijdert een Factor-Tessera volledig uit de asis-graph."""
+    tessera_uri = _tessera_uri(tessera_id)
+    asis_graph = _ds_asis_graph(ds_id)
+    sparql = f"""DELETE {{
+  GRAPH <{asis_graph}> {{ <{tessera_uri}> ?p ?o . }}
+}}
+WHERE {{
+  GRAPH <{asis_graph}> {{ <{tessera_uri}> ?p ?o . }}
+}}"""
+    await sparql_update(sparql, ds_id)
+
+
+# ---------------------------------------------------------------------------
+# Claim reads (SPARQL)
+# ---------------------------------------------------------------------------
+
+async def get_claims_for_version(version_id: str) -> list[dict]:
+    ds_id = await get_designspace_id_for_version(version_id)
+    if not ds_id:
+        return []
+    return await _sparql_get_claims(ds_id)
+
+
+async def get_claims_for_theme(theme_id: str) -> list[dict]:
+    version_id = await asyncio.to_thread(_get_active_version_id_for_theme_sync, theme_id)
+    if not version_id:
+        return []
+    return await get_claims_for_version(version_id)
+
+
+async def _sparql_get_claims(ds_id: str) -> list[dict]:
+    asis_graph = _ds_asis_graph(ds_id)
+    rows = await sparql_select_global(f"""
+SELECT ?tessera ?baseId ?statement ?polarity ?confidence
+       ?fromFactor ?sourceBaseId ?toFactor ?targetBaseId
+       ?evidenceText ?claimedAt WHERE {{
+  GRAPH <{asis_graph}> {{
+    ?tessera a <{VALOR_NS}Tessera> ;
+             <{VALOR_NS}baseId> ?baseId ;
+             <{VALOR_NS}claimContent> ?statement ;
+             <{VALOR_NS}fromFactor> ?fromFactor ;
+             <{VALOR_NS}toFactor> ?toFactor .
+    ?fromFactor <{VALOR_NS}baseId> ?sourceBaseId .
+    ?toFactor   <{VALOR_NS}baseId> ?targetBaseId .
+    OPTIONAL {{ ?tessera <{VALOR_NS}polarity>     ?polarity }}
+    OPTIONAL {{ ?tessera <{VALOR_NS}confidence>   ?confidence }}
+    OPTIONAL {{ ?tessera <{VALOR_NS}evidenceText> ?evidenceText }}
+    OPTIONAL {{ ?tessera <{VALOR_NS}claimedAt>    ?claimedAt }}
+  }}
+}}
+""")
+    return [
+        {
+            "id": row["baseId"],
+            "version_id": row["baseId"],
+            "statement": row.get("statement", ""),
+            "polarity": row.get("polarity", "+"),
+            "confidence": float(row["confidence"]) if row.get("confidence") else 0.5,
+            "evidence_text": row.get("evidenceText"),
+            "evidence_url": None,
+            "source_id": row["sourceBaseId"],
+            "target_id": row["targetBaseId"],
+            "source_version_id": row["sourceBaseId"],
+            "target_version_id": row["targetBaseId"],
+            "claim_thread_id": None,
+            "source_thread_id": None,
+            "target_thread_id": None,
+            "created_at": row.get("claimedAt"),
+            "created_by": None,
+            "status": None,
+        }
+        for row in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Claim writes (SPARQL)
+# ---------------------------------------------------------------------------
+
+async def create_claim_fuseki(
+    ds_id: str,
+    source_id: str,
+    target_id: str,
+    statement: str,
+    polarity: str,
+    user_id: str,
+    confidence: float = 1.0,
+    evidence_text: Optional[str] = None,
+    evidence_url: Optional[str] = None,
+) -> str:
+    """Maakt een nieuwe Claim-Tessera aan in Fuseki.
+
+    source_id en target_id zijn base_ids van de factor-Tesserae.
+    De werkelijke Tessera-URI's worden opgezocht via valor:baseId in de asis-graph,
+    zodat zowel gemigreerde als nieuwe factors correct worden gerefereerd.
+    """
+    base_id = str(uuid.uuid4())
+    tessera_uri = _tessera_uri(base_id)
+    asis_graph = _ds_asis_graph(ds_id)
+    user_uri = f"urn:valor:user:{user_id}"
+    claimed_at = datetime.now(timezone.utc).isoformat()
+    proposed_uri = f"{VALOR_NS}ProposedStatus"
+
+    # Zoek de werkelijke tessera-URIs op via valor:baseId
+    source_uri = await _find_tessera_uri_by_base_id(ds_id, source_id)
+    target_uri = await _find_tessera_uri_by_base_id(ds_id, target_id)
+
+    evidence_triple = (
+        f'<{tessera_uri}> <{VALOR_NS}evidenceText> "{_escape(evidence_text)}"@nl .'
+        if evidence_text else ""
+    )
+
+    sparql = f"""INSERT DATA {{
+  GRAPH <{asis_graph}> {{
+    <{tessera_uri}> a <{VALOR_NS}Tessera> ;
+      <{VALOR_NS}baseId> "{base_id}" ;
+      <{VALOR_NS}claimContent> "{_escape(statement)}"@nl ;
+      <{VALOR_NS}fromFactor> <{source_uri}> ;
+      <{VALOR_NS}toFactor> <{target_uri}> ;
+      <{VALOR_NS}polarity> "{_escape(polarity)}" ;
+      <{VALOR_NS}confidence> "{confidence}"^^<{_XSD}double> ;
+      <{VALOR_NS}epistemicStatus> <{proposed_uri}> ;
+      <{VALOR_NS}claimedBy> <{user_uri}> ;
+      <{VALOR_NS}claimedAt> "{claimed_at}"^^<{_XSD}dateTime> ;
+      <{VALOR_NS}inDesignSpace> <urn:valor:ds:{ds_id}> .
+    {evidence_triple}
+  }}
+}}"""
+    await sparql_update(sparql, ds_id)
+    return base_id
+
+
+async def update_claim_fuseki(
+    tessera_id: str,
+    ds_id: str,
+    statement: Optional[str] = None,
+    polarity: Optional[str] = None,
+    confidence: Optional[float] = None,
+    evidence_text: Optional[str] = None,
+) -> None:
+    """Werkt een bestaande Claim-Tessera bij in Fuseki (alleen opgegeven velden)."""
+    tessera_uri = _tessera_uri(tessera_id)
+    asis_graph = _ds_asis_graph(ds_id)
+
+    deletes, inserts, optionals = [], [], []
+
+    if statement is not None:
+        deletes.append(f"<{tessera_uri}> <{VALOR_NS}claimContent> ?oldStmt .")
+        inserts.append(f'<{tessera_uri}> <{VALOR_NS}claimContent> "{_escape(statement)}"@nl .')
+        optionals.append(f"OPTIONAL {{ <{tessera_uri}> <{VALOR_NS}claimContent> ?oldStmt }}")
+
+    if polarity is not None:
+        deletes.append(f"<{tessera_uri}> <{VALOR_NS}polarity> ?oldPol .")
+        inserts.append(f'<{tessera_uri}> <{VALOR_NS}polarity> "{_escape(polarity)}" .')
+        optionals.append(f"OPTIONAL {{ <{tessera_uri}> <{VALOR_NS}polarity> ?oldPol }}")
+
+    if confidence is not None:
+        deletes.append(f"<{tessera_uri}> <{VALOR_NS}confidence> ?oldConf .")
+        inserts.append(f'<{tessera_uri}> <{VALOR_NS}confidence> "{confidence}"^^<{_XSD}double> .')
+        optionals.append(f"OPTIONAL {{ <{tessera_uri}> <{VALOR_NS}confidence> ?oldConf }}")
+
+    if evidence_text is not None:
+        deletes.append(f"<{tessera_uri}> <{VALOR_NS}evidenceText> ?oldEvid .")
+        inserts.append(f'<{tessera_uri}> <{VALOR_NS}evidenceText> "{_escape(evidence_text)}"@nl .')
+        optionals.append(f"OPTIONAL {{ <{tessera_uri}> <{VALOR_NS}evidenceText> ?oldEvid }}")
+
+    if not deletes:
+        return
+
+    sparql = f"""DELETE {{
+  GRAPH <{asis_graph}> {{ {" ".join(deletes)} }}
+}}
+INSERT {{
+  GRAPH <{asis_graph}> {{ {" ".join(inserts)} }}
+}}
+WHERE {{
+  GRAPH <{asis_graph}> {{
+    <{tessera_uri}> a <{VALOR_NS}Tessera> .
+    {" ".join(optionals)}
+  }}
+}}"""
+    await sparql_update(sparql, ds_id)
+
+
+async def delete_claim_fuseki(tessera_id: str, ds_id: str) -> None:
+    """Verwijdert een Claim-Tessera volledig uit de asis-graph."""
+    tessera_uri = _tessera_uri(tessera_id)
+    asis_graph = _ds_asis_graph(ds_id)
+    sparql = f"""DELETE {{
+  GRAPH <{asis_graph}> {{ <{tessera_uri}> ?p ?o . }}
+}}
+WHERE {{
+  GRAPH <{asis_graph}> {{ <{tessera_uri}> ?p ?o . }}
+}}"""
+    await sparql_update(sparql, ds_id)

--- a/backend/app/routers/claims.py
+++ b/backend/app/routers/claims.py
@@ -6,12 +6,12 @@ import logging
 from app.auth import get_current_user
 from app.models.domain import Role
 from app.db.crud import (
-    create_claim_manual, update_claim_manual, delete_claim_manual,
-    get_project_id_by_claim, get_version_id_by_claim, get_project_id_by_theme,
-    get_active_version_id_if_theme, get_claims_for_theme, check_permission,
+    get_project_id_by_theme,
+    get_active_version_id_if_theme,
+    check_permission,
 )
+from app.db import fuseki_knowledge
 from app.services.connection_manager import manager
-from app.services.fuseki_sync import try_write_claim
 
 logger = logging.getLogger(__name__)
 
@@ -41,40 +41,52 @@ class ClaimUpdate(BaseModel):
 
 @router.get("/themes/{theme_id}/claims")
 async def list_theme_claims(theme_id: str):
-    return await get_claims_for_theme(theme_id)
+    return await fuseki_knowledge.get_claims_for_theme(theme_id)
 
 
 @router.get("/versions/{version_id}/claims")
 async def list_version_claims(version_id: str):
-    from app.db.crud import get_claims_for_version
-    return await get_claims_for_version(version_id)
+    return await fuseki_knowledge.get_claims_for_version(version_id)
 
 
 @router.post("/claims_manual")
 async def create_claim(claim: ClaimManualCreate, user: dict = Depends(get_current_user)):
-    logger.info(f"Creating claim: {claim} by {user['id']}")
+    logger.info("Creating claim by %s in theme %s", user["id"], claim.theme_id)
+
     version_id = await get_active_version_id_if_theme(claim.theme_id) if claim.theme_id else None
     project_id = await get_project_id_by_theme(claim.theme_id) if claim.theme_id else None
-    check_entity = version_id or project_id
+    ds_id = await fuseki_knowledge.get_designspace_id_for_version(version_id) if version_id else None
+
+    check_entity = ds_id or project_id
     if not check_entity or not await check_permission(user["id"], check_entity, Role.MEMBER):
         raise HTTPException(status_code=403, detail="Geen toegang om een claim aan te maken")
-    cid = await create_claim_manual(
-        claim.theme_id,
-        claim.source_id,
-        claim.target_id,
-        claim.statement,
-        user["id"],
-        claim.polarity,
-        claim.confidence,
-        claim.evidence_text,
-        claim.evidence_url
+    if not ds_id:
+        raise HTTPException(status_code=422, detail="Geen actieve DesignSpace gevonden voor dit thema")
+
+    cid = await fuseki_knowledge.create_claim_fuseki(
+        ds_id=ds_id,
+        source_id=claim.source_id,
+        target_id=claim.target_id,
+        statement=claim.statement,
+        polarity=claim.polarity or "+",
+        user_id=user["id"],
+        confidence=claim.confidence or 1.0,
+        evidence_text=claim.evidence_text,
+        evidence_url=claim.evidence_url,
     )
-    await try_write_claim(cid, claim.source_id, claim.target_id, claim.polarity or "+", claim.theme_id)
 
     if project_id:
         await manager.broadcast_data(project_id, {
             "type": "CLAIM_CREATED",
-            "payload": {"id": cid, "source_id": claim.source_id, "target_id": claim.target_id, "theme_id": claim.theme_id, "statement": claim.statement, "evidence_text": claim.evidence_text, "evidence_url": claim.evidence_url}
+            "payload": {
+                "id": cid,
+                "source_id": claim.source_id,
+                "target_id": claim.target_id,
+                "theme_id": claim.theme_id,
+                "statement": claim.statement,
+                "evidence_text": claim.evidence_text,
+                "evidence_url": claim.evidence_url,
+            },
         })
 
     return {"status": "created", "id": cid}
@@ -82,40 +94,46 @@ async def create_claim(claim: ClaimManualCreate, user: dict = Depends(get_curren
 
 @router.patch("/claims/{claim_id}")
 async def update_claim_route(claim_id: str, claim: ClaimUpdate, user: dict = Depends(get_current_user)):
-    project_id = await get_project_id_by_claim(claim_id)
-    version_id = await get_version_id_by_claim(claim_id)
-    check_entity = version_id or project_id
-    if not check_entity or not await check_permission(user["id"], check_entity, Role.MEMBER):
+    ds_id = await fuseki_knowledge.get_designspace_id_for_tessera(claim_id)
+    if not ds_id:
+        raise HTTPException(status_code=404, detail="Claim niet gevonden")
+    if not await check_permission(user["id"], ds_id, Role.MEMBER):
         raise HTTPException(status_code=403, detail="Geen toegang om deze claim te wijzigen")
-    await update_claim_manual(
-        claim_id,
-        claim.statement,
-        claim.polarity,
-        claim.confidence,
-        claim.source_id,
-        claim.target_id,
-        claim.evidence_text,
-        claim.evidence_url
+
+    await fuseki_knowledge.update_claim_fuseki(
+        tessera_id=claim_id,
+        ds_id=ds_id,
+        statement=claim.statement,
+        polarity=claim.polarity,
+        confidence=claim.confidence,
+        evidence_text=claim.evidence_text,
     )
+
+    project_id = await fuseki_knowledge.get_project_id_for_designspace(ds_id)
     if project_id:
         await manager.broadcast_data(project_id, {
             "type": "CLAIM_UPDATED",
-            "payload": {"id": claim_id, "changes": claim.dict(exclude_unset=True)}
+            "payload": {"id": claim_id, "changes": claim.dict(exclude_unset=True)},
         })
+
     return {"status": "updated"}
 
 
 @router.delete("/claims/{claim_id}")
 async def delete_claim_route(claim_id: str, user: dict = Depends(get_current_user)):
-    project_id = await get_project_id_by_claim(claim_id)
-    version_id = await get_version_id_by_claim(claim_id)
-    check_entity = version_id or project_id
-    if not check_entity or not await check_permission(user["id"], check_entity, Role.MEMBER):
+    ds_id = await fuseki_knowledge.get_designspace_id_for_tessera(claim_id)
+    if not ds_id:
+        raise HTTPException(status_code=404, detail="Claim niet gevonden")
+    if not await check_permission(user["id"], ds_id, Role.MEMBER):
         raise HTTPException(status_code=403, detail="Geen toegang om deze claim te verwijderen")
-    await delete_claim_manual(claim_id)
+
+    await fuseki_knowledge.delete_claim_fuseki(tessera_id=claim_id, ds_id=ds_id)
+
+    project_id = await fuseki_knowledge.get_project_id_for_designspace(ds_id)
     if project_id:
         await manager.broadcast_data(project_id, {
             "type": "CLAIM_DELETED",
-            "payload": {"id": claim_id}
+            "payload": {"id": claim_id},
         })
+
     return {"status": "deleted"}

--- a/backend/app/routers/factors.py
+++ b/backend/app/routers/factors.py
@@ -6,12 +6,12 @@ import logging
 from app.auth import get_current_user
 from app.models.domain import Role
 from app.db.crud import (
-    create_factor_manual, update_factor_manual, delete_factor_manual,
-    get_project_id_by_factor, get_version_id_by_factor, get_project_id_by_theme,
-    get_active_version_id_if_theme, get_factors_for_theme, check_permission,
+    get_project_id_by_theme,
+    get_active_version_id_if_theme,
+    check_permission,
 )
+from app.db import fuseki_knowledge
 from app.services.connection_manager import manager
-from app.services.fuseki_sync import try_write_factor
 
 logger = logging.getLogger(__name__)
 
@@ -34,30 +34,46 @@ class FactorUpdate(BaseModel):
 
 @router.get("/themes/{theme_id}/factors")
 async def list_theme_factors(theme_id: str):
-    return await get_factors_for_theme(theme_id)
+    return await fuseki_knowledge.get_factors_for_theme(theme_id)
 
 
 @router.get("/versions/{version_id}/factors")
 async def list_version_factors(version_id: str):
-    from app.db.crud import get_factors_for_version
-    return await get_factors_for_version(version_id)
+    return await fuseki_knowledge.get_factors_for_version(version_id)
 
 
 @router.post("/factors")
 async def create_factor(factor: FactorManualCreate, user: dict = Depends(get_current_user)):
-    logger.info(f"Creating factor: {factor} by {user['id']}")
+    logger.info("Creating factor: %s by %s", factor.name, user["id"])
+
     version_id = await get_active_version_id_if_theme(factor.theme_id) if factor.theme_id else None
-    project_id_check = await get_project_id_by_theme(factor.theme_id) if factor.theme_id else None
-    check_entity = version_id or project_id_check
+    project_id = await get_project_id_by_theme(factor.theme_id) if factor.theme_id else None
+    ds_id = await fuseki_knowledge.get_designspace_id_for_version(version_id) if version_id else None
+
+    check_entity = ds_id or project_id
     if not check_entity or not await check_permission(user["id"], check_entity, Role.MEMBER):
         raise HTTPException(status_code=403, detail="Geen toegang om een factor aan te maken")
-    fid = await create_factor_manual(factor.name, factor.description, factor.type or "systeemelement", factor.theme_id, author_id=user["id"])
-    await try_write_factor(fid, factor.name, factor.theme_id or "", user["id"])
+    if not ds_id:
+        raise HTTPException(status_code=422, detail="Geen actieve DesignSpace gevonden voor dit thema")
 
-    if project_id_check:
-        await manager.broadcast_data(project_id_check, {
+    fid = await fuseki_knowledge.create_factor_fuseki(
+        ds_id=ds_id,
+        name=factor.name,
+        role=factor.type or "systeemelement",
+        user_id=user["id"],
+        description=factor.description,
+    )
+
+    if project_id:
+        await manager.broadcast_data(project_id, {
             "type": "FACTOR_CREATED",
-            "payload": {"id": fid, "name": factor.name, "description": factor.description, "type": factor.type, "theme_id": factor.theme_id}
+            "payload": {
+                "id": fid,
+                "name": factor.name,
+                "description": factor.description,
+                "type": factor.type,
+                "theme_id": factor.theme_id,
+            },
         })
 
     return {"id": fid, "name": factor.name}
@@ -65,31 +81,45 @@ async def create_factor(factor: FactorManualCreate, user: dict = Depends(get_cur
 
 @router.patch("/factors/{factor_id}")
 async def update_factor_route(factor_id: str, factor: FactorUpdate, user: dict = Depends(get_current_user)):
-    project_id = await get_project_id_by_factor(factor_id)
-    version_id = await get_version_id_by_factor(factor_id)
-    check_entity = version_id or project_id
-    if not check_entity or not await check_permission(user["id"], check_entity, Role.MEMBER):
+    ds_id = await fuseki_knowledge.get_designspace_id_for_tessera(factor_id)
+    if not ds_id:
+        raise HTTPException(status_code=404, detail="Factor niet gevonden")
+    if not await check_permission(user["id"], ds_id, Role.MEMBER):
         raise HTTPException(status_code=403, detail="Geen toegang om deze factor te wijzigen")
-    await update_factor_manual(factor_id, factor.name, factor.description, factor.type, factor.theme_id)
+
+    await fuseki_knowledge.update_factor_fuseki(
+        tessera_id=factor_id,
+        ds_id=ds_id,
+        name=factor.name,
+        description=factor.description,
+        role=factor.type,
+    )
+
+    project_id = await fuseki_knowledge.get_project_id_for_designspace(ds_id)
     if project_id:
         await manager.broadcast_data(project_id, {
             "type": "FACTOR_UPDATED",
-            "payload": {"id": factor_id, "changes": factor.dict(exclude_unset=True)}
+            "payload": {"id": factor_id, "changes": factor.dict(exclude_unset=True)},
         })
+
     return {"status": "updated"}
 
 
 @router.delete("/factors/{factor_id}")
 async def delete_factor_route(factor_id: str, user: dict = Depends(get_current_user)):
-    project_id = await get_project_id_by_factor(factor_id)
-    version_id = await get_version_id_by_factor(factor_id)
-    check_entity = version_id or project_id
-    if not check_entity or not await check_permission(user["id"], check_entity, Role.MEMBER):
+    ds_id = await fuseki_knowledge.get_designspace_id_for_tessera(factor_id)
+    if not ds_id:
+        raise HTTPException(status_code=404, detail="Factor niet gevonden")
+    if not await check_permission(user["id"], ds_id, Role.MEMBER):
         raise HTTPException(status_code=403, detail="Geen toegang om deze factor te verwijderen")
-    await delete_factor_manual(factor_id)
+
+    await fuseki_knowledge.delete_factor_fuseki(tessera_id=factor_id, ds_id=ds_id)
+
+    project_id = await fuseki_knowledge.get_project_id_for_designspace(ds_id)
     if project_id:
         await manager.broadcast_data(project_id, {
             "type": "FACTOR_DELETED",
-            "payload": {"id": factor_id}
+            "payload": {"id": factor_id},
         })
+
     return {"status": "deleted"}

--- a/backend/scripts/fix_tessera_base_ids.py
+++ b/backend/scripts/fix_tessera_base_ids.py
@@ -1,0 +1,184 @@
+"""Fix-script: voeg valor:baseId toe aan alle bestaande Tesserae in Fuseki (US-11.2).
+
+Bestaande Tesserae missen mogelijk de valor:baseId property:
+- Tesserae aangemaakt via migratiescript: URI-suffix = FactorVersion.id (version_id)
+- Tesserae aangemaakt via dual-write: URI-suffix = FactorBase.id (base_id)
+
+Dit script:
+1. Vindt alle Tesserae zonder valor:baseId in Fuseki
+2. Zoekt in Neo4j de bijbehorende base_id op (via version_id of base_id lookup)
+3. Voegt valor:baseId toe als property (idempotent via INSERT WHERE NOT EXISTS)
+
+Na afloop kunnen de SPARQL-queries in fuseki_knowledge.py correct werken.
+
+Gebruik:
+    cd backend
+    FUSEKI_URL=http://localhost:3030 python scripts/fix_tessera_base_ids.py
+
+    # Dry-run (geen schrijfoperaties, alleen rapportage):
+    FUSEKI_URL=http://localhost:3030 python scripts/fix_tessera_base_ids.py --dry-run
+"""
+import asyncio
+import sys
+import os
+import argparse
+import logging
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s  %(message)s")
+logger = logging.getLogger(__name__)
+
+VALOR_NS = "https://valor-ecosystem.nl/ontology/"
+TESSERA_PREFIX = "urn:valor:tessera:"
+
+
+# ---------------------------------------------------------------------------
+# Fuseki: alle Tesserae zonder baseId ophalen
+# ---------------------------------------------------------------------------
+
+async def _get_tesserae_without_base_id() -> list[dict]:
+    """Geeft alle Tesserae zonder valor:baseId, met hun graph-URI."""
+    from app.services.fuseki import sparql_select_global
+    rows = await sparql_select_global(f"""
+SELECT ?tessera ?graph WHERE {{
+  GRAPH ?graph {{ ?tessera a <{VALOR_NS}Tessera> }}
+  FILTER NOT EXISTS {{
+    GRAPH ?graph {{ ?tessera <{VALOR_NS}baseId> ?bid }}
+  }}
+  FILTER(STRSTARTS(STR(?graph), "urn:valor:ds:"))
+}}
+""")
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Neo4j: base_id opzoeken voor een gegeven URI-suffix
+# ---------------------------------------------------------------------------
+
+def _resolve_base_id_neo4j(suffix: str) -> str | None:
+    """Zoekt de base_id op in Neo4j voor een gegeven URI-suffix.
+
+    Suffix kan een FactorVersion.id, FactorBase.id, ClaimVersion.id of ClaimBase.id zijn.
+    """
+    from app.db.utils import get_driver
+    driver = get_driver()
+    query = """
+    OPTIONAL MATCH (fv:FactorVersion {id: $suffix}) WITH fv
+    OPTIONAL MATCH (fb:FactorBase {id: $suffix})
+    OPTIONAL MATCH (cv:ClaimVersion {id: $suffix})
+    OPTIONAL MATCH (cb:ClaimBase {id: $suffix})
+    RETURN coalesce(fv.base_id, fb.id, cv.base_id, cb.id) AS base_id
+    """
+    with driver.session() as session:
+        r = session.run(query, {"suffix": suffix}).single()
+    return r["base_id"] if r else None
+
+
+# ---------------------------------------------------------------------------
+# Fuseki: valor:baseId toevoegen aan een Tessera (idempotent)
+# ---------------------------------------------------------------------------
+
+async def _add_base_id_to_tessera(tessera_uri: str, graph_uri: str, base_id: str) -> None:
+    import httpx
+    from app.services.fuseki import _UPDATE_ENDPOINT, FUSEKI_ADMIN_PASSWORD, _raise_for_fuseki_error
+
+    update = f"""
+INSERT {{
+  GRAPH <{graph_uri}> {{
+    <{tessera_uri}> <{VALOR_NS}baseId> "{base_id}" .
+  }}
+}}
+WHERE {{
+  FILTER NOT EXISTS {{
+    GRAPH <{graph_uri}> {{ <{tessera_uri}> <{VALOR_NS}baseId> ?bid }}
+  }}
+}}
+"""
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            _UPDATE_ENDPOINT,
+            data={"update": update},
+            auth=("admin", FUSEKI_ADMIN_PASSWORD),
+            timeout=30,
+        )
+    _raise_for_fuseki_error(response)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+async def main(dry_run: bool) -> None:
+    from app.db.utils import get_driver
+
+    logger.info("=== fix_tessera_base_ids: valor:baseId toevoegen aan bestaande Tesserae ===")
+    if dry_run:
+        logger.info("DRY-RUN modus — geen schrijfoperaties")
+
+    # Verbinding Neo4j initialiseren
+    get_driver()
+
+    # Stap 1: alle Tesserae zonder baseId ophalen
+    logger.info("\n[1] Tesserae zonder valor:baseId ophalen uit Fuseki...")
+    tesserae = await _get_tesserae_without_base_id()
+    logger.info("    Gevonden: %d Tessera(e) zonder valor:baseId", len(tesserae))
+
+    if not tesserae:
+        logger.info("Niets te doen — alle Tesserae hebben al een valor:baseId.")
+        return
+
+    # Stap 2: base_id oplossen en property toevoegen
+    fixed = skipped = errors = 0
+    for row in tesserae:
+        tessera_uri: str = row["tessera"]
+        graph_uri: str = row["graph"]
+
+        # Suffix extraheren uit de Tessera-URI
+        if tessera_uri.startswith(TESSERA_PREFIX):
+            suffix = tessera_uri[len(TESSERA_PREFIX):]
+        else:
+            logger.warning("  Onbekende URI-structuur: %s — overgeslagen", tessera_uri)
+            skipped += 1
+            continue
+
+        # Base_id opzoeken in Neo4j
+        base_id = await asyncio.to_thread(_resolve_base_id_neo4j, suffix)
+
+        if not base_id:
+            # Suffix is niet gevonden in Neo4j — gebruik suffix zelf als base_id
+            # (dit kan een al-correct base_id zijn van een niet-neoJ-gesyncte Tessera)
+            logger.warning("  [FALLBACK] %s niet gevonden in Neo4j — suffix als base_id: %s", tessera_uri, suffix)
+            base_id = suffix
+
+        if dry_run:
+            logger.info("  [DRY-RUN] zou toevoegen: %s → baseId=%s", tessera_uri, base_id)
+            fixed += 1
+            continue
+
+        try:
+            await _add_base_id_to_tessera(tessera_uri, graph_uri, base_id)
+            logger.info("  [OK] %s → baseId=%s", tessera_uri, base_id)
+            fixed += 1
+        except Exception as e:
+            logger.error("  [FOUT] %s: %s", tessera_uri, e)
+            errors += 1
+
+    logger.info(
+        "\n=== Resultaat === %s: gefixeerd=%d, overgeslagen=%d, fouten=%d",
+        "DRY-RUN" if dry_run else "UITGEVOERD",
+        fixed, skipped, errors,
+    )
+
+    if errors > 0:
+        logger.error("Er zijn fouten opgetreden. Controleer de output hierboven.")
+        sys.exit(1)
+    else:
+        logger.info("Klaar.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Voeg valor:baseId toe aan bestaande Tesserae")
+    parser.add_argument("--dry-run", action="store_true", help="Geen schrijfoperaties")
+    args = parser.parse_args()
+    asyncio.run(main(dry_run=args.dry_run))

--- a/backend/tests/integration/test_fuseki_knowledge.py
+++ b/backend/tests/integration/test_fuseki_knowledge.py
@@ -1,0 +1,280 @@
+"""Integratietests voor app.db.fuseki_knowledge (US-11.2).
+
+Test de SPARQL-gebaseerde lees- en schrijfoperaties voor Factors en Claims.
+Neo4j-aanroepen zijn gemonkey-patched — alleen Fuseki is vereist.
+
+Gebruik:
+    cd backend
+    FUSEKI_URL=http://localhost:3030 pytest tests/integration/test_fuseki_knowledge.py -v
+"""
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from app.ontology import VALOR_NS
+
+pytestmark = pytest.mark.integration
+
+USER_ID = "user-test-001"
+USER_URI = f"urn:valor:user:{USER_ID}"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _seed_design_space(ds_id: str) -> None:
+    """Initialiseert de asis-graph voor een test-DesignSpace."""
+    from app.services.fuseki import initialize_design_space_graphs
+    await initialize_design_space_graphs(ds_id, f"urn:valor:issue:{ds_id}")
+
+
+async def _count_tesserae(ds_id: str) -> int:
+    from app.services.fuseki import sparql_select_global
+    graph = f"urn:valor:ds:{ds_id}/asis"
+    rows = await sparql_select_global(
+        f"SELECT (COUNT(?t) AS ?c) WHERE {{ GRAPH <{graph}> {{ ?t a <{VALOR_NS}Tessera> }} }}"
+    )
+    return int(rows[0]["c"]) if rows else 0
+
+
+# ---------------------------------------------------------------------------
+# Factor writes
+# ---------------------------------------------------------------------------
+
+async def test_create_factor_fuseki_maakt_tessera_aan(ds_id):
+    await _seed_design_space(ds_id)
+    from app.db.fuseki_knowledge import create_factor_fuseki, get_factors_for_version
+
+    base_id = await create_factor_fuseki(ds_id, "Factor Alpha", "middel", USER_ID)
+    assert base_id
+
+    count = await _count_tesserae(ds_id)
+    assert count == 1
+
+
+async def test_create_factor_fuseki_slaat_base_id_op(ds_id):
+    await _seed_design_space(ds_id)
+    from app.db.fuseki_knowledge import create_factor_fuseki
+    from app.services.fuseki import sparql_select_global
+
+    base_id = await create_factor_fuseki(ds_id, "Factor Beta", "criterium", USER_ID, description="Een criterium")
+
+    graph = f"urn:valor:ds:{ds_id}/asis"
+    rows = await sparql_select_global(
+        f'SELECT ?bid WHERE {{ GRAPH <{graph}> {{ <urn:valor:tessera:{base_id}> <{VALOR_NS}baseId> ?bid }} }}'
+    )
+    assert rows, "valor:baseId niet gevonden"
+    assert rows[0]["bid"] == base_id
+
+
+async def test_update_factor_fuseki_wijzigt_naam(ds_id):
+    await _seed_design_space(ds_id)
+    from app.db.fuseki_knowledge import create_factor_fuseki, update_factor_fuseki
+    from app.services.fuseki import sparql_select_global
+
+    base_id = await create_factor_fuseki(ds_id, "Oude naam", "middel", USER_ID)
+    await update_factor_fuseki(base_id, ds_id, name="Nieuwe naam")
+
+    graph = f"urn:valor:ds:{ds_id}/asis"
+    rows = await sparql_select_global(
+        f'SELECT ?name WHERE {{ GRAPH <{graph}> {{ <urn:valor:tessera:{base_id}> <{VALOR_NS}claimContent> ?name }} }}'
+    )
+    assert any("Nieuwe naam" in r["name"] for r in rows), "Naam niet bijgewerkt"
+
+
+async def test_delete_factor_fuseki_verwijdert_tessera(ds_id):
+    await _seed_design_space(ds_id)
+    from app.db.fuseki_knowledge import create_factor_fuseki, delete_factor_fuseki
+
+    base_id = await create_factor_fuseki(ds_id, "Te verwijderen", "middel", USER_ID)
+    assert await _count_tesserae(ds_id) == 1
+
+    await delete_factor_fuseki(base_id, ds_id)
+    assert await _count_tesserae(ds_id) == 0
+
+
+# ---------------------------------------------------------------------------
+# Factor reads (GET)
+# ---------------------------------------------------------------------------
+
+async def test_get_factors_for_version_retourneert_factoren(ds_id):
+    await _seed_design_space(ds_id)
+    from app.db.fuseki_knowledge import create_factor_fuseki, get_factors_for_version
+    import app.db.fuseki_knowledge as mod
+
+    # Patch Neo4j lookup
+    original = mod._get_designspace_id_for_version_sync
+    mod._get_designspace_id_for_version_sync = lambda vid: ds_id
+
+    await create_factor_fuseki(ds_id, "Factor A", "middel", USER_ID)
+    await create_factor_fuseki(ds_id, "Factor B", "criterium", USER_ID)
+
+    try:
+        factors = await get_factors_for_version("version-test")
+    finally:
+        mod._get_designspace_id_for_version_sync = original
+
+    assert len(factors) == 2
+    names = {f["name"] for f in factors}
+    assert "Factor A" in names
+    assert "Factor B" in names
+
+
+async def test_get_factors_retourneert_base_id_als_id(ds_id):
+    await _seed_design_space(ds_id)
+    from app.db.fuseki_knowledge import create_factor_fuseki, get_factors_for_version
+    import app.db.fuseki_knowledge as mod
+
+    original = mod._get_designspace_id_for_version_sync
+    mod._get_designspace_id_for_version_sync = lambda vid: ds_id
+
+    base_id = await create_factor_fuseki(ds_id, "Factor met ID", "middel", USER_ID)
+
+    try:
+        factors = await get_factors_for_version("version-test")
+    finally:
+        mod._get_designspace_id_for_version_sync = original
+
+    assert len(factors) == 1
+    assert factors[0]["id"] == base_id
+
+
+async def test_get_factors_lege_designspace_geeft_lege_lijst(ds_id):
+    await _seed_design_space(ds_id)
+    from app.db.fuseki_knowledge import get_factors_for_version
+    import app.db.fuseki_knowledge as mod
+
+    original = mod._get_designspace_id_for_version_sync
+    mod._get_designspace_id_for_version_sync = lambda vid: ds_id
+
+    try:
+        factors = await get_factors_for_version("version-test")
+    finally:
+        mod._get_designspace_id_for_version_sync = original
+
+    assert factors == []
+
+
+# ---------------------------------------------------------------------------
+# Claim writes
+# ---------------------------------------------------------------------------
+
+async def test_create_claim_fuseki_koppelt_factor_uris(ds_id):
+    await _seed_design_space(ds_id)
+    from app.db.fuseki_knowledge import create_factor_fuseki, create_claim_fuseki
+    from app.services.fuseki import sparql_select_global
+
+    fac_a = await create_factor_fuseki(ds_id, "Factor A", "middel", USER_ID)
+    fac_b = await create_factor_fuseki(ds_id, "Factor B", "criterium", USER_ID)
+
+    claim_id = await create_claim_fuseki(
+        ds_id=ds_id,
+        source_id=fac_a,
+        target_id=fac_b,
+        statement="A beïnvloedt B",
+        polarity="+",
+        user_id=USER_ID,
+    )
+    assert claim_id
+
+    graph = f"urn:valor:ds:{ds_id}/asis"
+    rows = await sparql_select_global(f"""
+        SELECT ?from ?to WHERE {{
+          GRAPH <{graph}> {{
+            <urn:valor:tessera:{claim_id}> <{VALOR_NS}fromFactor> ?from ;
+                                           <{VALOR_NS}toFactor> ?to .
+          }}
+        }}
+    """)
+    assert rows, "fromFactor/toFactor niet gevonden"
+    assert f"urn:valor:tessera:{fac_a}" == rows[0]["from"]
+    assert f"urn:valor:tessera:{fac_b}" == rows[0]["to"]
+
+
+async def test_create_claim_fuseki_slaat_base_id_op(ds_id):
+    await _seed_design_space(ds_id)
+    from app.db.fuseki_knowledge import create_factor_fuseki, create_claim_fuseki
+    from app.services.fuseki import sparql_select_global
+
+    fac_a = await create_factor_fuseki(ds_id, "Bron", "middel", USER_ID)
+    fac_b = await create_factor_fuseki(ds_id, "Doel", "middel", USER_ID)
+    claim_id = await create_claim_fuseki(ds_id, fac_a, fac_b, "Stelling", "+", USER_ID)
+
+    graph = f"urn:valor:ds:{ds_id}/asis"
+    rows = await sparql_select_global(
+        f'SELECT ?bid WHERE {{ GRAPH <{graph}> {{ <urn:valor:tessera:{claim_id}> <{VALOR_NS}baseId> ?bid }} }}'
+    )
+    assert rows
+    assert rows[0]["bid"] == claim_id
+
+
+# ---------------------------------------------------------------------------
+# Claim reads (GET)
+# ---------------------------------------------------------------------------
+
+async def test_get_claims_for_version_retourneert_claims(ds_id):
+    await _seed_design_space(ds_id)
+    from app.db.fuseki_knowledge import create_factor_fuseki, create_claim_fuseki, get_claims_for_version
+    import app.db.fuseki_knowledge as mod
+
+    original = mod._get_designspace_id_for_version_sync
+    mod._get_designspace_id_for_version_sync = lambda vid: ds_id
+
+    fac_a = await create_factor_fuseki(ds_id, "Bron", "middel", USER_ID)
+    fac_b = await create_factor_fuseki(ds_id, "Doel", "middel", USER_ID)
+    await create_claim_fuseki(ds_id, fac_a, fac_b, "A veroorzaakt B", "+", USER_ID, confidence=0.8)
+
+    try:
+        claims = await get_claims_for_version("version-test")
+    finally:
+        mod._get_designspace_id_for_version_sync = original
+
+    assert len(claims) == 1
+    c = claims[0]
+    assert c["statement"] == "A veroorzaakt B"
+    assert c["polarity"] == "+"
+    assert c["source_id"] == fac_a
+    assert c["target_id"] == fac_b
+
+
+async def test_get_claims_retourneert_base_id_als_id(ds_id):
+    await _seed_design_space(ds_id)
+    from app.db.fuseki_knowledge import create_factor_fuseki, create_claim_fuseki, get_claims_for_version
+    import app.db.fuseki_knowledge as mod
+
+    original = mod._get_designspace_id_for_version_sync
+    mod._get_designspace_id_for_version_sync = lambda vid: ds_id
+
+    fac_a = await create_factor_fuseki(ds_id, "A", "middel", USER_ID)
+    fac_b = await create_factor_fuseki(ds_id, "B", "middel", USER_ID)
+    claim_id = await create_claim_fuseki(ds_id, fac_a, fac_b, "Stelling", "+", USER_ID)
+
+    try:
+        claims = await get_claims_for_version("version-test")
+    finally:
+        mod._get_designspace_id_for_version_sync = original
+
+    assert len(claims) == 1
+    assert claims[0]["id"] == claim_id
+
+
+# ---------------------------------------------------------------------------
+# DesignSpace lookup via Fuseki
+# ---------------------------------------------------------------------------
+
+async def test_get_designspace_id_for_tessera(ds_id):
+    await _seed_design_space(ds_id)
+    from app.db.fuseki_knowledge import create_factor_fuseki, get_designspace_id_for_tessera
+
+    base_id = await create_factor_fuseki(ds_id, "Factor X", "middel", USER_ID)
+    found_ds = await get_designspace_id_for_tessera(base_id)
+    assert found_ds == ds_id
+
+
+async def test_get_designspace_id_for_tessera_onbekend_geeft_none(ds_id):
+    from app.db.fuseki_knowledge import get_designspace_id_for_tessera
+    result = await get_designspace_id_for_tessera("niet-bestaand-id")
+    assert result is None


### PR DESCRIPTION
## Samenvatting

Sluit US-11.2 af: Factors en Claims worden uitsluitend via Fuseki (SPARQL) gelezen en geschreven. Dual-write via Neo4j is verwijderd.

### Wijzigingen

- **`app/db/fuseki_knowledge.py`** (nieuw) — volledige SPARQL read/write module
  - Elke Tessera krijgt `valor:baseId` als canoniek ID-property (Option A)
  - `_find_tessera_uri_by_base_id` lost echte tessera-URI op voor claim-aanmaak (lost de URI-inconsistentie op tussen gemigreerde en dual-write Tesserae)
  - Neo4j alleen nog voor hiërarchie-lookups (ThemeVersion → DesignSpace, Project → DesignSpace)
- **`app/routers/factors.py`** — herschreven: geen Neo4j knowledge imports, geen `try_write_factor`, alle routes via `fuseki_knowledge`
- **`app/routers/claims.py`** — herschreven: geen Neo4j knowledge imports, geen `try_write_claim`, alle routes via `fuseki_knowledge`
- **`scripts/fix_tessera_base_ids.py`** (nieuw) — eenmalig fix-script voor bestaande Tesserae zonder `valor:baseId`
- **`tests/integration/test_fuseki_knowledge.py`** (nieuw) — 13 integratietests voor volledige CRUD

### Test resultaten

```
13 passed in test_fuseki_knowledge.py
87 passed in full integration suite
```

## Closes

Closes #320