### PR TITLE
feat(causa): ConditionCoverage engine per CausalClaim × DesignAlternative (US-4.7)

### DIFF
--- a/backend/app/db/fuseki_knowledge.py
+++ b/backend/app/db/fuseki_knowledge.py
@@ -423,3 +423,87 @@ SELECT DISTINCT ?baseId WHERE {{
 """
     rows = await sparql_select_global(cycle_query)
     return [row["baseId"] for row in rows]
+
+
+# ---------------------------------------------------------------------------
+# ConditionCoverage (CAUSA-engine, US-4.7)
+# ---------------------------------------------------------------------------
+
+_CAUSA_NS = f"{VALOR_NS}causa#"
+_CAPAX_NS = f"{VALOR_NS}capax#"
+
+
+async def get_condition_coverage(ds_id: str, alt_id: str) -> list[dict]:
+    """Berekent capax:ConditionCoverage per CausalClaim voor het gegeven alternatief.
+
+    Logica (voor CAPAX-integratie in Epic 9):
+    - Full    : claim heeft causa:hasManifestationCondition EN causa:realisedBy
+    - Partial : claim heeft causa:hasManifestationCondition maar GEEN causa:realisedBy
+    - None    : claim heeft geen causa:hasManifestationCondition
+
+    Resultaat wordt opgeslagen als capax:ConditionCoverage triple in de alternative graph.
+    Retourneert lijst van { claim_id, coverage }.
+    """
+    asis_graph = _ds_asis_graph(ds_id)
+    alt_graph = f"urn:valor:ds:{ds_id}/alternative/{alt_id}"
+    computed_at = datetime.now(timezone.utc).isoformat()
+
+    rows = await sparql_select_global(f"""
+SELECT ?baseId (BOUND(?cond) AS ?hasCondition) (BOUND(?rt) AS ?hasRealised) WHERE {{
+  GRAPH <{asis_graph}> {{
+    ?tessera a <{VALOR_NS}Tessera> ;
+             <{VALOR_NS}baseId> ?baseId ;
+             <{VALOR_NS}fromFactor> ?fromFactor .
+    OPTIONAL {{ ?tessera <{_CAUSA_NS}hasManifestationCondition> ?cond }}
+    OPTIONAL {{ ?tessera <{_CAUSA_NS}realisedBy> ?rt }}
+  }}
+}}
+""")
+
+    result = []
+    insert_triples = []
+
+    for row in rows:
+        claim_id = row["baseId"]
+        has_condition = str(row.get("hasCondition", "false")).lower() == "true"
+        has_realised = str(row.get("hasRealised", "false")).lower() == "true"
+
+        if has_condition and has_realised:
+            coverage = "Full"
+        elif has_condition:
+            coverage = "Partial"
+        else:
+            coverage = "None"
+
+        coverage_uri = f"urn:valor:coverage:{ds_id}:{alt_id}:{claim_id}"
+        tessera_uri = _tessera_uri(claim_id)
+        insert_triples.append(
+            f"<{coverage_uri}> a <{_CAPAX_NS}ConditionCoverage> ; "
+            f"<{VALOR_NS}forClaim> <{tessera_uri}> ; "
+            f'<{_CAPAX_NS}coverageOutcome> <{_CAPAX_NS}{coverage}> ; '
+            f'<{VALOR_NS}computedAt> "{computed_at}"^^<{_XSD}dateTime> .'
+        )
+        result.append({"claim_id": claim_id, "coverage": coverage})
+
+    if insert_triples:
+        # Verwijder eerder berekende coverage voor dit alternatief, dan schrijf nieuw
+        delete_sparql = f"""DELETE {{
+  GRAPH <{alt_graph}> {{ ?cov ?p ?o }}
+}}
+WHERE {{
+  GRAPH <{alt_graph}> {{
+    ?cov a <{_CAPAX_NS}ConditionCoverage> ;
+         ?p ?o .
+  }}
+}}"""
+        await sparql_update(delete_sparql, ds_id)
+
+        triples_str = "\n    ".join(insert_triples)
+        insert_sparql = f"""INSERT DATA {{
+  GRAPH <{alt_graph}> {{
+    {triples_str}
+  }}
+}}"""
+        await sparql_update(insert_sparql, ds_id)
+
+    return result

--- a/backend/app/routers/designspace.py
+++ b/backend/app/routers/designspace.py
@@ -3,6 +3,7 @@ import uuid
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
 from fastapi.responses import JSONResponse
 
 from app.auth import get_current_user
@@ -21,6 +22,7 @@ from app.models.domain import (
     ParticipantAdd, ParticipantResponse,
 )
 from app.ontology import VALOR_NS
+from app.db.fuseki_knowledge import get_condition_coverage
 from app.services.fuseki import (
     initialize_design_space_graphs, initialize_alternative_graph,
     sparql_proxy_query, sparql_select, sparql_update,
@@ -181,6 +183,34 @@ async def list_alternatives(
             created_at=row.get("createdAt", ""),
         ))
     return result
+
+
+class ConditionCoverageItem(BaseModel):
+    claim_id: str
+    coverage: str  # "Full" | "Partial" | "None"
+
+
+@router.get("/{design_space_id}/alternative/{alternative_id}/coverage", response_model=list[ConditionCoverageItem])
+async def get_alternative_coverage(
+    design_space_id: str,
+    alternative_id: str,
+    user: dict = Depends(get_current_user),
+) -> list[ConditionCoverageItem]:
+    """Berekent en retourneert capax:ConditionCoverage per CausalClaim voor het gegeven alternatief."""
+    user_id = user["id"]
+
+    if not await check_permission(user_id, design_space_id, Role.VIEWER):
+        raise HTTPException(
+            status_code=403,
+            detail="Onvoldoende rechten voor deze DesignSpace.",
+        )
+
+    items = await get_condition_coverage(design_space_id, alternative_id)
+    logger.info(
+        "ConditionCoverage berekend voor DesignSpace %s / alternatief %s door %s — %d claims",
+        design_space_id, alternative_id, user_id, len(items),
+    )
+    return [ConditionCoverageItem(**item) for item in items]
 
 
 @router.get("/{design_space_id}/sparql")

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -575,6 +575,11 @@ export const api = {
     },
 
     // DesignSpace
+    getConditionCoverage: async (dsId: string, altId: string): Promise<{ claim_id: string; coverage: 'Full' | 'Partial' | 'None' }[]> => {
+        const response = await apiClient.get(`/designspace/${dsId}/alternative/${altId}/coverage`);
+        return response.data;
+    },
+
     getDesignSpacesByProject: async (projectId: string, themeId?: string): Promise<{ id: string; name: string; status: string; current_phase: string }[]> => {
         const response = await apiClient.get(`/designspace/by-project/${projectId}`, {
             params: themeId ? { theme_id: themeId } : undefined,


### PR DESCRIPTION
## Wat
CAUSA-engine die per CausalClaim een `capax:ConditionCoverage` berekent voor een gegeven DesignAlternative.

## Implementatie

**Backend — `fuseki_knowledge.py`**
Nieuwe functie `get_condition_coverage(ds_id, alt_id)`:
- SPARQL query over de asis graph: haalt per claim op of `causa:hasManifestationCondition` en `causa:realisedBy` aanwezig zijn
- Berekent coverage: `Full` (beide aanwezig), `Partial` (alleen conditie), `None` (geen conditie)
- Slaat resultaat op als `capax:ConditionCoverage` triples in de alternative named graph (herberekent bij elke aanroep)

**Backend — `designspace.py`**
Nieuw endpoint:
```
GET /designspace/{design_space_id}/alternative/{alternative_id}/coverage
→ [{ claim_id, coverage: "Full" | "Partial" | "None" }, ...]
```

**Frontend — `api.ts`**
Nieuwe functie `getConditionCoverage(dsId, altId)`.

## Noot: CAPAX-afhankelijkheid
De issue beschrijft een SPARQL-patroon met `capax:requiresCapability`/`capax:hasCapability`. Die data bestaat nog niet (Epic 9). De huidige implementatie gebruikt wat wél beschikbaar is (US-4.5 + US-4.6 data) en is forward-compatible met CAPAX-integratie.

## Verificatie
- ✅ Frontend build slaagt (`npm run build`)
- ✅ Python syntax correct
- ✅ Backend herstart zonder errors
- ✅ Endpoint zichtbaar in OpenAPI spec (`/designspace/{id}/alternative/{alt_id}/coverage`)

Closes #358