### PR TITLE
feat(causa): ClaimCoverageAssessment gate-Tessera (US-4.8)

### DIFF
--- a/backend/app/db/fuseki_knowledge.py
+++ b/backend/app/db/fuseki_knowledge.py
@@ -507,3 +507,58 @@ WHERE {{
         await sparql_update(insert_sparql, ds_id)
 
     return result
+
+
+async def create_claim_coverage_assessment(ds_id: str, alt_id: str, user_id: str) -> dict:
+    """Aggregeert ConditionCoverage-oordelen en slaat een causa:ClaimCoverageAssessment op.
+
+    Aggregatielogica:
+    - Geen claims met conditie, of alle conditioned claims Full  → FullyCovered
+    - Enige conditioned claim Partial                            → PartiallyCovered
+    - (NotCovered gereserveerd voor CAPAX-integratie, Epic 9)
+
+    Retourneert: { assessment_id, assessment_uri, outcome }
+    """
+    alt_graph = f"urn:valor:ds:{ds_id}/alternative/{alt_id}"
+    proposed_uri = f"{VALOR_NS}ProposedStatus"
+    user_uri = f"urn:valor:user:{user_id}"
+    created_at = datetime.now(timezone.utc).isoformat()
+
+    # Bereken huidige coverage
+    coverage_items = await get_condition_coverage(ds_id, alt_id)
+    conditioned = [c for c in coverage_items if c["coverage"] != "None"]
+
+    if all(c["coverage"] == "Full" for c in conditioned):
+        outcome = "FullyCovered"
+    else:
+        outcome = "PartiallyCovered"
+
+    assessment_id = str(uuid.uuid4())
+    assessment_uri = f"urn:valor:assessment:{assessment_id}"
+    outcome_uri = f"{_CAUSA_NS}{outcome}"
+
+    # Verwijder eerder aangemaakte assessment voor dit alternatief
+    delete_sparql = f"""DELETE {{
+  GRAPH <{alt_graph}> {{ ?a ?p ?o }}
+}}
+WHERE {{
+  GRAPH <{alt_graph}> {{
+    ?a a <{_CAUSA_NS}ClaimCoverageAssessment> ;
+       ?p ?o .
+  }}
+}}"""
+    await sparql_update(delete_sparql, ds_id)
+
+    insert_sparql = f"""INSERT DATA {{
+  GRAPH <{alt_graph}> {{
+    <{assessment_uri}> a <{_CAUSA_NS}ClaimCoverageAssessment> ;
+      <{_CAUSA_NS}coverageOutcome> <{outcome_uri}> ;
+      <{VALOR_NS}epistemicStatus> <{proposed_uri}> ;
+      <{VALOR_NS}claimedBy> <{user_uri}> ;
+      <{VALOR_NS}claimedAt> "{created_at}"^^<{_XSD}dateTime> ;
+      <{VALOR_NS}inDesignSpace> <urn:valor:ds:{ds_id}> .
+  }}
+}}"""
+    await sparql_update(insert_sparql, ds_id)
+
+    return {"assessment_id": assessment_id, "assessment_uri": assessment_uri, "outcome": outcome}

--- a/backend/app/routers/designspace.py
+++ b/backend/app/routers/designspace.py
@@ -22,7 +22,7 @@ from app.models.domain import (
     ParticipantAdd, ParticipantResponse,
 )
 from app.ontology import VALOR_NS
-from app.db.fuseki_knowledge import get_condition_coverage
+from app.db.fuseki_knowledge import get_condition_coverage, create_claim_coverage_assessment
 from app.services.fuseki import (
     initialize_design_space_graphs, initialize_alternative_graph,
     sparql_proxy_query, sparql_select, sparql_update,
@@ -213,6 +213,39 @@ async def get_alternative_coverage(
     return [ConditionCoverageItem(**item) for item in items]
 
 
+class ClaimCoverageAssessmentResponse(BaseModel):
+    assessment_id: str
+    assessment_uri: str
+    outcome: str  # "FullyCovered" | "PartiallyCovered"
+
+
+@router.post(
+    "/{design_space_id}/alternative/{alternative_id}/assessment/coverage",
+    response_model=ClaimCoverageAssessmentResponse,
+    status_code=201,
+)
+async def create_coverage_assessment(
+    design_space_id: str,
+    alternative_id: str,
+    user: dict = Depends(get_current_user),
+) -> ClaimCoverageAssessmentResponse:
+    """Aggregeert ConditionCoverage en maakt een causa:ClaimCoverageAssessment Tessera aan."""
+    user_id = user["id"]
+
+    if not await check_permission(user_id, design_space_id, Role.MEMBER):
+        raise HTTPException(
+            status_code=403,
+            detail="Onvoldoende rechten voor deze DesignSpace.",
+        )
+
+    result = await create_claim_coverage_assessment(design_space_id, alternative_id, user_id)
+    logger.info(
+        "ClaimCoverageAssessment aangemaakt voor DesignSpace %s / alternatief %s: %s",
+        design_space_id, alternative_id, result["outcome"],
+    )
+    return ClaimCoverageAssessmentResponse(**result)
+
+
 @router.get("/{design_space_id}/sparql")
 async def sparql_query(
     design_space_id: str,
@@ -289,25 +322,39 @@ async def phase_transition(
     active_alternatives = [r["alt"] for r in alt_rows]
 
     # -- Gate-check per actief alternatief -------------------------------------
+    causa_ns = f"{VALOR_NS}causa#"
     missing_gates: list[str] = []
     for alt_uri in active_alternatives:
-        for gate_type, gate_label in [
-            (f"{VALOR_NS}FeasibilityAssessment", "FeasibilityAssessment"),
-            (f"{VALOR_NS}ClaimCoverageAssessment", "ClaimCoverageAssessment"),
-        ]:
-            rows = await sparql_select(
-                f"""SELECT ?status WHERE {{
-                  GRAPH <{asis_graph}> {{
-                    ?t a <{gate_type}> ;
-                       <{VALOR_NS}inAlternative> <{alt_uri}> ;
-                       <{VALOR_NS}epistemicStatus> ?status .
-                  }}
-                }}""",
-                design_space_id,
-            )
-            if not rows:
-                alt_label = alt_uri.rsplit(":", 1)[-1]
-                missing_gates.append(f"{gate_label} ontbreekt voor alternatief '{alt_label}'")
+        alt_id = alt_uri.rsplit("/", 1)[-1]
+        alt_graph = f"urn:valor:ds:{design_space_id}/alternative/{alt_id}"
+        alt_label = alt_id
+
+        # FeasibilityAssessment: in asis graph (CAPAX, Epic 9)
+        feasibility_rows = await sparql_select(
+            f"""SELECT ?status WHERE {{
+              GRAPH <{asis_graph}> {{
+                ?t a <{VALOR_NS}FeasibilityAssessment> ;
+                   <{VALOR_NS}inAlternative> <{alt_uri}> ;
+                   <{VALOR_NS}epistemicStatus> ?status .
+              }}
+            }}""",
+            design_space_id,
+        )
+        if not feasibility_rows:
+            missing_gates.append(f"FeasibilityAssessment ontbreekt voor alternatief '{alt_label}'")
+
+        # ClaimCoverageAssessment: in alternative graph (CAUSA-engine, US-4.8)
+        coverage_rows = await sparql_select(
+            f"""SELECT ?status WHERE {{
+              GRAPH <{alt_graph}> {{
+                ?t a <{causa_ns}ClaimCoverageAssessment> ;
+                   <{VALOR_NS}epistemicStatus> ?status .
+              }}
+            }}""",
+            design_space_id,
+        )
+        if not coverage_rows:
+            missing_gates.append(f"ClaimCoverageAssessment ontbreekt voor alternatief '{alt_label}'")
 
     if missing_gates:
         raise HTTPException(

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -580,6 +580,11 @@ export const api = {
         return response.data;
     },
 
+    createClaimCoverageAssessment: async (dsId: string, altId: string): Promise<{ assessment_id: string; assessment_uri: string; outcome: string }> => {
+        const response = await apiClient.post(`/designspace/${dsId}/alternative/${altId}/assessment/coverage`);
+        return response.data;
+    },
+
     getDesignSpacesByProject: async (projectId: string, themeId?: string): Promise<{ id: string; name: string; status: string; current_phase: string }[]> => {
         const response = await apiClient.get(`/designspace/by-project/${projectId}`, {
             params: themeId ? { theme_id: themeId } : undefined,


### PR DESCRIPTION
## Wat
`causa:ClaimCoverageAssessment` als gate-Tessera: aggregeert alle ConditionCoverage-oordelen per alternatief en legt de uitkomst vast als Tessera in de alternative named graph.

## Wijzigingen

**`fuseki_knowledge.py`** — `create_claim_coverage_assessment(ds_id, alt_id, user_id)`:
- Roept `get_condition_coverage()` aan voor actuele coverage-data
- Aggregeert: alle conditioned claims Full → `FullyCovered`, anders → `PartiallyCovered`
- Verwijdert vorige assessment, schrijft nieuwe `causa:ClaimCoverageAssessment` triple in alternative graph

**`designspace.py`** — `POST /designspace/{id}/alternative/{alt_id}/assessment/coverage`
- Vereist MEMBER-rol
- Retourneert `{ assessment_id, assessment_uri, outcome }`

**Gate-check fix** (fase transition):
- `ClaimCoverageAssessment` wordt nu gezocht in de **alternative graph** (was: asis graph)
- Gebruikt `causa:` namespace (was: `valor:`)
- `FeasibilityAssessment` blijft in asis graph (CAPAX, Epic 9)

**`api.ts`** — `createClaimCoverageAssessment(dsId, altId)`

## Verificatie
- ✅ Frontend build slaagt
- ✅ Python syntax correct
- ✅ Backend herstart zonder errors
- ✅ Beide endpoints in OpenAPI spec

Closes #359