### PR TITLE
feat(workspace): add As-is/To-be view toggle filtering on claimType (US-4.3)

### DIFF
--- a/backend/app/db/fuseki_knowledge.py
+++ b/backend/app/db/fuseki_knowledge.py
@@ -226,8 +226,13 @@ WHERE {{
 # Claim reads (SPARQL)
 # ---------------------------------------------------------------------------
 
-async def _sparql_get_claims(ds_id: str) -> list[dict]:
+async def _sparql_get_claims(ds_id: str, claim_type: Optional[str] = None) -> list[dict]:
     asis_graph = _ds_asis_graph(ds_id)
+    if claim_type is not None:
+        claim_type_uri = f"{VALOR_NS}{claim_type}"
+        claim_type_filter = f"?tessera <{VALOR_NS}claimType> <{claim_type_uri}> ."
+    else:
+        claim_type_filter = ""
     rows = await sparql_select_global(f"""
 SELECT ?tessera ?baseId ?statement ?polarity ?confidence
        ?fromFactor ?sourceBaseId ?toFactor ?targetBaseId
@@ -238,6 +243,7 @@ SELECT ?tessera ?baseId ?statement ?polarity ?confidence
              <{VALOR_NS}claimContent> ?statement ;
              <{VALOR_NS}fromFactor> ?fromFactor ;
              <{VALOR_NS}toFactor> ?toFactor .
+    {claim_type_filter}
     ?fromFactor <{VALOR_NS}baseId> ?sourceBaseId .
     ?toFactor   <{VALOR_NS}baseId> ?targetBaseId .
     OPTIONAL {{ ?tessera <{VALOR_NS}polarity>     ?polarity }}

--- a/backend/app/routers/claims.py
+++ b/backend/app/routers/claims.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from typing import Optional
 from pydantic import BaseModel
 import logging
@@ -35,11 +35,20 @@ class ClaimUpdate(BaseModel):
     evidence_url: Optional[str] = None
 
 
+_VALID_CLAIM_TYPES = {"AsIsType", "ToBeType"}
+
+
 @router.get("/designspace/{ds_id}/claims")
-async def list_designspace_claims(ds_id: str, user: dict = Depends(get_current_user)):
+async def list_designspace_claims(
+    ds_id: str,
+    claim_type: Optional[str] = Query(None, description="Filter op claimType: 'AsIsType' of 'ToBeType'"),
+    user: dict = Depends(get_current_user),
+):
+    if claim_type is not None and claim_type not in _VALID_CLAIM_TYPES:
+        raise HTTPException(status_code=422, detail=f"Ongeldig claim_type '{claim_type}'. Toegestane waarden: {sorted(_VALID_CLAIM_TYPES)}")
     if not await check_permission(user["id"], ds_id, Role.MEMBER):
         raise HTTPException(status_code=403, detail="Geen toegang tot deze DesignSpace")
-    return await fuseki_knowledge._sparql_get_claims(ds_id)
+    return await fuseki_knowledge._sparql_get_claims(ds_id, claim_type=claim_type)
 
 
 @router.post("/claims_manual")

--- a/frontend/src/perspectives/causa/Shell.tsx
+++ b/frontend/src/perspectives/causa/Shell.tsx
@@ -13,6 +13,7 @@ import { PerspectiveToolbar } from '@/components/shell/PerspectiveToolbar';
 import { ExportMenu } from '@/components/shell/ExportMenu';
 import { useDomExport } from '@/hooks/useDomExport';
 import { CLDView } from './views/CLDView';
+import { ClaimViewToggle } from './views/ClaimViewToggle';
 import { useCausaData } from './hooks/useCausaData';
 import { LayoutSession } from './layout/session';
 import { ForceRunner } from './layout/runners/force';
@@ -123,7 +124,7 @@ export const CausaShell = ({ themeId, websocket, currentUserId, onSelect, onOpen
 
     // B. Fetch Data
     // console.log('[CausaShell] Props:', { themeId, versionId, activeVersionId: themeState.activeVersion?.id });
-    const { nodes, links, factors, refresh, loading } = useCausaData(themeId, versionId || themeState.activeVersion?.id);
+    const { nodes, links, factors, refresh, loading, viewFilter, setViewFilter } = useCausaData(themeId, versionId || themeState.activeVersion?.id);
 
     // C. Initialize Session
     // Re-create session ONLY when layoutMode changes
@@ -313,6 +314,7 @@ export const CausaShell = ({ themeId, websocket, currentUserId, onSelect, onOpen
                     </TooltipProvider>
                 )}
 
+                <ClaimViewToggle value={viewFilter} onChange={setViewFilter} />
 
             </PerspectiveToolbar>
 

--- a/frontend/src/perspectives/causa/hooks/useCausaData.ts
+++ b/frontend/src/perspectives/causa/hooks/useCausaData.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
-import { api, type Factor, type Claim } from '../../../services/api';
+import { api, type Factor, type Claim, type ClaimViewType } from '../../../services/api';
 import { mapFactors, mapClaims } from '../layout/mappers';
 import type { CausalNode, CausalLink } from '../types';
 
@@ -11,6 +11,8 @@ interface CausaData {
     loading: boolean;
     error: Error | null;
     refresh: (force?: boolean) => Promise<void>;
+    viewFilter: ClaimViewType | null;
+    setViewFilter: (filter: ClaimViewType | null) => void;
 }
 
 export const useCausaData = (themeId: string, versionId?: string): CausaData => {
@@ -20,6 +22,7 @@ export const useCausaData = (themeId: string, versionId?: string): CausaData => 
     const [claims, setClaims] = useState<Claim[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<Error | null>(null);
+    const [viewFilter, setViewFilter] = useState<ClaimViewType | null>(null);
 
     const lastFetchRef = useRef<string | null>(null);
 
@@ -68,5 +71,10 @@ export const useCausaData = (themeId: string, versionId?: string): CausaData => 
         }
     }, [refresh]);
 
-    return { nodes, links, factors, claims, loading, error, refresh };
+    // Lokale filter: nodes altijd zichtbaar, links gefilterd op claimType
+    const filteredLinks = viewFilter === null
+        ? links
+        : links.filter(link => (link as any).claimType === viewFilter || !(link as any).claimType);
+
+    return { nodes, links: filteredLinks, factors, claims, loading, error, refresh, viewFilter, setViewFilter };
 };

--- a/frontend/src/perspectives/causa/views/ClaimViewToggle.tsx
+++ b/frontend/src/perspectives/causa/views/ClaimViewToggle.tsx
@@ -1,0 +1,38 @@
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import type { ClaimViewType } from "@/services/api";
+
+interface ClaimViewToggleProps {
+    value: ClaimViewType | null;
+    onChange: (value: ClaimViewType | null) => void;
+}
+
+export const ClaimViewToggle = ({ value, onChange }: ClaimViewToggleProps) => {
+    const handleChange = (val: string) => {
+        if (!val || val === 'all') {
+            onChange(null);
+        } else {
+            onChange(val as ClaimViewType);
+        }
+    };
+
+    return (
+        <ToggleGroup
+            type="single"
+            size="sm"
+            variant="outline"
+            value={value ?? 'all'}
+            onValueChange={handleChange}
+            className="h-8"
+        >
+            <ToggleGroupItem value="all" className="h-8 px-3 text-xs">
+                Alles
+            </ToggleGroupItem>
+            <ToggleGroupItem value="AsIsType" className="h-8 px-3 text-xs">
+                As-is
+            </ToggleGroupItem>
+            <ToggleGroupItem value="ToBeType" className="h-8 px-3 text-xs">
+                To-be
+            </ToggleGroupItem>
+        </ToggleGroup>
+    );
+};

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -32,6 +32,7 @@ apiClient.interceptors.response.use(
 );
 
 export type FactorType = 'middel' | 'extern' | 'systeemelement' | 'criterium';
+export type ClaimViewType = 'AsIsType' | 'ToBeType';
 
 export interface Claim {
     id: string;
@@ -459,8 +460,9 @@ export const api = {
         return response.data;
     },
 
-    getThemeClaims: async (dsId: string) => {
-        const response = await apiClient.get<Claim[]>(`/designspace/${dsId}/claims`);
+    getThemeClaims: async (dsId: string, claimType?: ClaimViewType) => {
+        const params = claimType ? { claim_type: claimType } : undefined;
+        const response = await apiClient.get<Claim[]>(`/designspace/${dsId}/claims`, { params });
         return response.data;
     },
 


### PR DESCRIPTION
## Summary
- Backend: `claim_type` filter parameter in `_sparql_get_claims` (`fuseki_knowledge.py`) met SPARQL `FILTER`
- Backend: `GET /designspace/{ds_id}/claims?claim_type=AsIsType|ToBeType` met 422 validatie (`claims.py`)
- Frontend: `ClaimViewType = 'AsIs' | 'ToBe'` type en `getThemeClaims` parameter uitbreiding in `api.ts`
- Frontend: `ClaimViewToggle` component (Shadcn ToggleGroup) met opties Alles/As-is/To-be
- Frontend: `viewFilter` state in `useCausaData.ts` — filtert links client-side na ophalen
- Frontend: toggle geïntegreerd in `Shell.tsx` toolbar

## Closes
Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)