### PR TITLE
feat(causa): manifestation_condition veld in claim edit modal (US-4.5)

### DIFF
--- a/backend/app/db/fuseki_knowledge.py
+++ b/backend/app/db/fuseki_knowledge.py
@@ -236,7 +236,7 @@ async def _sparql_get_claims(ds_id: str, claim_type: Optional[str] = None) -> li
     rows = await sparql_select_global(f"""
 SELECT ?tessera ?baseId ?statement ?polarity ?confidence
        ?fromFactor ?sourceBaseId ?toFactor ?targetBaseId
-       ?evidenceText ?claimedAt WHERE {{
+       ?evidenceText ?claimedAt ?manifestationCondition WHERE {{
   GRAPH <{asis_graph}> {{
     ?tessera a <{VALOR_NS}Tessera> ;
              <{VALOR_NS}baseId> ?baseId ;
@@ -250,6 +250,7 @@ SELECT ?tessera ?baseId ?statement ?polarity ?confidence
     OPTIONAL {{ ?tessera <{VALOR_NS}confidence>   ?confidence }}
     OPTIONAL {{ ?tessera <{VALOR_NS}evidenceText> ?evidenceText }}
     OPTIONAL {{ ?tessera <{VALOR_NS}claimedAt>    ?claimedAt }}
+    OPTIONAL {{ ?tessera <{_CAUSA_NS}hasManifestationCondition> ?manifestationCondition }}
   }}
 }}
 """)
@@ -272,6 +273,7 @@ SELECT ?tessera ?baseId ?statement ?polarity ?confidence
             "created_at": row.get("claimedAt"),
             "created_by": None,
             "status": None,
+            "manifestation_condition": row.get("manifestationCondition"),
         }
         for row in rows
     ]
@@ -341,6 +343,7 @@ async def update_claim_fuseki(
     polarity: Optional[str] = None,
     confidence: Optional[float] = None,
     evidence_text: Optional[str] = None,
+    manifestation_condition: Optional[str] = None,
 ) -> None:
     """Werkt een bestaande Claim-Tessera bij in Fuseki (alleen opgegeven velden)."""
     tessera_uri = _tessera_uri(tessera_id)
@@ -367,6 +370,12 @@ async def update_claim_fuseki(
         deletes.append(f"<{tessera_uri}> <{VALOR_NS}evidenceText> ?oldEvid .")
         inserts.append(f'<{tessera_uri}> <{VALOR_NS}evidenceText> "{_escape(evidence_text)}"@nl .')
         optionals.append(f"OPTIONAL {{ <{tessera_uri}> <{VALOR_NS}evidenceText> ?oldEvid }}")
+
+    if manifestation_condition is not None:
+        deletes.append(f"<{tessera_uri}> <{_CAUSA_NS}hasManifestationCondition> ?oldMc .")
+        if manifestation_condition:
+            inserts.append(f'<{tessera_uri}> <{_CAUSA_NS}hasManifestationCondition> "{_escape(manifestation_condition)}"@nl .')
+        optionals.append(f"OPTIONAL {{ <{tessera_uri}> <{_CAUSA_NS}hasManifestationCondition> ?oldMc }}")
 
     if not deletes:
         return

--- a/backend/app/routers/claims.py
+++ b/backend/app/routers/claims.py
@@ -33,6 +33,7 @@ class ClaimUpdate(BaseModel):
     target_id: Optional[str] = None
     evidence_text: Optional[str] = None
     evidence_url: Optional[str] = None
+    manifestation_condition: Optional[str] = None
 
 
 _VALID_CLAIM_TYPES = {"AsIsType", "ToBeType"}
@@ -111,6 +112,7 @@ async def update_claim_route(claim_id: str, claim: ClaimUpdate, user: dict = Dep
         polarity=claim.polarity,
         confidence=claim.confidence,
         evidence_text=claim.evidence_text,
+        manifestation_condition=claim.manifestation_condition,
     )
 
     project_id = await fuseki_knowledge.get_project_id_for_designspace(ds_id)

--- a/frontend/src/perspectives/causa/views/modals/EditFactorDetailModal.tsx
+++ b/frontend/src/perspectives/causa/views/modals/EditFactorDetailModal.tsx
@@ -46,6 +46,7 @@ export const EditFactorDetailModal: React.FC<EditFactorDetailModalProps> = ({
     const [targetId, setTargetId] = useState('');
     const [evidenceText, setEvidenceText] = useState('');
     const [evidenceUrl, setEvidenceUrl] = useState('');
+    const [manifestationCondition, setManifestationCondition] = useState('');
 
     const [isSaving, setIsSaving] = useState(false);
     const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
@@ -93,6 +94,7 @@ export const EditFactorDetailModal: React.FC<EditFactorDetailModalProps> = ({
             setTargetId(data.target_id || data.target || '');
             setEvidenceText(data.evidence_text || '');
             setEvidenceUrl(data.evidence_url || '');
+            setManifestationCondition(data.manifestation_condition || '');
         }
     }, [selection, open]);
 
@@ -110,7 +112,8 @@ export const EditFactorDetailModal: React.FC<EditFactorDetailModalProps> = ({
                     source_id: sourceId,
                     target_id: targetId,
                     evidence_text: evidenceText,
-                    evidence_url: evidenceUrl
+                    evidence_url: evidenceUrl,
+                    manifestation_condition: manifestationCondition || undefined,
                 });
             }
             toast.success("Wijzigingen opgeslagen.");
@@ -322,6 +325,17 @@ export const EditFactorDetailModal: React.FC<EditFactorDetailModalProps> = ({
                                 <div className="grid gap-2">
                                     <Label htmlFor="evidenceText">Bewijs / Context</Label>
                                     <Textarea id="evidenceText" value={evidenceText} onChange={e => setEvidenceText(e.target.value)} disabled={readOnly} placeholder="Geciteerde tekst of toelichting..." />
+                                </div>
+                                <div className="grid gap-2">
+                                    <Label htmlFor="manifestationCondition">Manifesteringsconditie</Label>
+                                    <Textarea
+                                        id="manifestationCondition"
+                                        value={manifestationCondition}
+                                        onChange={e => setManifestationCondition(e.target.value)}
+                                        disabled={readOnly}
+                                        placeholder="Welke systeemconditie moet aanwezig zijn voor deze relatie om te manifesteren?"
+                                        className="text-sm"
+                                    />
                                 </div>
                                 <div className="grid grid-cols-2 gap-4">
                                     <div className="grid gap-2">

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -524,6 +524,7 @@ export const api = {
         target_id?: string;
         evidence_text?: string;
         evidence_url?: string;
+        manifestation_condition?: string;
     }) => {
         const response = await apiClient.patch(`/claims/${id}`, data);
         return response.data;


### PR DESCRIPTION
## Wat

Maakt het mogelijk om `causa:hasManifestationCondition` in te stellen op een bestaande CausalClaim via de UI — noodzakelijk om US-4.7/4.8/4.9 te kunnen testen.

## Wijzigingen

**Backend**
- `fuseki_knowledge.py`: `_sparql_get_claims` geeft nu `manifestation_condition` terug via OPTIONAL SPARQL-clausule
- `fuseki_knowledge.py`: `update_claim_fuseki` accepteert `manifestation_condition` en schrijft DELETE/INSERT naar `causa:hasManifestationCondition`
- `claims.py`: `ClaimUpdate` model en `PATCH /claims/{id}` route doorgestuurd met `manifestation_condition`

**Frontend**
- `api.ts`: `updateClaim` type uitgebreid met `manifestation_condition?: string`
- `EditFactorDetailModal`: Textarea veld "Manifesteringsconditie" toegevoegd bij verbinding bewerken; pre-populated vanuit bestaande waarde; meegestuurd bij opslaan

## Testen

1. Open een CausalClaim in de CAUSA-view (klik op een edge → bewerken)
2. Vul "Manifesteringsconditie" in
3. Opslaan
4. Activeer de Layers-knop in de toolbar → edge kleurt oranje (Partial, want geen `realisedBy`)

Closes #356