### PR TITLE
feat(delibera): stem op Tessera via DecisionEpisode (US-5.2)

### DIFF
--- a/backend/app/models/domain.py
+++ b/backend/app/models/domain.py
@@ -280,7 +280,7 @@ class VotingSession(BaseModel):
 class Feedback(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     session_id: str
-    claim_version_id: str
+    tessera_base_id: str
     user_id: str
     color: str # green, amber, red
     motivation: Optional[str] = None
@@ -295,7 +295,7 @@ class RankingCategory(str, Enum):
 class Ranking(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     session_id: str
-    claim_version_id: str
+    tessera_base_id: str
     user_id: str
     category: RankingCategory
     created_at: datetime = Field(default_factory=datetime.now)
@@ -307,8 +307,32 @@ class ConsentVoteType(str, Enum):
 class ConsentVote(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     session_id: str
-    claim_version_id: str
+    tessera_base_id: str
     user_id: str
     vote: ConsentVoteType
     motivation: Optional[str] = None
     created_at: datetime = Field(default_factory=datetime.now)
+
+
+# --- Tessera Voting (US-5.2) ---
+
+class TesseraVoteType(str, Enum):
+    ACCEPT = "Accept"
+    REJECT = "Reject"
+    DEFER = "Defer"
+
+
+class CastVoteRequest(BaseModel):
+    design_space_id: str
+    vote_type: TesseraVoteType
+    alternative_id: Optional[str] = None  # aanwezig als Tessera in een DesignAlternative zit
+
+
+class VoteResponse(BaseModel):
+    vote_uri: str
+    episode_uri: str
+    tessera_id: str
+    tessera_uri: str
+    vote_type: str
+    quorum_reached: bool
+    new_epistemic_status: Optional[str] = None

--- a/backend/app/routers/tessera.py
+++ b/backend/app/routers/tessera.py
@@ -8,8 +8,9 @@ from pydantic import BaseModel
 
 from app.auth import get_current_user
 from app.db.permissions import check_permission
-from app.models.domain import Role
+from app.models.domain import Role, CastVoteRequest, VoteResponse
 from app.services.fuseki import sparql_select, sparql_update, sparql_shacl_validate, named_graph_uri, record_provenance_activity
+from app.services.fuseki_decisions import create_or_get_decision_episode, cast_vote, evaluate_quorum
 from app.services.ontology_cache import (
     get_evidence_label_to_uri,
     get_status_label_to_uri,
@@ -19,6 +20,7 @@ from app.services.ontology_cache import (
     get_argue_label_to_uri,
     get_shacl_shapes_graph,
     get_uncertainty_label_to_uri,
+    get_participant_role_data,
 )
 from app.ontology import VALOR_NS
 
@@ -854,3 +856,124 @@ SELECT ?activity ?used WHERE {{
         ))
 
     return results
+
+
+# --- Stemmen op een Tessera via DecisionEpisode (US-5.2) ---
+
+_VOTING_VALOR_ROLES = {"Initiator", "Contributor"}
+
+
+@router.post("/{tessera_id}/vote", response_model=VoteResponse, status_code=201)
+async def cast_tessera_vote(
+    tessera_id: str,
+    request: CastVoteRequest,
+    user: dict = Depends(get_current_user),
+):
+    """Brengt een stem (Accept/Reject/Defer) uit op een Tessera via een DecisionEpisode.
+
+    Alleen gebruikers met VALOR-O rol Initiator of Contributor mogen stemmen (HTTP 403 anders).
+    Na elke stem wordt quorum geëvalueerd; bij quorum wijzigt de epistemische status automatisch.
+    """
+    user_id = user["id"]
+    user_uri = f"urn:valor:user:{user_id}"
+
+    # Basis leesrecht op de DesignSpace
+    if not await check_permission(user_id, request.design_space_id, Role.MEMBER):
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten voor deze DesignSpace.")
+
+    # Controleer stemrecht via VALOR-O rol
+    participant_role_data = get_participant_role_data()
+    voting_role_uris = {
+        data["uri"]
+        for label, data in participant_role_data.items()
+        if label in _VOTING_VALOR_ROLES
+    }
+
+    decisions_graph = f"urn:valor:ds:{request.design_space_id}/decisions"
+    participant_rows = await sparql_select(
+        f"""SELECT ?role WHERE {{
+          GRAPH <{decisions_graph}> {{
+            ?participant <{VALOR_NS}hasUser> <{user_uri}> ;
+                         <{VALOR_NS}hasValorRole> ?role .
+          }}
+        }}""",
+        request.design_space_id,
+    )
+
+    voter_has_right = any(
+        row["role"] in voting_role_uris for row in participant_rows
+    )
+    if not voter_has_right:
+        raise HTTPException(
+            status_code=403,
+            detail="Alleen Initiator of Contributor mag stemmen op een Tessera.",
+        )
+
+    tessera_uri = f"urn:valor:tessera:{tessera_id}"
+
+    # Bepaal de graph waar de Tessera in staat
+    if request.alternative_id:
+        tessera_graph = f"urn:valor:ds:{request.design_space_id}/alternative/{request.alternative_id}"
+    else:
+        tessera_graph = named_graph_uri(request.design_space_id)
+
+    # Controleer dat de Tessera bestaat
+    exist_rows = await sparql_select(
+        f"""SELECT ?t WHERE {{
+          GRAPH <{tessera_graph}> {{
+            <{tessera_uri}> a <{VALOR_NS}Tessera> .
+            BIND(<{tessera_uri}> AS ?t)
+          }}
+        }}""",
+        request.design_space_id,
+    )
+    if not exist_rows:
+        raise HTTPException(status_code=404, detail="Tessera niet gevonden in deze DesignSpace.")
+
+    # DecisionEpisode ophalen of aanmaken
+    episode_uri = await create_or_get_decision_episode(
+        request.design_space_id,
+        tessera_uri,
+        user_uri,
+    )
+
+    # Stem uitbrengen
+    vote_uri = await cast_vote(
+        request.design_space_id,
+        episode_uri,
+        tessera_uri,
+        user_uri,
+        request.vote_type.value,
+    )
+
+    # Provenance vastleggen
+    await record_provenance_activity(
+        request.design_space_id,
+        "VoteCast",
+        user_uri,
+        generated=vote_uri,
+        used=[tessera_uri, episode_uri],
+    )
+
+    # Quorum evalueren
+    new_status = await evaluate_quorum(
+        request.design_space_id,
+        episode_uri,
+        tessera_uri,
+        tessera_graph,
+    )
+
+    logger.info(
+        "Stem uitgebracht: %s op Tessera %s (episode %s) door %s — quorum: %s",
+        request.vote_type.value, tessera_uri, episode_uri, user_id, new_status is not None,
+    )
+
+    return VoteResponse(
+        vote_uri=vote_uri,
+        episode_uri=episode_uri,
+        tessera_id=tessera_id,
+        tessera_uri=tessera_uri,
+        vote_type=request.vote_type.value,
+        quorum_reached=new_status is not None,
+        new_epistemic_status=new_status,
+    )

--- a/backend/app/services/fuseki_decisions.py
+++ b/backend/app/services/fuseki_decisions.py
@@ -1,0 +1,260 @@
+"""Fuseki-operaties voor DecisionEpisodes en stemmen (US-5.2).
+
+Alle schrijfoperaties gaan naar de `decisions` named graph van de DesignSpace.
+Quorumdrempel is configureerbaar via env var VALOR_QUORUM_THRESHOLD (default 0.5).
+"""
+import logging
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from app.ontology import VALOR_NS
+from app.services.fuseki import sparql_select, sparql_update, record_provenance_activity
+
+logger = logging.getLogger(__name__)
+
+PROV_NS = "https://www.w3.org/ns/prov#"
+XSD_NS = "http://www.w3.org/2001/XMLSchema#"
+
+QUORUM_THRESHOLD = float(os.getenv("VALOR_QUORUM_THRESHOLD", "0.5"))
+
+_VOTE_TYPE_URIS = {
+    "Accept": f"{VALOR_NS}AcceptVote",
+    "Reject": f"{VALOR_NS}RejectVote",
+    "Defer":  f"{VALOR_NS}DeferVote",
+}
+
+_VOTE_URI_TO_TYPE = {v: k for k, v in _VOTE_TYPE_URIS.items()}
+
+
+def _decisions_graph(ds_id: str) -> str:
+    return f"urn:valor:ds:{ds_id}/decisions"
+
+
+async def create_or_get_decision_episode(
+    ds_id: str,
+    tessera_uri: str,
+    created_by_uri: str,
+) -> str:
+    """Geeft de URI van een bestaande open DecisionEpisode voor de Tessera,
+    of maakt een nieuwe aan als er nog geen is.
+
+    Retourneert episode_uri.
+    """
+    decisions_graph = _decisions_graph(ds_id)
+
+    rows = await sparql_select(
+        f"""SELECT ?episode WHERE {{
+          GRAPH <{decisions_graph}> {{
+            ?episode a <{VALOR_NS}DecisionEpisode> ;
+                     <{VALOR_NS}concernsTessera> <{tessera_uri}> ;
+                     <{VALOR_NS}episodeStatus> <{VALOR_NS}OpenEpisode> .
+          }}
+        }}""",
+        ds_id,
+    )
+
+    if rows:
+        return rows[0]["episode"]
+
+    episode_id = str(uuid.uuid4())
+    episode_uri = f"urn:valor:episode:{episode_id}"
+    created_at = datetime.now(timezone.utc).isoformat()
+
+    update = f"""INSERT DATA {{
+  GRAPH <{decisions_graph}> {{
+    <{episode_uri}> a <{VALOR_NS}DecisionEpisode> ;
+      <{VALOR_NS}concernsTessera> <{tessera_uri}> ;
+      <{VALOR_NS}episodeStatus> <{VALOR_NS}OpenEpisode> ;
+      <{VALOR_NS}createdBy> <{created_by_uri}> ;
+      <{VALOR_NS}createdAt> "{created_at}"^^<{XSD_NS}dateTime> .
+  }}
+}}"""
+    await sparql_update(update, ds_id)
+
+    logger.info("DecisionEpisode aangemaakt: %s voor Tessera %s", episode_uri, tessera_uri)
+    return episode_uri
+
+
+async def cast_vote(
+    ds_id: str,
+    episode_uri: str,
+    tessera_uri: str,
+    voter_uri: str,
+    vote_type: str,
+) -> str:
+    """Schrijft een valor:Vote naar de decisions graph.
+
+    Een gebruiker kan per episode maar één stem uitbrengen — bestaande stem
+    wordt vervangen (idempotent per kiezer per episode).
+
+    Retourneert vote_uri.
+    """
+    vote_type_uri = _VOTE_TYPE_URIS.get(vote_type)
+    if not vote_type_uri:
+        raise ValueError(f"Ongeldig vote_type '{vote_type}'. Geldige waarden: {sorted(_VOTE_TYPE_URIS)}.")
+
+    decisions_graph = _decisions_graph(ds_id)
+    voted_at = datetime.now(timezone.utc).isoformat()
+
+    # Verwijder bestaande stem van dezelfde kiezer op hetzelfde episode
+    delete_existing = f"""DELETE {{
+  GRAPH <{decisions_graph}> {{
+    ?existing_vote a <{VALOR_NS}Vote> ;
+      <{VALOR_NS}castBy> <{voter_uri}> ;
+      <{VALOR_NS}inEpisode> <{episode_uri}> ;
+      <{VALOR_NS}voteType> ?old_type ;
+      <{VALOR_NS}votedAt> ?old_at .
+  }}
+}}
+WHERE {{
+  GRAPH <{decisions_graph}> {{
+    ?existing_vote a <{VALOR_NS}Vote> ;
+      <{VALOR_NS}castBy> <{voter_uri}> ;
+      <{VALOR_NS}inEpisode> <{episode_uri}> ;
+      <{VALOR_NS}voteType> ?old_type ;
+      <{VALOR_NS}votedAt> ?old_at .
+  }}
+}}"""
+    await sparql_update(delete_existing, ds_id)
+
+    vote_id = str(uuid.uuid4())
+    vote_uri = f"urn:valor:vote:{vote_id}"
+
+    insert = f"""INSERT DATA {{
+  GRAPH <{decisions_graph}> {{
+    <{vote_uri}> a <{VALOR_NS}Vote> ;
+      <{VALOR_NS}castBy> <{voter_uri}> ;
+      <{VALOR_NS}inEpisode> <{episode_uri}> ;
+      <{VALOR_NS}voteType> <{vote_type_uri}> ;
+      <{VALOR_NS}votedAt> "{voted_at}"^^<{XSD_NS}dateTime> .
+    <{episode_uri}> <{VALOR_NS}hasVote> <{vote_uri}> .
+  }}
+}}"""
+    await sparql_update(insert, ds_id)
+
+    logger.info("Vote %s uitgebracht: %s door %s op episode %s", vote_uri, vote_type, voter_uri, episode_uri)
+    return vote_uri
+
+
+async def evaluate_quorum(
+    ds_id: str,
+    episode_uri: str,
+    tessera_uri: str,
+    graph_uri: str,
+) -> Optional[str]:
+    """Berekent of quorum bereikt is en past epistemische status aan indien nodig.
+
+    Telt Accept en Reject stemmen. Als één van de twee > QUORUM_THRESHOLD van het
+    totaal aantal stemmen, sluit het episode en wijzigt de epistemische status.
+
+    Retourneert de nieuwe status-label als quorum bereikt is, anders None.
+    """
+    from app.services.ontology_cache import get_status_label_to_uri, get_status_uri_to_label
+
+    decisions_graph = _decisions_graph(ds_id)
+
+    vote_rows = await sparql_select(
+        f"""SELECT ?voteType (COUNT(?vote) AS ?count) WHERE {{
+          GRAPH <{decisions_graph}> {{
+            ?vote a <{VALOR_NS}Vote> ;
+              <{VALOR_NS}inEpisode> <{episode_uri}> ;
+              <{VALOR_NS}voteType> ?voteType .
+          }}
+        }}
+        GROUP BY ?voteType""",
+        ds_id,
+    )
+
+    counts: dict[str, int] = {}
+    for row in vote_rows:
+        vtype_uri = row["voteType"]
+        label = _VOTE_URI_TO_TYPE.get(vtype_uri, vtype_uri)
+        counts[label] = int(row["count"])
+
+    total = sum(counts.values())
+    if total == 0:
+        return None
+
+    accept_count = counts.get("Accept", 0)
+    reject_count = counts.get("Reject", 0)
+
+    new_status_label: Optional[str] = None
+    if accept_count / total > QUORUM_THRESHOLD:
+        new_status_label = "Accepted"
+    elif reject_count / total > QUORUM_THRESHOLD:
+        new_status_label = "Rejected"
+
+    if not new_status_label:
+        return None
+
+    status_label_to_uri = get_status_label_to_uri()
+    new_status_uri = status_label_to_uri.get(new_status_label)
+    if not new_status_uri:
+        logger.warning("Status '%s' niet gevonden in ontologie, quorum niet toegepast.", new_status_label)
+        return None
+
+    # Haal huidige status op uit de correcte graph
+    status_rows = await sparql_select(
+        f"""SELECT ?status WHERE {{
+          GRAPH <{graph_uri}> {{
+            <{tessera_uri}> <{VALOR_NS}epistemicStatus> ?status .
+          }}
+        }}""",
+        ds_id,
+    )
+    if not status_rows:
+        logger.warning("Tessera %s niet gevonden in graph %s voor quorum-update.", tessera_uri, graph_uri)
+        return None
+
+    current_uri = status_rows[0]["status"]
+
+    # Update epistemische status in de tessera-graph
+    await sparql_update(
+        f"""DELETE {{
+  GRAPH <{graph_uri}> {{
+    <{tessera_uri}> <{VALOR_NS}epistemicStatus> <{current_uri}> .
+  }}
+}}
+INSERT {{
+  GRAPH <{graph_uri}> {{
+    <{tessera_uri}> <{VALOR_NS}epistemicStatus> <{new_status_uri}> .
+  }}
+}}
+WHERE {{
+  GRAPH <{graph_uri}> {{
+    <{tessera_uri}> <{VALOR_NS}epistemicStatus> <{current_uri}> .
+  }}
+}}""",
+        ds_id,
+    )
+
+    # Sluit het episode
+    closed_at = datetime.now(timezone.utc).isoformat()
+    await sparql_update(
+        f"""DELETE {{
+  GRAPH <{decisions_graph}> {{
+    <{episode_uri}> <{VALOR_NS}episodeStatus> <{VALOR_NS}OpenEpisode> .
+  }}
+}}
+INSERT {{
+  GRAPH <{decisions_graph}> {{
+    <{episode_uri}> <{VALOR_NS}episodeStatus> <{VALOR_NS}ClosedEpisode> ;
+                    <{VALOR_NS}closedAt> "{closed_at}"^^<{XSD_NS}dateTime> ;
+                    <{VALOR_NS}resolvedWith> <{new_status_uri}> .
+  }}
+}}
+WHERE {{
+  GRAPH <{decisions_graph}> {{
+    <{episode_uri}> <{VALOR_NS}episodeStatus> <{VALOR_NS}OpenEpisode> .
+  }}
+}}""",
+        ds_id,
+    )
+
+    logger.info(
+        "Quorum bereikt op episode %s: Tessera %s → %s",
+        episode_uri, tessera_uri, new_status_label,
+    )
+    return new_status_label


### PR DESCRIPTION
## Summary

- Nieuwe service `fuseki_decisions.py` met drie functies: `create_or_get_decision_episode`, `cast_vote` en `evaluate_quorum` — alle schrijfoperaties gaan naar de `decisions` named graph
- Nieuwe route `POST /tessera/{tessera_id}/vote` — brengt een `valor:Vote` (Accept/Reject/Defer) uit via een `valor:DecisionEpisode`
- RBAC: alleen VALOR-O rollen Initiator en Contributor mogen stemmen (HTTP 403 anders)
- Quorumdrempel configureerbaar via env var `VALOR_QUORUM_THRESHOLD` (default 0.5); epistemische status wijzigt automatisch naar Accepted of Rejected na quorum
- Pydantic modellen `TesseraVoteType`, `CastVoteRequest` en `VoteResponse` toegevoegd aan `domain.py`

Sluit #303

## Test plan

- [ ] `POST /tessera/{tessera_id}/vote` met `vote_type: "Accept"` als Initiator → HTTP 201, `vote_uri` en `episode_uri` in response
- [ ] Zelfde aanroep als gebruiker zonder Initiator/Contributor rol → HTTP 403
- [ ] Twee Accept-stemmen bij twee stemgerechtigden → `quorum_reached: true`, `new_epistemic_status: "Accepted"`
- [ ] Meerderheid Reject → `new_epistemic_status: "Rejected"`
- [ ] Stem op niet-bestaande Tessera → HTTP 404
- [ ] Stem op Tessera in DesignAlternative (met `alternative_id`) → Vote correct opgeslagen in decisions graph
- [ ] Dezelfde kiezer stemt opnieuw → vorige stem vervangen (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)