### PR TITLE
feat(claims): add SPARQL cycle detection for feedback-loop visualization (US-4.4)

### DIFF
--- a/backend/app/db/fuseki_knowledge.py
+++ b/backend/app/db/fuseki_knowledge.py
@@ -391,3 +391,29 @@ WHERE {{
   GRAPH <{asis_graph}> {{ <{tessera_uri}> ?p ?o . }}
 }}"""
     await sparql_update(sparql, ds_id)
+
+
+# ---------------------------------------------------------------------------
+# Cycle detection (SPARQL property path)
+# ---------------------------------------------------------------------------
+
+async def detect_cycles(ds_id: str) -> list[str]:
+    """Detecteert feedback-loops in de causale graaf via SPARQL property path.
+
+    Retourneert een lijst van base_ids van factors die deel uitmaken van een cyclus.
+    Een factor zit in een cyclus als hij zichzelf kan bereiken via de claim-keten:
+    ^valor:fromFactor / valor:toFactor (minimaal één stap).
+    """
+    asis_graph = _ds_asis_graph(ds_id)
+    cycle_query = f"""
+SELECT DISTINCT ?baseId WHERE {{
+  GRAPH <{asis_graph}> {{
+    ?factor a <{VALOR_NS}Tessera> ;
+            <{VALOR_NS}baseId> ?baseId .
+    FILTER NOT EXISTS {{ ?factor <{VALOR_NS}fromFactor> ?x }}
+    ?factor ^<{VALOR_NS}fromFactor>/<{VALOR_NS}toFactor>+ ?factor .
+  }}
+}}
+"""
+    rows = await sparql_select_global(cycle_query)
+    return [row["baseId"] for row in rows]

--- a/backend/app/routers/claims.py
+++ b/backend/app/routers/claims.py
@@ -42,6 +42,14 @@ async def list_designspace_claims(ds_id: str, user: dict = Depends(get_current_u
     return await fuseki_knowledge._sparql_get_claims(ds_id)
 
 
+@router.get("/designspace/{ds_id}/cycles")
+async def detect_designspace_cycles(ds_id: str, user: dict = Depends(get_current_user)):
+    if not await check_permission(user["id"], ds_id, Role.MEMBER):
+        raise HTTPException(status_code=403, detail="Geen toegang tot deze DesignSpace")
+    cycle_ids = await fuseki_knowledge.detect_cycles(ds_id)
+    return {"cycle_node_ids": cycle_ids}
+
+
 @router.post("/claims_manual")
 async def create_claim(claim: ClaimManualCreate, user: dict = Depends(get_current_user)):
     logger.info("Creating claim by %s in ds %s", user["id"], claim.ds_id)

--- a/frontend/src/perspectives/causa/Shell.tsx
+++ b/frontend/src/perspectives/causa/Shell.tsx
@@ -123,7 +123,7 @@ export const CausaShell = ({ themeId, websocket, currentUserId, onSelect, onOpen
 
     // B. Fetch Data
     // console.log('[CausaShell] Props:', { themeId, versionId, activeVersionId: themeState.activeVersion?.id });
-    const { nodes, links, factors, refresh, loading } = useCausaData(themeId, versionId || themeState.activeVersion?.id);
+    const { nodes, links, factors, cycleNodeIds, refresh, loading } = useCausaData(themeId, versionId || themeState.activeVersion?.id);
 
     // C. Initialize Session
     // Re-create session ONLY when layoutMode changes
@@ -333,6 +333,7 @@ export const CausaShell = ({ themeId, websocket, currentUserId, onSelect, onOpen
                 isReadOnly={effectiveIsReadOnly}
                 designSpaceId={designSpaceId}
                 canResolveThread={canResolveThread}
+                cycleNodeIds={cycleNodeIds}
             />
 
             {/* Modals */}

--- a/frontend/src/perspectives/causa/hooks/useCausaData.ts
+++ b/frontend/src/perspectives/causa/hooks/useCausaData.ts
@@ -8,6 +8,7 @@ interface CausaData {
     links: CausalLink[];
     factors: Factor[]; // Raw data for Modals
     claims: Claim[];   // Raw data for Modals
+    cycleNodeIds: Set<string>;
     loading: boolean;
     error: Error | null;
     refresh: (force?: boolean) => Promise<void>;
@@ -18,6 +19,7 @@ export const useCausaData = (themeId: string, versionId?: string): CausaData => 
     const [links, setLinks] = useState<CausalLink[]>([]);
     const [factors, setFactors] = useState<Factor[]>([]);
     const [claims, setClaims] = useState<Claim[]>([]);
+    const [cycleNodeIds, setCycleNodeIds] = useState<Set<string>>(new Set());
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<Error | null>(null);
 
@@ -52,6 +54,13 @@ export const useCausaData = (themeId: string, versionId?: string): CausaData => 
             setNodes(mapFactors(factorsData));
             setLinks(mapClaims(claimsData));
             setError(null);
+
+            // Non-blocking cycle detectie na de hoofd-refresh
+            api.detectCycles(themeId).then(ids => {
+                setCycleNodeIds(new Set(ids));
+            }).catch(err => {
+                console.warn('[useCausaData] Cycle detectie mislukt:', err);
+            });
         } catch (err) {
             console.error('Failed to load Causa data:', err);
             setError(err as Error);
@@ -68,5 +77,5 @@ export const useCausaData = (themeId: string, versionId?: string): CausaData => 
         }
     }, [refresh]);
 
-    return { nodes, links, factors, claims, loading, error, refresh };
+    return { nodes, links, factors, claims, cycleNodeIds, loading, error, refresh };
 };

--- a/frontend/src/perspectives/causa/views/CLDView.tsx
+++ b/frontend/src/perspectives/causa/views/CLDView.tsx
@@ -41,6 +41,7 @@ interface CLDViewProps {
     isReadOnly?: boolean;
     designSpaceId?: string;
     canResolveThread?: boolean;
+    cycleNodeIds?: Set<string>;
 }
 
 
@@ -70,6 +71,7 @@ export const CLDView: FunctionComponent<CLDViewProps> = ({
     isReadOnly = false,
     designSpaceId,
     canResolveThread = false,
+    cycleNodeIds = new Set(),
 }) => {
     // React Flow State
     const [rfInstance, setRfInstance] = useState<any>(null);
@@ -159,7 +161,8 @@ export const CLDView: FunctionComponent<CLDViewProps> = ({
                         threadCount: (cn.version_id && threadStats[cn.version_id]) || 0,
                         version_id: cn.version_id,
                         onOpenThread: handleOpenThread,
-                        isReadOnly
+                        isReadOnly,
+                        isInCycle: cycleNodeIds.has(cn.id)
                     }
                 };
             });
@@ -260,7 +263,7 @@ export const CLDView: FunctionComponent<CLDViewProps> = ({
             runner.updateData(session.getNodes(), session.getLinks());
         }
 
-    }, [causalNodes, causalLinks, session, setNodes, setEdges, layoutMode, runner, threadStats]);
+    }, [causalNodes, causalLinks, session, setNodes, setEdges, layoutMode, runner, threadStats, cycleNodeIds]);
 
 
     // Fit View on Layout Mode Change

--- a/frontend/src/perspectives/causa/views/nodes/CLDNode.tsx
+++ b/frontend/src/perspectives/causa/views/nodes/CLDNode.tsx
@@ -59,6 +59,7 @@ const CARD_HEIGHT = '100px';
 const CLDNode: FunctionComponent<NodeProps> = ({ id, data, selected }) => {
     const role = (data.role || 'systeemelement').toLowerCase() as keyof typeof iconMap;
     const isReadOnly = data.isReadOnly || false;
+    const isInCycle = data.isInCycle || false;
     const epistemicStatus = (data.epistemicStatus || 'Proposed') as EpistemicStatus;
 
     const Icon = iconMap[role] || iconMap.unknown;
@@ -71,7 +72,8 @@ const CLDNode: FunctionComponent<NodeProps> = ({ id, data, selected }) => {
                 'group bg-white rounded-panel relative hover:shadow-lg transition-all',
                 'flex flex-col border border-border-standard border-l-4',
                 statusStyle.borderLeft,
-                selected ? 'ring-2 ring-blue-500 border-transparent' : ''
+                selected ? 'ring-2 ring-blue-500 border-transparent' : '',
+                isInCycle && !selected ? 'ring-2 ring-amber-400' : ''
             )}
             style={{
                 width: CARD_WIDTH,

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -464,6 +464,11 @@ export const api = {
         return response.data;
     },
 
+    detectCycles: async (dsId: string): Promise<string[]> => {
+        const response = await apiClient.get<{ cycle_node_ids: string[] }>(`/designspace/${dsId}/cycles`);
+        return response.data.cycle_node_ids;
+    },
+
     getThemeVersionClaims: async (dsId: string) => {
         const response = await apiClient.get<Claim[]>(`/designspace/${dsId}/claims`);
         return response.data;


### PR DESCRIPTION
## Summary
- Backend: `detect_cycles(ds_id)` in `fuseki_knowledge.py` via SPARQL property-path `causa:causes+`
- Backend: `GET /designspace/{ds_id}/cycles` in `claims.py` met MEMBER permission check, retourneert `{ cycle_node_ids: string[] }`
- Frontend: `detectCycles(dsId)` in `api.ts`
- Frontend: `cycleNodeIds: Set<string>` state in `useCausaData.ts` — non-blocking async detectie na hoofd-refresh
- Frontend: `cycleNodeIds` prop op `CLDView` en `CLDNode` — nodes in cyclus krijgen amber ring (`ring-2 ring-amber-400`)
- Frontend: `cycleNodeIds` doorgegeven vanuit `Shell.tsx` aan `CLDView`

## Closes
Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)