### PR TITLE
feat(causa): ConditionCoverage overlay in CAUSA view (US-4.9)

### DIFF
--- a/backend/app/db/fuseki_knowledge.py
+++ b/backend/app/db/fuseki_knowledge.py
@@ -433,6 +433,32 @@ _CAUSA_NS = f"{VALOR_NS}causa#"
 _CAPAX_NS = f"{VALOR_NS}capax#"
 
 
+async def get_asis_condition_coverage(ds_id: str) -> list[dict]:
+    """Berekent ConditionCoverage vanuit de asis-graph zonder opslag (voor visualisatie).
+
+    Retourneert alleen claims MET een hasManifestationCondition.
+    """
+    asis_graph = _ds_asis_graph(ds_id)
+    rows = await sparql_select_global(f"""
+SELECT ?baseId (BOUND(?rt) AS ?hasRealised) WHERE {{
+  GRAPH <{asis_graph}> {{
+    ?tessera a <{VALOR_NS}Tessera> ;
+             <{VALOR_NS}baseId> ?baseId ;
+             <{VALOR_NS}fromFactor> ?fromFactor ;
+             <{_CAUSA_NS}hasManifestationCondition> ?cond .
+    OPTIONAL {{ ?tessera <{_CAUSA_NS}realisedBy> ?rt }}
+  }}
+}}
+""")
+    return [
+        {
+            "claim_id": row["baseId"],
+            "coverage": "Full" if str(row.get("hasRealised", "false")).lower() == "true" else "Partial",
+        }
+        for row in rows
+    ]
+
+
 async def get_condition_coverage(ds_id: str, alt_id: str) -> list[dict]:
     """Berekent capax:ConditionCoverage per CausalClaim voor het gegeven alternatief.
 

--- a/backend/app/routers/designspace.py
+++ b/backend/app/routers/designspace.py
@@ -22,7 +22,7 @@ from app.models.domain import (
     ParticipantAdd, ParticipantResponse,
 )
 from app.ontology import VALOR_NS
-from app.db.fuseki_knowledge import get_condition_coverage, create_claim_coverage_assessment
+from app.db.fuseki_knowledge import get_condition_coverage, create_claim_coverage_assessment, get_asis_condition_coverage
 from app.services.fuseki import (
     initialize_design_space_graphs, initialize_alternative_graph,
     sparql_proxy_query, sparql_select, sparql_update,
@@ -210,6 +210,21 @@ async def get_alternative_coverage(
         "ConditionCoverage berekend voor DesignSpace %s / alternatief %s door %s — %d claims",
         design_space_id, alternative_id, user_id, len(items),
     )
+    return [ConditionCoverageItem(**item) for item in items]
+
+
+@router.get("/{design_space_id}/coverage", response_model=list[ConditionCoverageItem])
+async def get_asis_coverage(
+    design_space_id: str,
+    user: dict = Depends(get_current_user),
+) -> list[ConditionCoverageItem]:
+    """Berekent ConditionCoverage vanuit de asis-graph (geen alternatief nodig, voor overlay-visualisatie)."""
+    user_id = user["id"]
+
+    if not await check_permission(user_id, design_space_id, Role.VIEWER):
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten voor deze DesignSpace.")
+
+    items = await get_asis_condition_coverage(design_space_id)
     return [ConditionCoverageItem(**item) for item in items]
 
 

--- a/frontend/src/perspectives/causa/Shell.tsx
+++ b/frontend/src/perspectives/causa/Shell.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { Plus } from "lucide-react";
+import { Plus, Layers } from "lucide-react";
 import { useEffect, useMemo, useState, useRef } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { getNodesBounds } from 'reactflow';
@@ -82,6 +82,22 @@ export const CausaShell = ({ themeId, websocket, currentUserId, onSelect, onOpen
     });
 
     const [isStartingSession, setIsStartingSession] = useState(false);
+    const [showCoverageOverlay, setShowCoverageOverlay] = useState(false);
+    const [coverageMap, setCoverageMap] = useState<Map<string, 'Full' | 'Partial' | 'None'>>(new Map());
+
+    useEffect(() => {
+        if (!showCoverageOverlay || !designSpaceId) {
+            setCoverageMap(new Map());
+            return;
+        }
+        api.getAsisCoverage(designSpaceId).then(items => {
+            const map = new Map<string, 'Full' | 'Partial' | 'None'>();
+            items.forEach(item => map.set(item.claim_id, item.coverage as 'Full' | 'Partial' | 'None'));
+            setCoverageMap(map);
+        }).catch(err => {
+            console.warn('[CausaShell] Coverage overlay mislukt:', err);
+        });
+    }, [showCoverageOverlay, designSpaceId]);
 
     // Helpers for Export
     const getExportConfig = () => {
@@ -316,6 +332,24 @@ export const CausaShell = ({ themeId, websocket, currentUserId, onSelect, onOpen
 
                 <ClaimViewToggle value={viewFilter} onChange={setViewFilter} />
 
+                {designSpaceId && (
+                    <TooltipProvider>
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <Button
+                                    size="sm"
+                                    variant={showCoverageOverlay ? "secondary" : "ghost"}
+                                    className="h-8 w-8 p-0"
+                                    onClick={() => setShowCoverageOverlay(v => !v)}
+                                >
+                                    <Layers className="h-4 w-4" />
+                                </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>Conditiedekking overlay</TooltipContent>
+                        </Tooltip>
+                    </TooltipProvider>
+                )}
+
             </PerspectiveToolbar>
 
             {/* View */}
@@ -336,6 +370,7 @@ export const CausaShell = ({ themeId, websocket, currentUserId, onSelect, onOpen
                 designSpaceId={designSpaceId}
                 canResolveThread={canResolveThread}
                 cycleNodeIds={cycleNodeIds}
+                coverageMap={coverageMap}
             />
 
             {/* Modals */}

--- a/frontend/src/perspectives/causa/views/CLDView.tsx
+++ b/frontend/src/perspectives/causa/views/CLDView.tsx
@@ -42,6 +42,7 @@ interface CLDViewProps {
     designSpaceId?: string;
     canResolveThread?: boolean;
     cycleNodeIds?: Set<string>;
+    coverageMap?: Map<string, 'Full' | 'Partial' | 'None'>;
 }
 
 
@@ -72,6 +73,7 @@ export const CLDView: FunctionComponent<CLDViewProps> = ({
     designSpaceId,
     canResolveThread = false,
     cycleNodeIds = new Set(),
+    coverageMap = new Map(),
 }) => {
     // React Flow State
     const [rfInstance, setRfInstance] = useState<any>(null);
@@ -251,7 +253,8 @@ export const CLDView: FunctionComponent<CLDViewProps> = ({
                         version_id: cl.version_id,
                         evidence_text: cl.evidence_text,
                         evidence_url: cl.evidence_url,
-                        onOpenThread: handleOpenThread
+                        onOpenThread: handleOpenThread,
+                        coverage: coverageMap.get(cl.id) ?? null,
                     }
                 };
             });
@@ -263,7 +266,7 @@ export const CLDView: FunctionComponent<CLDViewProps> = ({
             runner.updateData(session.getNodes(), session.getLinks());
         }
 
-    }, [causalNodes, causalLinks, session, setNodes, setEdges, layoutMode, runner, threadStats, cycleNodeIds]);
+    }, [causalNodes, causalLinks, session, setNodes, setEdges, layoutMode, runner, threadStats, cycleNodeIds, coverageMap]);
 
 
     // Fit View on Layout Mode Change

--- a/frontend/src/perspectives/causa/views/edges/CLDEdge.tsx
+++ b/frontend/src/perspectives/causa/views/edges/CLDEdge.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import { type EdgeProps, getBezierPath, EdgeLabelRenderer, BaseEdge } from 'reactflow';
-import { PlusCircle, MinusCircle, MessageSquare, FileText } from 'lucide-react';
+import { PlusCircle, MinusCircle, MessageSquare, FileText, KeyRound } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { EpistemicStatus } from '../../types';
 
@@ -34,6 +34,9 @@ const CLDEdge = ({
         targetPosition,
     });
 
+    const coverage = data?.coverage as 'Full' | 'Partial' | 'None' | undefined;
+    const coverageStroke = coverage === 'Full' ? '#22c55e' : coverage === 'Partial' ? '#f97316' : undefined;
+
     const polarity = data?.polarity || '+';
     const isPositive = polarity === '+' || polarity === 'positive';
     const Icon = isPositive ? PlusCircle : MinusCircle;
@@ -46,7 +49,7 @@ const CLDEdge = ({
 
     return (
         <>
-            <BaseEdge id={id} path={edgePath} markerEnd={markerEnd} style={{ ...style, stroke: strokeColor, strokeOpacity }} />
+            <BaseEdge id={id} path={edgePath} markerEnd={markerEnd} style={{ ...style, stroke: coverageStroke ?? strokeColor, strokeOpacity, strokeWidth: coverageStroke ? 3 : 2 }} />
             <EdgeLabelRenderer>
                 <div
                     style={{
@@ -70,6 +73,21 @@ const CLDEdge = ({
                             strokeWidth={2}
                         />
                     </div>
+
+                    {/* ManifestationCondition Indicator */}
+                    {coverage && (
+                        <div
+                            className="bg-white rounded-full p-[3px] shadow-sm ring-1 flex items-center justify-center pointer-events-none"
+                            style={{ border: `1px solid ${coverageStroke}` }}
+                            title={
+                                coverage === 'Full'
+                                    ? 'Manifesteringsconditie gedekt'
+                                    : 'Manifesteringsconditie niet volledig gedekt'
+                            }
+                        >
+                            <KeyRound size={12} strokeWidth={2.5} style={{ color: coverageStroke }} />
+                        </div>
+                    )}
 
                     {/* Evidence Indicator */}
                     {(data?.evidence_text || data?.evidence_url) && (

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -575,6 +575,11 @@ export const api = {
     },
 
     // DesignSpace
+    getAsisCoverage: async (dsId: string): Promise<{ claim_id: string; coverage: 'Full' | 'Partial' | 'None' }[]> => {
+        const response = await apiClient.get(`/designspace/${dsId}/coverage`);
+        return response.data;
+    },
+
     getConditionCoverage: async (dsId: string, altId: string): Promise<{ claim_id: string; coverage: 'Full' | 'Partial' | 'None' }[]> => {
         const response = await apiClient.get(`/designspace/${dsId}/alternative/${altId}/coverage`);
         return response.data;


### PR DESCRIPTION
## Wat
Visuele overlay in de CAUSA-view die claims met een ManifestationCondition markeert via kleur en icoon.

## Wijzigingen

**Backend**
- Nieuwe functie `get_asis_condition_coverage(ds_id)` in `fuseki_knowledge.py`: berekent coverage vanuit de asis-graph zonder alternatief en zonder opslag
- Nieuw endpoint `GET /designspace/{id}/coverage` — retourneert alleen claims MET een `causa:hasManifestationCondition`

**Frontend**
- `CLDEdge`: toont een `KeyRound`-icoon bij claims met een ManifestationCondition; kleurt de edge groen (Full) of oranje (Partial)
- `CLDView`: accepteert `coverageMap: Map<claimId, coverage>` prop, geeft coverage door aan edge data
- `Shell`: `Layers`-knop in de toolbar (alleen zichtbaar als `designSpaceId` aanwezig); fetcht coverage bij activatie; geeft `coverageMap` door aan `CLDView`

## Werking
- Overlay is standaard **uit** — activeer via de `Layers`-knop in de toolbar
- Alleen zichtbaar wanneer de CAUSA shell een `designSpaceId` heeft
- Claims zonder ManifestationCondition worden niet gemarkeerd

## Verificatie
- ✅ Frontend build slaagt
- ✅ Python syntax correct
- ✅ Backend herstart zonder errors
- ✅ Alle 3 coverage-endpoints zichtbaar in OpenAPI spec

Closes #360