### PR TITLE
feat(delibera): beslissingstijdlijn van DecisionEpisodes (US-5.4)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ import { VersionDashboard } from './pages/VersionDashboard';
 import { VersionChat } from './pages/VersionChat';
 import { RefinementBoardComponent } from './components/deliberation/RefinementBoard';
 import { ArgumentationDiagram } from './components/deliberation/ArgumentationDiagram';
+import { DecisionTimeline } from './components/deliberation/DecisionTimeline';
 import { DesignSpaceProvider } from './context/DesignSpaceContext';
 
 function App() {
@@ -124,6 +125,7 @@ function App() {
               <Route path="overview" element={<VersionDashboard />} />
               <Route path="claims" element={<RefinementBoardComponent />} />
               <Route path="argumentatie" element={<ArgumentationDiagram />} />
+              <Route path="tijdlijn" element={<DecisionTimeline />} />
               <Route path="chat" element={<VersionChat />} />
               <Route path="members" element={<div className="p-8">Members (Coming Soon)</div>} />
               <Route path="settings" element={<div className="p-8">Version Settings (Coming Soon)</div>} />

--- a/frontend/src/components/deliberation/DecisionTimeline.tsx
+++ b/frontend/src/components/deliberation/DecisionTimeline.tsx
@@ -1,0 +1,191 @@
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useParams } from 'react-router-dom';
+import { AlertCircle, Loader2, Clock, User, Tag } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { api, type DecisionEpisodeRaw } from '@/services/api';
+
+const FASE_LABELS: Record<string, string> = {
+    refine: 'Verfijnen',
+    Refine: 'Verfijnen',
+    ranking: 'Prioritering',
+    Ranking: 'Prioritering',
+    consent: 'Instemming',
+    Consent: 'Instemming',
+};
+
+const VOTE_TYPE_LABELS: Record<string, string> = {
+    Accept: 'Akkoord',
+    accept: 'Akkoord',
+    Reject: 'Afwijzen',
+    reject: 'Afwijzen',
+    Defer: 'Uitstellen',
+    defer: 'Uitstellen',
+};
+
+const VOTE_TYPE_VARIANT: Record<string, 'default' | 'destructive' | 'outline' | 'secondary'> = {
+    Accept: 'default',
+    accept: 'default',
+    Reject: 'destructive',
+    reject: 'destructive',
+    Defer: 'secondary',
+    defer: 'secondary',
+};
+
+const TYPE_LABELS: Record<string, string> = {
+    DecisionEpisode: 'Beslissing',
+    PhaseTransition: 'Faseovergang',
+};
+
+function formatDateTime(iso: string): string {
+    try {
+        return new Intl.DateTimeFormat('nl-NL', {
+            dateStyle: 'medium',
+            timeStyle: 'short',
+        }).format(new Date(iso));
+    } catch {
+        return iso;
+    }
+}
+
+function formatUri(uri: string): string {
+    const fragment = uri.split('/').pop()?.split('#').pop() ?? uri;
+    // Verwijder UUID-achtige suffixen en toon alleen leesbaar deel
+    if (fragment.length > 36 && fragment.includes('-')) {
+        return fragment.substring(0, 8) + '…';
+    }
+    return fragment;
+}
+
+interface EpisodeCardProps {
+    episode: DecisionEpisodeRaw;
+}
+
+const EpisodeCard: React.FC<EpisodeCardProps> = ({ episode }) => {
+    const typeLabel = TYPE_LABELS[episode.type] ?? episode.type;
+    const faseLabel = episode.phase ? (FASE_LABELS[episode.phase] ?? episode.phase) : null;
+
+    return (
+        <div className="flex gap-4">
+            {/* Tijdlijn indicator */}
+            <div className="flex flex-col items-center">
+                <div className="w-3 h-3 rounded-full bg-primary mt-1 shrink-0" />
+                <div className="w-px flex-1 bg-border mt-1" />
+            </div>
+
+            {/* Kaartinhoud */}
+            <div className="pb-6 flex-1 min-w-0">
+                <div className="rounded-lg border bg-card p-4 shadow-sm">
+                    {/* Header */}
+                    <div className="flex flex-wrap items-center gap-2 mb-2">
+                        <Badge variant="outline" className="text-xs">
+                            {typeLabel}
+                        </Badge>
+                        {faseLabel && (
+                            <Badge variant="secondary" className="text-xs">
+                                <Tag className="h-3 w-3 mr-1" />
+                                {faseLabel}
+                            </Badge>
+                        )}
+                    </div>
+
+                    {/* Metadata */}
+                    <div className="flex flex-wrap gap-4 text-xs text-muted-foreground mt-2">
+                        {episode.startedAt && (
+                            <span className="flex items-center gap-1">
+                                <Clock className="h-3 w-3" />
+                                {formatDateTime(episode.startedAt)}
+                            </span>
+                        )}
+                        {episode.startedBy && (
+                            <span className="flex items-center gap-1">
+                                <User className="h-3 w-3" />
+                                {formatUri(episode.startedBy)}
+                            </span>
+                        )}
+                    </div>
+
+                    {/* Stemmen */}
+                    {episode.votes.length > 0 && (
+                        <div className="mt-3 pt-3 border-t">
+                            <p className="text-xs font-medium text-muted-foreground mb-2">
+                                Stemmen ({episode.votes.length})
+                            </p>
+                            <div className="flex flex-wrap gap-2">
+                                {episode.votes.map((vote) => {
+                                    const label = VOTE_TYPE_LABELS[vote.voteType] ?? vote.voteType;
+                                    const variant = VOTE_TYPE_VARIANT[vote.voteType] ?? 'outline';
+                                    return (
+                                        <div key={vote.voteUri} className="flex items-center gap-1.5">
+                                            <Badge variant={variant} className="text-xs">
+                                                {label}
+                                            </Badge>
+                                            <span className="text-xs text-muted-foreground">
+                                                {formatUri(vote.castBy)}
+                                            </span>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+interface DecisionTimelineProps {
+    dsId?: string;
+}
+
+export const DecisionTimeline: React.FC<DecisionTimelineProps> = ({ dsId: dsProp }) => {
+    const { dsId: dsParam } = useParams<{ dsId: string }>();
+    const dsId = dsProp ?? dsParam ?? '';
+
+    const { data, isLoading, isError } = useQuery({
+        queryKey: ['decision-timeline', dsId],
+        queryFn: () => api.getDecisionTimeline(dsId),
+        enabled: !!dsId,
+    });
+
+    if (isLoading) {
+        return (
+            <div className="flex items-center justify-center h-64 gap-2 text-muted-foreground">
+                <Loader2 className="h-5 w-5 animate-spin" />
+                <span className="text-sm">Beslissingen laden...</span>
+            </div>
+        );
+    }
+
+    if (isError) {
+        return (
+            <Alert variant="destructive" className="m-6">
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription>
+                    De beslissingstijdlijn kon niet worden geladen. Controleer de verbinding en probeer het opnieuw.
+                </AlertDescription>
+            </Alert>
+        );
+    }
+
+    if (!data || data.length === 0) {
+        return (
+            <div className="flex items-center justify-center h-64 text-muted-foreground text-sm">
+                Nog geen beslissingen vastgelegd.
+            </div>
+        );
+    }
+
+    return (
+        <div className="max-w-2xl mx-auto px-6 py-8">
+            <h1 className="text-xl font-semibold mb-6">Beslissingstijdlijn</h1>
+            <div className="flex flex-col">
+                {data.map((episode) => (
+                    <EpisodeCard key={episode.episodeUri} episode={episode} />
+                ))}
+            </div>
+        </div>
+    );
+};

--- a/frontend/src/components/layout/VersionLayout.tsx
+++ b/frontend/src/components/layout/VersionLayout.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Sidebar, type NavItem } from '@/components/ui/Sidebar';
 import { DashboardHeader } from '@/components/dashboard/DashboardHeader';
-import { LayoutDashboard, MessageSquare, FileText, Settings, Users, GitBranch } from 'lucide-react';
+import { LayoutDashboard, MessageSquare, FileText, Settings, Users, GitBranch, Clock } from 'lucide-react';
 import { useParams, Outlet } from 'react-router-dom';
 
 interface VersionLayoutProps {
@@ -30,6 +30,12 @@ export const VersionLayout: React.FC<VersionLayoutProps> = ({ children }) => {
             icon: GitBranch,
             label: 'Argumentatie',
             path: `/designspace/${dsId}/argumentatie`
+        },
+        {
+            id: 'tijdlijn',
+            icon: Clock,
+            label: 'Tijdlijn',
+            path: `/designspace/${dsId}/tijdlijn`
         },
         {
             id: 'chat',

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -649,6 +649,34 @@ export const api = {
         return response.data;
     },
 
+    // DecisionTimeline (US-5.4)
+    getDecisionTimeline: async (dsId: string): Promise<DecisionEpisodeRaw[]> => {
+        const query = `
+PREFIX valor: <https://valor-ecosystem.nl/ontology/>
+PREFIX prov: <https://www.w3.org/ns/prov#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT ?episode ?type ?phase ?startedAt ?startedBy ?vote ?voteType ?castBy ?onTessera WHERE {
+  ?episode a ?type .
+  FILTER(?type IN (valor:DecisionEpisode, valor:PhaseTransition))
+  OPTIONAL { ?episode valor:forPhase ?phase }
+  OPTIONAL { ?episode prov:startedAtTime ?startedAt }
+  OPTIONAL { ?episode prov:wasStartedBy ?startedBy }
+  OPTIONAL {
+    ?episode valor:hasVote ?vote .
+    ?vote valor:voteType ?voteType ;
+          valor:castBy ?castBy .
+    OPTIONAL { ?vote valor:onTessera ?onTessera }
+  }
+}
+ORDER BY DESC(?startedAt)`.trim();
+        const response = await apiClient.get<DecisionTimelineRaw>(
+            `/designspace/${dsId}/sparql`,
+            { params: { query } }
+        );
+        return parseDecisionTimeline(response.data);
+    },
+
     // Argue-relatietypes uit de ontologie — US-5.1
     getArgueTypes: async (): Promise<ArgueType[]> => {
         const response = await apiClient.get<ArgueType[]>('/tessera/argue-types');
@@ -819,6 +847,79 @@ function parseArgumentationNetwork(raw: ArgumentationNetworkRaw, argueTypes: Arg
     }
 
     return { nodes: Array.from(nodesMap.values()), edges };
+}
+
+// DecisionTimeline types (US-5.4)
+export interface DecisionVote {
+    voteUri: string;
+    voteType: string;
+    castBy: string;
+    onTessera: string | null;
+}
+
+export interface DecisionEpisodeRaw {
+    episodeUri: string;
+    type: 'DecisionEpisode' | 'PhaseTransition';
+    phase: string | null;
+    startedAt: string | null;
+    startedBy: string | null;
+    votes: DecisionVote[];
+}
+
+interface DecisionTimelineSparqlBinding {
+    episode: SparqlBinding;
+    type: SparqlBinding;
+    phase?: SparqlBinding;
+    startedAt?: SparqlBinding;
+    startedBy?: SparqlBinding;
+    vote?: SparqlBinding;
+    voteType?: SparqlBinding;
+    castBy?: SparqlBinding;
+    onTessera?: SparqlBinding;
+}
+
+interface DecisionTimelineRaw {
+    results: {
+        bindings: DecisionTimelineSparqlBinding[];
+    };
+}
+
+function parseDecisionTimeline(raw: DecisionTimelineRaw): DecisionEpisodeRaw[] {
+    const episodesMap = new Map<string, DecisionEpisodeRaw>();
+
+    for (const b of raw.results.bindings) {
+        const episodeUri = b.episode.value;
+        const typeFragment = b.type.value.split('/').pop()?.split('#').pop() ?? 'DecisionEpisode';
+        const episodeType: 'DecisionEpisode' | 'PhaseTransition' =
+            typeFragment === 'PhaseTransition' ? 'PhaseTransition' : 'DecisionEpisode';
+
+        if (!episodesMap.has(episodeUri)) {
+            episodesMap.set(episodeUri, {
+                episodeUri,
+                type: episodeType,
+                phase: b.phase ? (b.phase.value.split('/').pop() ?? b.phase.value) : null,
+                startedAt: b.startedAt?.value ?? null,
+                startedBy: b.startedBy?.value ?? null,
+                votes: [],
+            });
+        }
+
+        const episode = episodesMap.get(episodeUri)!;
+        if (b.vote && b.voteType && b.castBy) {
+            const voteUri = b.vote.value;
+            const alreadyAdded = episode.votes.some(v => v.voteUri === voteUri);
+            if (!alreadyAdded) {
+                episode.votes.push({
+                    voteUri,
+                    voteType: b.voteType.value.split('/').pop() ?? b.voteType.value,
+                    castBy: b.castBy.value,
+                    onTessera: b.onTessera?.value ?? null,
+                });
+            }
+        }
+    }
+
+    return Array.from(episodesMap.values());
 }
 
 export type LifecycleStatus = 'draft' | 'proposed' | 'accepted' | 'rejected' | 'deprecated';


### PR DESCRIPTION
## Summary

- Nieuw `DecisionTimeline.tsx` component met verticale tijdlijn per `DecisionEpisode` en `PhaseTransition`
- SPARQL query via bestaande `/designspace/{dsId}/sparql` proxy — geen nieuw backend endpoint
- Stemmen per episode getoond als gekleurde badges (Akkoord/Afwijzen/Uitstellen), met initiator en datum/tijd
- Route `/designspace/:dsId/tijdlijn` geregistreerd in `App.tsx`
- Navigatielink "Tijdlijn" (Clock-icoon) toegevoegd in `VersionLayout` sidebar, naast de Argumentatie-link

## Closes

Fixes #305

## Test plan

- [ ] Navigeer naar een DesignSpace met bestaande DecisionEpisodes — tijdlijn toont episodes met datum, fase-badge en stemmen
- [ ] DesignSpace zonder episodes — lege toestand "Nog geen beslissingen vastgelegd." verschijnt
- [ ] Foutstate bij onbereikbare Fuseki — foutmelding getoond
- [ ] TypeScript check: `./node_modules/.bin/tsc --noEmit` geeft geen fouten

🤖 Generated with [Claude Code](https://claude.com/claude-code)