### PR TITLE
Epic 5 — Delibera Perspectief (#272)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ frontend/lint_output*.txt
 backend/debug_*.py
 backend/deduplicate_db.py
 
+.worktrees/

--- a/backend/app/db/deliberation.py
+++ b/backend/app/db/deliberation.py
@@ -306,10 +306,51 @@ async def get_session_participation(session_id: str) -> List[Dict[str, Any]]:
         logger.error(f"Error getting session participation: {e}")
         return []
 
+async def _get_accepted_rejected_ids(session_id: str) -> tuple[list[str], list[str]]:
+    """Bepaalt welke tesserae geaccepteerd en welke afgewezen zijn op basis van ranking + consent.
+
+    Een tessera is afgewezen als:
+    - discard_p >= 0.3 (afgewezen via ranking), OF
+    - minstens één deelnemer heeft 'reject' gestemd in consent
+
+    Tesserae die nooit geranked zijn, worden niet aangeraakt.
+    """
+    driver = get_driver()
+    query_rankings = """
+    MATCH (s:VotingSession {id: $sid})-[:COLLECTED]->(r:Ranking)
+    WITH r.tessera_base_id AS tid,
+         count(*) AS total,
+         count(CASE WHEN r.category = 'discard' THEN 1 END) AS discard_count
+    RETURN tid, (toFloat(discard_count) / total) AS discard_p
+    """
+    query_consent_rejected = """
+    MATCH (s:VotingSession {id: $sid})-[:COLLECTED]->(v:ConsentVote)
+    WHERE v.vote = 'reject'
+    RETURN DISTINCT v.tessera_base_id AS tid
+    """
+    with driver.session() as sess:
+        rankings = {r["tid"]: r["discard_p"] for r in sess.run(query_rankings, {"sid": session_id})}
+        consent_rejected = {r["tid"] for r in sess.run(query_consent_rejected, {"sid": session_id})}
+
+    accepted, rejected = [], []
+    for tid, discard_p in rankings.items():
+        if discard_p >= 0.3 or tid in consent_rejected:
+            rejected.append(tid)
+        else:
+            accepted.append(tid)
+    return accepted, rejected
+
+
 async def finalize_deliberation(session_id: str, user_id: str) -> Dict[str, Any]:
-    """Sluit de deliberatiesessie af en zet de DesignSpace door naar de volgende fase."""
+    """Sluit de deliberatiesessie af, maakt een fase-snapshot en prunet afgewezen items uit asis."""
     from app.db.sessions import get_session_context, get_ds_id_for_session
     from app.db.designspace import get_design_space_meta, set_design_space_phase, PHASE_SEQUENCE
+    from app.db.fuseki_phases import (
+        copy_asis_to_snapshot,
+        annotate_snapshot,
+        register_snapshot_in_decisions,
+        prune_rejected_from_asis,
+    )
 
     driver = get_driver()
 
@@ -318,6 +359,7 @@ async def finalize_deliberation(session_id: str, user_id: str) -> Dict[str, Any]
         return {"status": "error", "message": "Context niet gevonden"}
 
     try:
+        # 1. Sluit de sessie
         query_close = """
         MATCH (s:VotingSession {id: $sid})
         SET s.status = 'closed', s.stage = 'closed', s.ended_at = datetime()
@@ -326,10 +368,21 @@ async def finalize_deliberation(session_id: str, user_id: str) -> Dict[str, Any]
         with driver.session() as sess:
             sess.run(query_close, {"sid": session_id})
 
-        # Zet DesignSpace door naar de volgende fase
+        # 2. Bepaal geaccepteerde en afgewezen tesserae
+        accepted_ids, rejected_ids = await _get_accepted_rejected_ids(session_id)
+
+        # 3. Fase-snapshot + pruning (alleen als er een DesignSpace is)
         ds_id = await get_ds_id_for_session(session_id)
         next_phase = None
         if ds_id:
+            await copy_asis_to_snapshot(ds_id, session_id)
+            await annotate_snapshot(ds_id, session_id, accepted_ids, rejected_ids)
+            await register_snapshot_in_decisions(
+                ds_id, session_id, len(accepted_ids), len(rejected_ids)
+            )
+            await prune_rejected_from_asis(ds_id, rejected_ids)
+
+            # 4. Zet DesignSpace door naar de volgende fase
             meta = get_design_space_meta(ds_id)
             current_phase = (meta or {}).get("current_phase", "exploration")
             if current_phase in PHASE_SEQUENCE:
@@ -338,7 +391,13 @@ async def finalize_deliberation(session_id: str, user_id: str) -> Dict[str, Any]
                     next_phase = PHASE_SEQUENCE[idx + 1]
                     set_design_space_phase(ds_id, next_phase)
 
-        return {"status": "success", "session_id": session_id, "next_phase": next_phase}
+        return {
+            "status": "success",
+            "session_id": session_id,
+            "accepted": len(accepted_ids),
+            "rejected": len(rejected_ids),
+            "next_phase": next_phase,
+        }
 
     except Exception as e:
         logger.error(f"Error finalizing deliberation: {e}")

--- a/backend/app/db/deliberation.py
+++ b/backend/app/db/deliberation.py
@@ -195,7 +195,11 @@ async def get_consent_shortlist(session_id: str, user_id: Optional[str] = None) 
     try:
         with driver.session() as session:
             result = session.run(query, {"sid": session_id, "uid": user_id})
-            return [dict(record) for record in result]
+            rows = [dict(record) for record in result]
+            # Voeg 'id' toe zodat frontend claim.id kan gebruiken als tessera_base_id
+            for row in rows:
+                row["id"] = row["tessera_base_id"]
+            return rows
     except Exception as e:
         logger.error(f"Error getting consent shortlist: {e}")
         return []

--- a/backend/app/db/deliberation.py
+++ b/backend/app/db/deliberation.py
@@ -71,7 +71,7 @@ async def submit_ranking(ranking: Ranking) -> bool:
     MATCH (s:VotingSession {id: $sid})
     MATCH (u:User {id: $uid})
 
-    // Delete existing ranking for this tessera in this session
+    // Delete existing ranking
     OPTIONAL MATCH (u)-[old:RANKED]->(r_old:Ranking)
     WHERE r_old.session_id = $sid AND r_old.tessera_base_id = $tbid
     DETACH DELETE r_old
@@ -136,16 +136,13 @@ async def update_session_stage(session_id: str, stage: str) -> bool:
         return False
 
 async def get_eligible_claims_for_ranking(session_id: str) -> List[Dict[str, Any]]:
-    """
-    Returns tessera_base_ids that have had no objections (red feedback) in the refinement phase.
-    """
     driver = get_driver()
     query = """
     MATCH (s:VotingSession {id: $sid})
     MATCH (s)-[:COLLECTED]->(f:Feedback)
     WITH f.tessera_base_id as tessera_base_id, collect(f.color) as colors
     WHERE NOT 'red' IN colors
-    RETURN DISTINCT tessera_base_id
+    RETURN DISTINCT tessera_base_id as id
     """
     try:
         with driver.session() as session:
@@ -156,13 +153,6 @@ async def get_eligible_claims_for_ranking(session_id: str) -> List[Dict[str, Any
         return []
 
 async def get_consent_shortlist(session_id: str, user_id: Optional[str] = None) -> List[Dict[str, Any]]:
-    """
-    Calculates the shortlist based on Phase 2a rankings and thresholds.
-    Drempels:
-    - Positive: >= 40% in 'high' OR >= 60% in 'high' + 'medium'
-    - Rejected: >= 30% in 'discard'
-    - Contested: In between
-    """
     driver = get_driver()
     query = """
     MATCH (s:VotingSession {id: $sid})
@@ -177,11 +167,11 @@ async def get_consent_shortlist(session_id: str, user_id: Optional[str] = None) 
          (toFloat(combined_count) / total_votes) as combined_p,
          (toFloat(discard_count) / total_votes) as discard_p
 
-    // Check if current user voted consent on this tessera
+    // Check if current user voted
     OPTIONAL MATCH (u:User {id: $uid})-[:VOTED_CONSENT]->(v:ConsentVote)
     WHERE v.session_id = $sid AND v.tessera_base_id = tessera_base_id
 
-    RETURN tessera_base_id,
+    RETURN tessera_base_id as id,
            CASE
                WHEN discard_p >= 0.3 THEN 'rejected'
                WHEN high_p >= 0.4 OR combined_p >= 0.6 THEN 'positive'
@@ -195,11 +185,7 @@ async def get_consent_shortlist(session_id: str, user_id: Optional[str] = None) 
     try:
         with driver.session() as session:
             result = session.run(query, {"sid": session_id, "uid": user_id})
-            rows = [dict(record) for record in result]
-            # Voeg 'id' toe zodat frontend claim.id kan gebruiken als tessera_base_id
-            for row in rows:
-                row["id"] = row["tessera_base_id"]
-            return rows
+            return [dict(record) for record in result]
     except Exception as e:
         logger.error(f"Error getting consent shortlist: {e}")
         return []
@@ -212,7 +198,7 @@ async def submit_consent_vote(vote: ConsentVote) -> bool:
     MATCH (s:VotingSession {id: $sid})
     MATCH (u:User {id: $uid})
 
-    // Delete existing consent vote for this tessera in this session
+    // Delete existing consent vote
     OPTIONAL MATCH (u)-[old:VOTED_CONSENT]->(v_old:ConsentVote)
     WHERE v_old.session_id = $sid AND v_old.tessera_base_id = $tbid
     DETACH DELETE v_old
@@ -306,51 +292,9 @@ async def get_session_participation(session_id: str) -> List[Dict[str, Any]]:
         logger.error(f"Error getting session participation: {e}")
         return []
 
-async def _get_accepted_rejected_ids(session_id: str) -> tuple[list[str], list[str]]:
-    """Bepaalt welke tesserae geaccepteerd en welke afgewezen zijn op basis van ranking + consent.
-
-    Een tessera is afgewezen als:
-    - discard_p >= 0.3 (afgewezen via ranking), OF
-    - minstens één deelnemer heeft 'reject' gestemd in consent
-
-    Tesserae die nooit geranked zijn, worden niet aangeraakt.
-    """
-    driver = get_driver()
-    query_rankings = """
-    MATCH (s:VotingSession {id: $sid})-[:COLLECTED]->(r:Ranking)
-    WITH r.tessera_base_id AS tid,
-         count(*) AS total,
-         count(CASE WHEN r.category = 'discard' THEN 1 END) AS discard_count
-    RETURN tid, (toFloat(discard_count) / total) AS discard_p
-    """
-    query_consent_rejected = """
-    MATCH (s:VotingSession {id: $sid})-[:COLLECTED]->(v:ConsentVote)
-    WHERE v.vote = 'reject'
-    RETURN DISTINCT v.tessera_base_id AS tid
-    """
-    with driver.session() as sess:
-        rankings = {r["tid"]: r["discard_p"] for r in sess.run(query_rankings, {"sid": session_id})}
-        consent_rejected = {r["tid"] for r in sess.run(query_consent_rejected, {"sid": session_id})}
-
-    accepted, rejected = [], []
-    for tid, discard_p in rankings.items():
-        if discard_p >= 0.3 or tid in consent_rejected:
-            rejected.append(tid)
-        else:
-            accepted.append(tid)
-    return accepted, rejected
-
-
 async def finalize_deliberation(session_id: str, user_id: str) -> Dict[str, Any]:
-    """Sluit de deliberatiesessie af, maakt een fase-snapshot en prunet afgewezen items uit asis."""
-    from app.db.sessions import get_session_context, get_ds_id_for_session
-    from app.db.designspace import get_design_space_meta, set_design_space_phase, PHASE_SEQUENCE
-    from app.db.fuseki_phases import (
-        copy_asis_to_snapshot,
-        annotate_snapshot,
-        register_snapshot_in_decisions,
-        prune_rejected_from_asis,
-    )
+    """Sluit de deliberatiesessie af en registreert de consensus in de DesignSpace."""
+    from app.db.sessions import get_session_context
 
     driver = get_driver()
 
@@ -359,7 +303,6 @@ async def finalize_deliberation(session_id: str, user_id: str) -> Dict[str, Any]
         return {"status": "error", "message": "Context niet gevonden"}
 
     try:
-        # 1. Sluit de sessie
         query_close = """
         MATCH (s:VotingSession {id: $sid})
         SET s.status = 'closed', s.stage = 'closed', s.ended_at = datetime()
@@ -368,36 +311,7 @@ async def finalize_deliberation(session_id: str, user_id: str) -> Dict[str, Any]
         with driver.session() as sess:
             sess.run(query_close, {"sid": session_id})
 
-        # 2. Bepaal geaccepteerde en afgewezen tesserae
-        accepted_ids, rejected_ids = await _get_accepted_rejected_ids(session_id)
-
-        # 3. Fase-snapshot + pruning (alleen als er een DesignSpace is)
-        ds_id = await get_ds_id_for_session(session_id)
-        next_phase = None
-        if ds_id:
-            await copy_asis_to_snapshot(ds_id, session_id)
-            await annotate_snapshot(ds_id, session_id, accepted_ids, rejected_ids)
-            await register_snapshot_in_decisions(
-                ds_id, session_id, len(accepted_ids), len(rejected_ids)
-            )
-            await prune_rejected_from_asis(ds_id, rejected_ids)
-
-            # 4. Zet DesignSpace door naar de volgende fase
-            meta = get_design_space_meta(ds_id)
-            current_phase = (meta or {}).get("current_phase", "exploration")
-            if current_phase in PHASE_SEQUENCE:
-                idx = PHASE_SEQUENCE.index(current_phase)
-                if idx + 1 < len(PHASE_SEQUENCE):
-                    next_phase = PHASE_SEQUENCE[idx + 1]
-                    set_design_space_phase(ds_id, next_phase)
-
-        return {
-            "status": "success",
-            "session_id": session_id,
-            "accepted": len(accepted_ids),
-            "rejected": len(rejected_ids),
-            "next_phase": next_phase,
-        }
+        return {"status": "success", "session_id": session_id}
 
     except Exception as e:
         logger.error(f"Error finalizing deliberation: {e}")
@@ -458,6 +372,12 @@ async def validate_phase_transition(session_id: str, current_stage: str, target_
         """
         with driver.session() as session:
             count = session.run(query, {"sid": session_id}).single()["count"]
+
+        # We might want to allow force-close if really stuck, but for now strict.
+        # Actually, let's make it a warning if manual finalized via update_stage,
+        # but finalize_deliberation endpoint might have its own checks.
+        # The user dashboard calls 'finalize' endpoint for Consent->Closed.
+        # This validator is mostly for the 'Advance Stage' button logic.
 
         if count == 0:
              return {

--- a/backend/app/db/deliberation.py
+++ b/backend/app/db/deliberation.py
@@ -11,17 +11,17 @@ async def submit_feedback(feedback: Feedback) -> bool:
     driver = get_driver()
     query = """
     MATCH (s:VotingSession {id: $sid})
-    MATCH (cv:ClaimVersion {id: $cvid})
     MATCH (u:User {id: $uid})
-    
-    // Delete existing feedback from this user for this claim in this session
-    OPTIONAL MATCH (u)-[old:GAVE_FEEDBACK]->(f_old:Feedback)-[:ON_CLAIM]->(cv)
-    WHERE f_old.session_id = $sid
+
+    // Delete existing feedback from this user for this tessera in this session
+    OPTIONAL MATCH (u)-[old:GAVE_FEEDBACK]->(f_old:Feedback)
+    WHERE f_old.session_id = $sid AND f_old.tessera_base_id = $tbid
     DETACH DELETE f_old
-    
+
     MERGE (f:Feedback {id: $fid})
-    ON CREATE SET 
+    ON CREATE SET
         f.session_id = $sid,
+        f.tessera_base_id = $tbid,
         f.color = $color,
         f.motivation = $motivation,
         f.created_at = datetime($now)
@@ -29,9 +29,8 @@ async def submit_feedback(feedback: Feedback) -> bool:
         f.color = $color,
         f.motivation = $motivation,
         f.updated_at = datetime($now)
-        
+
     MERGE (u)-[:GAVE_FEEDBACK]->(f)
-    MERGE (f)-[:ON_CLAIM]->(cv)
     MERGE (s)-[:COLLECTED]->(f)
     RETURN f.id
     """
@@ -39,7 +38,7 @@ async def submit_feedback(feedback: Feedback) -> bool:
         with driver.session() as session:
             session.run(query, {
                 "sid": feedback.session_id,
-                "cvid": feedback.claim_version_id,
+                "tbid": feedback.tessera_base_id,
                 "uid": feedback.user_id,
                 "fid": feedback.id,
                 "color": feedback.color,
@@ -54,9 +53,9 @@ async def submit_feedback(feedback: Feedback) -> bool:
 async def get_session_feedback(session_id: str) -> List[Dict[str, Any]]:
     driver = get_driver()
     query = """
-    MATCH (s:VotingSession {id: $sid})-[:COLLECTED]->(f:Feedback)-[:ON_CLAIM]->(cv:ClaimVersion)
+    MATCH (s:VotingSession {id: $sid})-[:COLLECTED]->(f:Feedback)
     MATCH (u:User)-[:GAVE_FEEDBACK]->(f)
-    RETURN cv.id as claim_version_id, f.color as color, f.motivation as motivation, u.id as user_id, u.name as user_name
+    RETURN f.tessera_base_id as tessera_base_id, f.color as color, f.motivation as motivation, u.id as user_id, u.name as user_name
     """
     try:
         with driver.session() as session:
@@ -70,25 +69,24 @@ async def submit_ranking(ranking: Ranking) -> bool:
     driver = get_driver()
     query = """
     MATCH (s:VotingSession {id: $sid})
-    MATCH (cv:ClaimVersion {id: $cvid})
     MATCH (u:User {id: $uid})
-    
-    // Delete existing ranking
-    OPTIONAL MATCH (u)-[old:RANKED]->(r_old:Ranking)-[:RANKED_CLAIM]->(cv)
-    WHERE r_old.session_id = $sid
+
+    // Delete existing ranking for this tessera in this session
+    OPTIONAL MATCH (u)-[old:RANKED]->(r_old:Ranking)
+    WHERE r_old.session_id = $sid AND r_old.tessera_base_id = $tbid
     DETACH DELETE r_old
-    
+
     MERGE (r:Ranking {id: $rid})
     ON CREATE SET
         r.session_id = $sid,
+        r.tessera_base_id = $tbid,
         r.category = $category,
         r.created_at = datetime($now)
     ON MATCH SET
         r.category = $category,
         r.updated_at = datetime($now)
-        
+
     MERGE (u)-[:RANKED]->(r)
-    MERGE (r)-[:RANKED_CLAIM]->(cv)
     MERGE (s)-[:COLLECTED]->(r)
     RETURN r.id
     """
@@ -96,7 +94,7 @@ async def submit_ranking(ranking: Ranking) -> bool:
         with driver.session() as session:
             session.run(query, {
                 "sid": ranking.session_id,
-                "cvid": ranking.claim_version_id,
+                "tbid": ranking.tessera_base_id,
                 "uid": ranking.user_id,
                 "rid": ranking.id,
                 "category": ranking.category,
@@ -110,8 +108,8 @@ async def submit_ranking(ranking: Ranking) -> bool:
 async def get_session_rankings(session_id: str) -> List[Dict[str, Any]]:
     driver = get_driver()
     query = """
-    MATCH (s:VotingSession {id: $sid})-[:COLLECTED]->(r:Ranking)-[:RANKED_CLAIM]->(cv:ClaimVersion)
-    RETURN cv.id as claim_version_id, r.category as category, count(r) as count
+    MATCH (s:VotingSession {id: $sid})-[:COLLECTED]->(r:Ranking)
+    RETURN r.tessera_base_id as tessera_base_id, r.category as category, count(r) as count
     ORDER BY count DESC
     """
     try:
@@ -139,15 +137,15 @@ async def update_session_stage(session_id: str, stage: str) -> bool:
 
 async def get_eligible_claims_for_ranking(session_id: str) -> List[Dict[str, Any]]:
     """
-    Returns claims that have had no objections (red feedback) in the refinement phase.
+    Returns tessera_base_ids that have had no objections (red feedback) in the refinement phase.
     """
     driver = get_driver()
     query = """
     MATCH (s:VotingSession {id: $sid})
-    MATCH (s)-[:COLLECTED]->(f:Feedback)-[:ON_CLAIM]->(cv:ClaimVersion)
-    WITH cv, collect(f.color) as colors
+    MATCH (s)-[:COLLECTED]->(f:Feedback)
+    WITH f.tessera_base_id as tessera_base_id, collect(f.color) as colors
     WHERE NOT 'red' IN colors
-    RETURN DISTINCT cv.id as id, cv.statement as statement, cv.polarity as polarity, cv.confidence as confidence
+    RETURN DISTINCT tessera_base_id
     """
     try:
         with driver.session() as session:
@@ -168,24 +166,23 @@ async def get_consent_shortlist(session_id: str, user_id: Optional[str] = None) 
     driver = get_driver()
     query = """
     MATCH (s:VotingSession {id: $sid})
-    MATCH (s)-[:COLLECTED]->(r:Ranking)-[:RANKED_CLAIM]->(cv:ClaimVersion)
-    WITH cv,
+    MATCH (s)-[:COLLECTED]->(r:Ranking)
+    WITH r.tessera_base_id as tessera_base_id,
          count(r) as total_votes,
          count(CASE WHEN r.category = 'high' THEN 1 END) as high_count,
          count(CASE WHEN r.category IN ['high', 'medium'] THEN 1 END) as combined_count,
          count(CASE WHEN r.category = 'discard' THEN 1 END) as discard_count
-    WITH cv, total_votes,
+    WITH tessera_base_id, total_votes,
          (toFloat(high_count) / total_votes) as high_p,
          (toFloat(combined_count) / total_votes) as combined_p,
          (toFloat(discard_count) / total_votes) as discard_p
-    
-    // Check if current user voted
-    OPTIONAL MATCH (u:User {id: $uid})-[:VOTED_CONSENT]->(v:ConsentVote)-[:VOTE_ON]->(cv)
-    WHERE v.session_id = $sid
-    
-    RETURN cv.id as id, 
-           cv.statement as statement,
-           CASE 
+
+    // Check if current user voted consent on this tessera
+    OPTIONAL MATCH (u:User {id: $uid})-[:VOTED_CONSENT]->(v:ConsentVote)
+    WHERE v.session_id = $sid AND v.tessera_base_id = tessera_base_id
+
+    RETURN tessera_base_id,
+           CASE
                WHEN discard_p >= 0.3 THEN 'rejected'
                WHEN high_p >= 0.4 OR combined_p >= 0.6 THEN 'positive'
                ELSE 'contested'
@@ -209,17 +206,17 @@ async def submit_consent_vote(vote: ConsentVote) -> bool:
     driver = get_driver()
     query = """
     MATCH (s:VotingSession {id: $sid})
-    MATCH (cv:ClaimVersion {id: $cvid})
     MATCH (u:User {id: $uid})
-    
-    // Delete existing consent vote
-    OPTIONAL MATCH (u)-[old:VOTED_CONSENT]->(v_old:ConsentVote)-[:VOTE_ON]->(cv)
-    WHERE v_old.session_id = $sid
+
+    // Delete existing consent vote for this tessera in this session
+    OPTIONAL MATCH (u)-[old:VOTED_CONSENT]->(v_old:ConsentVote)
+    WHERE v_old.session_id = $sid AND v_old.tessera_base_id = $tbid
     DETACH DELETE v_old
-    
+
     MERGE (v:ConsentVote {id: $vid})
     ON CREATE SET
         v.session_id = $sid,
+        v.tessera_base_id = $tbid,
         v.vote = $vote,
         v.motivation = $motivation,
         v.created_at = datetime($now)
@@ -227,9 +224,8 @@ async def submit_consent_vote(vote: ConsentVote) -> bool:
         v.vote = $vote,
         v.motivation = $motivation,
         v.updated_at = datetime($now)
-        
+
     MERGE (u)-[:VOTED_CONSENT]->(v)
-    MERGE (v)-[:VOTE_ON]->(cv)
     MERGE (s)-[:COLLECTED]->(v)
     RETURN v.id
     """
@@ -237,7 +233,7 @@ async def submit_consent_vote(vote: ConsentVote) -> bool:
         with driver.session() as session:
             session.run(query, {
                 "sid": vote.session_id,
-                "cvid": vote.claim_version_id,
+                "tbid": vote.tessera_base_id,
                 "uid": vote.user_id,
                 "vid": vote.id,
                 "vote": vote.vote,
@@ -275,21 +271,21 @@ async def get_session_participation(session_id: str) -> List[Dict[str, Any]]:
     query = """
     MATCH (s:VotingSession {id: $sid})<-[:HAS_SESSION]-(ds:DesignSpace)
     MATCH (u:User)-[:HAS_ROLE]->(ds)
-    
+
     WITH DISTINCT u, s
-    
+
     OPTIONAL MATCH (u)-[:GAVE_FEEDBACK]->(f:Feedback) WHERE f.session_id = $sid
     OPTIONAL MATCH (u)-[:RANKED]->(r:Ranking) WHERE r.session_id = $sid
     OPTIONAL MATCH (u)-[:VOTED_CONSENT]->(v:ConsentVote) WHERE v.session_id = $sid
-    
+
     // Check for explicit completion
     OPTIONAL MATCH (u)-[c_refine:COMPLETED_PHASE {phase: 'refine'}]->(s)
     OPTIONAL MATCH (u)-[c_ranking:COMPLETED_PHASE {phase: 'ranking'}]->(s)
     OPTIONAL MATCH (u)-[c_consent:COMPLETED_PHASE {phase: 'consent'}]->(s)
-    
-    RETURN u.email as email, 
-           coalesce(u.name, u.email) as name, 
-           u.id as user_id, 
+
+    RETURN u.email as email,
+           coalesce(u.name, u.email) as name,
+           u.id as user_id,
            count(DISTINCT f) > 0 as has_feedback,
            count(DISTINCT r) > 0 as has_ranking,
            count(DISTINCT v) > 0 as has_consent,
@@ -342,7 +338,7 @@ async def validate_phase_transition(session_id: str, current_stage: str, target_
         }
     """
     driver = get_driver()
-    
+
     # 1. Refine -> Ranking
     if target_stage == 'ranking':
         query = """
@@ -352,14 +348,14 @@ async def validate_phase_transition(session_id: str, current_stage: str, target_
         """
         with driver.session() as session:
             count = session.run(query, {"sid": session_id}).single()["count"]
-            
+
         if count == 0:
             return {
                 "allowed": True, # Non-blocking warning
                 "type": "warning",
                 "message": "Er is nog geen feedback gegeven. Weet je zeker dat je wilt doorgaan?"
             }
-            
+
     # 2. Ranking -> Consent (STRICT GATEKEEPER)
     if target_stage == 'consent':
         query = """
@@ -369,7 +365,7 @@ async def validate_phase_transition(session_id: str, current_stage: str, target_
         """
         with driver.session() as session:
             count = session.run(query, {"sid": session_id}).single()["count"]
-            
+
         if count == 0:
             return {
                 "allowed": False, # BLOCKING
@@ -386,13 +382,7 @@ async def validate_phase_transition(session_id: str, current_stage: str, target_
         """
         with driver.session() as session:
             count = session.run(query, {"sid": session_id}).single()["count"]
-        
-        # We might want to allow force-close if really stuck, but for now strict.
-        # Actually, let's make it a warning if manual finalized via update_stage, 
-        # but finalize_deliberation endpoint might have its own checks.
-        # The user dashboard calls 'finalize' endpoint for Consent->Closed.
-        # This validator is mostly for the 'Advance Stage' button logic.
-        
+
         if count == 0:
              return {
                 "allowed": False,

--- a/backend/app/db/deliberation.py
+++ b/backend/app/db/deliberation.py
@@ -307,8 +307,9 @@ async def get_session_participation(session_id: str) -> List[Dict[str, Any]]:
         return []
 
 async def finalize_deliberation(session_id: str, user_id: str) -> Dict[str, Any]:
-    """Sluit de deliberatiesessie af en registreert de consensus in de DesignSpace."""
-    from app.db.sessions import get_session_context
+    """Sluit de deliberatiesessie af en zet de DesignSpace door naar de volgende fase."""
+    from app.db.sessions import get_session_context, get_ds_id_for_session
+    from app.db.designspace import get_design_space_meta, set_design_space_phase, PHASE_SEQUENCE
 
     driver = get_driver()
 
@@ -325,7 +326,19 @@ async def finalize_deliberation(session_id: str, user_id: str) -> Dict[str, Any]
         with driver.session() as sess:
             sess.run(query_close, {"sid": session_id})
 
-        return {"status": "success", "session_id": session_id}
+        # Zet DesignSpace door naar de volgende fase
+        ds_id = await get_ds_id_for_session(session_id)
+        next_phase = None
+        if ds_id:
+            meta = get_design_space_meta(ds_id)
+            current_phase = (meta or {}).get("current_phase", "exploration")
+            if current_phase in PHASE_SEQUENCE:
+                idx = PHASE_SEQUENCE.index(current_phase)
+                if idx + 1 < len(PHASE_SEQUENCE):
+                    next_phase = PHASE_SEQUENCE[idx + 1]
+                    set_design_space_phase(ds_id, next_phase)
+
+        return {"status": "success", "session_id": session_id, "next_phase": next_phase}
 
     except Exception as e:
         logger.error(f"Error finalizing deliberation: {e}")

--- a/backend/app/db/deliberation.py
+++ b/backend/app/db/deliberation.py
@@ -71,7 +71,7 @@ async def submit_ranking(ranking: Ranking) -> bool:
     MATCH (s:VotingSession {id: $sid})
     MATCH (u:User {id: $uid})
 
-    // Delete existing ranking
+    // Delete existing ranking for this tessera in this session
     OPTIONAL MATCH (u)-[old:RANKED]->(r_old:Ranking)
     WHERE r_old.session_id = $sid AND r_old.tessera_base_id = $tbid
     DETACH DELETE r_old
@@ -136,13 +136,16 @@ async def update_session_stage(session_id: str, stage: str) -> bool:
         return False
 
 async def get_eligible_claims_for_ranking(session_id: str) -> List[Dict[str, Any]]:
+    """
+    Returns tessera_base_ids that have had no objections (red feedback) in the refinement phase.
+    """
     driver = get_driver()
     query = """
     MATCH (s:VotingSession {id: $sid})
     MATCH (s)-[:COLLECTED]->(f:Feedback)
     WITH f.tessera_base_id as tessera_base_id, collect(f.color) as colors
     WHERE NOT 'red' IN colors
-    RETURN DISTINCT tessera_base_id as id
+    RETURN DISTINCT tessera_base_id
     """
     try:
         with driver.session() as session:
@@ -153,6 +156,13 @@ async def get_eligible_claims_for_ranking(session_id: str) -> List[Dict[str, Any
         return []
 
 async def get_consent_shortlist(session_id: str, user_id: Optional[str] = None) -> List[Dict[str, Any]]:
+    """
+    Calculates the shortlist based on Phase 2a rankings and thresholds.
+    Drempels:
+    - Positive: >= 40% in 'high' OR >= 60% in 'high' + 'medium'
+    - Rejected: >= 30% in 'discard'
+    - Contested: In between
+    """
     driver = get_driver()
     query = """
     MATCH (s:VotingSession {id: $sid})
@@ -167,11 +177,11 @@ async def get_consent_shortlist(session_id: str, user_id: Optional[str] = None) 
          (toFloat(combined_count) / total_votes) as combined_p,
          (toFloat(discard_count) / total_votes) as discard_p
 
-    // Check if current user voted
+    // Check if current user voted consent on this tessera
     OPTIONAL MATCH (u:User {id: $uid})-[:VOTED_CONSENT]->(v:ConsentVote)
     WHERE v.session_id = $sid AND v.tessera_base_id = tessera_base_id
 
-    RETURN tessera_base_id as id,
+    RETURN tessera_base_id,
            CASE
                WHEN discard_p >= 0.3 THEN 'rejected'
                WHEN high_p >= 0.4 OR combined_p >= 0.6 THEN 'positive'
@@ -185,7 +195,11 @@ async def get_consent_shortlist(session_id: str, user_id: Optional[str] = None) 
     try:
         with driver.session() as session:
             result = session.run(query, {"sid": session_id, "uid": user_id})
-            return [dict(record) for record in result]
+            rows = [dict(record) for record in result]
+            # Voeg 'id' toe zodat frontend claim.id kan gebruiken als tessera_base_id
+            for row in rows:
+                row["id"] = row["tessera_base_id"]
+            return rows
     except Exception as e:
         logger.error(f"Error getting consent shortlist: {e}")
         return []
@@ -198,7 +212,7 @@ async def submit_consent_vote(vote: ConsentVote) -> bool:
     MATCH (s:VotingSession {id: $sid})
     MATCH (u:User {id: $uid})
 
-    // Delete existing consent vote
+    // Delete existing consent vote for this tessera in this session
     OPTIONAL MATCH (u)-[old:VOTED_CONSENT]->(v_old:ConsentVote)
     WHERE v_old.session_id = $sid AND v_old.tessera_base_id = $tbid
     DETACH DELETE v_old
@@ -292,9 +306,51 @@ async def get_session_participation(session_id: str) -> List[Dict[str, Any]]:
         logger.error(f"Error getting session participation: {e}")
         return []
 
+async def _get_accepted_rejected_ids(session_id: str) -> tuple[list[str], list[str]]:
+    """Bepaalt welke tesserae geaccepteerd en welke afgewezen zijn op basis van ranking + consent.
+
+    Een tessera is afgewezen als:
+    - discard_p >= 0.3 (afgewezen via ranking), OF
+    - minstens één deelnemer heeft 'reject' gestemd in consent
+
+    Tesserae die nooit geranked zijn, worden niet aangeraakt.
+    """
+    driver = get_driver()
+    query_rankings = """
+    MATCH (s:VotingSession {id: $sid})-[:COLLECTED]->(r:Ranking)
+    WITH r.tessera_base_id AS tid,
+         count(*) AS total,
+         count(CASE WHEN r.category = 'discard' THEN 1 END) AS discard_count
+    RETURN tid, (toFloat(discard_count) / total) AS discard_p
+    """
+    query_consent_rejected = """
+    MATCH (s:VotingSession {id: $sid})-[:COLLECTED]->(v:ConsentVote)
+    WHERE v.vote = 'reject'
+    RETURN DISTINCT v.tessera_base_id AS tid
+    """
+    with driver.session() as sess:
+        rankings = {r["tid"]: r["discard_p"] for r in sess.run(query_rankings, {"sid": session_id})}
+        consent_rejected = {r["tid"] for r in sess.run(query_consent_rejected, {"sid": session_id})}
+
+    accepted, rejected = [], []
+    for tid, discard_p in rankings.items():
+        if discard_p >= 0.3 or tid in consent_rejected:
+            rejected.append(tid)
+        else:
+            accepted.append(tid)
+    return accepted, rejected
+
+
 async def finalize_deliberation(session_id: str, user_id: str) -> Dict[str, Any]:
-    """Sluit de deliberatiesessie af en registreert de consensus in de DesignSpace."""
-    from app.db.sessions import get_session_context
+    """Sluit de deliberatiesessie af, maakt een fase-snapshot en prunet afgewezen items uit asis."""
+    from app.db.sessions import get_session_context, get_ds_id_for_session
+    from app.db.designspace import get_design_space_meta, set_design_space_phase, PHASE_SEQUENCE
+    from app.db.fuseki_phases import (
+        copy_asis_to_snapshot,
+        annotate_snapshot,
+        register_snapshot_in_decisions,
+        prune_rejected_from_asis,
+    )
 
     driver = get_driver()
 
@@ -303,6 +359,7 @@ async def finalize_deliberation(session_id: str, user_id: str) -> Dict[str, Any]
         return {"status": "error", "message": "Context niet gevonden"}
 
     try:
+        # 1. Sluit de sessie
         query_close = """
         MATCH (s:VotingSession {id: $sid})
         SET s.status = 'closed', s.stage = 'closed', s.ended_at = datetime()
@@ -311,7 +368,36 @@ async def finalize_deliberation(session_id: str, user_id: str) -> Dict[str, Any]
         with driver.session() as sess:
             sess.run(query_close, {"sid": session_id})
 
-        return {"status": "success", "session_id": session_id}
+        # 2. Bepaal geaccepteerde en afgewezen tesserae
+        accepted_ids, rejected_ids = await _get_accepted_rejected_ids(session_id)
+
+        # 3. Fase-snapshot + pruning (alleen als er een DesignSpace is)
+        ds_id = await get_ds_id_for_session(session_id)
+        next_phase = None
+        if ds_id:
+            await copy_asis_to_snapshot(ds_id, session_id)
+            await annotate_snapshot(ds_id, session_id, accepted_ids, rejected_ids)
+            await register_snapshot_in_decisions(
+                ds_id, session_id, len(accepted_ids), len(rejected_ids)
+            )
+            await prune_rejected_from_asis(ds_id, rejected_ids)
+
+            # 4. Zet DesignSpace door naar de volgende fase
+            meta = get_design_space_meta(ds_id)
+            current_phase = (meta or {}).get("current_phase", "exploration")
+            if current_phase in PHASE_SEQUENCE:
+                idx = PHASE_SEQUENCE.index(current_phase)
+                if idx + 1 < len(PHASE_SEQUENCE):
+                    next_phase = PHASE_SEQUENCE[idx + 1]
+                    set_design_space_phase(ds_id, next_phase)
+
+        return {
+            "status": "success",
+            "session_id": session_id,
+            "accepted": len(accepted_ids),
+            "rejected": len(rejected_ids),
+            "next_phase": next_phase,
+        }
 
     except Exception as e:
         logger.error(f"Error finalizing deliberation: {e}")
@@ -372,12 +458,6 @@ async def validate_phase_transition(session_id: str, current_stage: str, target_
         """
         with driver.session() as session:
             count = session.run(query, {"sid": session_id}).single()["count"]
-
-        # We might want to allow force-close if really stuck, but for now strict.
-        # Actually, let's make it a warning if manual finalized via update_stage,
-        # but finalize_deliberation endpoint might have its own checks.
-        # The user dashboard calls 'finalize' endpoint for Consent->Closed.
-        # This validator is mostly for the 'Advance Stage' button logic.
 
         if count == 0:
              return {

--- a/backend/app/db/fuseki_decisions.py
+++ b/backend/app/db/fuseki_decisions.py
@@ -1,0 +1,92 @@
+"""SPARQL schrijffuncties voor deliberatie-beslissingen in Fuseki.
+
+Verantwoordelijk voor het opslaan van valor:PhaseTransition en valor:Vote
+resources in de decisions named graph van een DesignSpace.
+
+Architectuur:
+- valor:PhaseTransition is een subtype van valor:DecisionEpisode (VALOR-O §6.1, §4.7)
+- Stemmen worden opgeslagen als valor:Vote resources, gekoppeld via valor:hasVote
+- Alle writes zijn fire-and-forget: fouten worden gelogd als WARNING en niet gepropageerd
+"""
+import uuid
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+from app.ontology import VALOR_NS
+from app.services.fuseki import sparql_update
+
+logger = logging.getLogger(__name__)
+
+_XSD = "http://www.w3.org/2001/XMLSchema#"
+_PROV = "https://www.w3.org/ns/prov#"
+
+
+def _decisions_graph(design_space_id: str) -> str:
+    return f"urn:valor:ds:{design_space_id}/decisions"
+
+
+def _escape(text: str) -> str:
+    return text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "")
+
+
+async def create_phase_transition(
+    design_space_id: str,
+    session_id: str,
+    phase: str,
+    votes: list[dict],
+    user_id: str,
+) -> str:
+    """Schrijft een valor:PhaseTransition naar de decisions named graph.
+
+    Args:
+        design_space_id: ID van de DesignSpace (zonder urn-prefix).
+        session_id: ID van de VotingSession in Neo4j.
+        phase: Fase-label, bijv. "refine", "ranking" of "consent".
+        votes: Lijst van vote-dicts met sleutels user_id, tessera_id, vote_type.
+        user_id: ID van de gebruiker die de transitie initieert.
+
+    Returns:
+        De URI string van de aangemaakte PhaseTransition.
+    """
+    transition_id = str(uuid.uuid4())
+    transition_uri = f"urn:valor:phase-transition:{transition_id}"
+    decisions_graph = _decisions_graph(design_space_id)
+    ds_uri = f"urn:valor:ds:{design_space_id}"
+    user_uri = f"urn:valor:user:{user_id}"
+    timestamp = datetime.now(timezone.utc).isoformat()
+
+    phase_escaped = _escape(phase)
+    session_escaped = _escape(session_id)
+
+    vote_triples = []
+    for vote in votes:
+        vote_id = str(uuid.uuid4())
+        vote_uri = f"urn:valor:vote:{vote_id}"
+        voter_uri = f"urn:valor:user:{_escape(vote['user_id'])}"
+        tessera_uri = f"urn:valor:tessera:{_escape(vote['tessera_id'])}"
+        vote_type_escaped = _escape(vote.get("vote_type", ""))
+        vote_triples.append(
+            f"""    <{vote_uri}> a <{VALOR_NS}Vote> ;
+      <{VALOR_NS}castBy> <{voter_uri}> ;
+      <{VALOR_NS}onTessera> <{tessera_uri}> ;
+      <{VALOR_NS}voteType> "{vote_type_escaped}"^^<{_XSD}string> .
+    <{transition_uri}> <{VALOR_NS}hasVote> <{vote_uri}> ."""
+        )
+
+    vote_block = "\n".join(vote_triples)
+
+    sparql = f"""INSERT DATA {{
+  GRAPH <{decisions_graph}> {{
+    <{transition_uri}> a <{VALOR_NS}PhaseTransition>, <{VALOR_NS}DecisionEpisode> ;
+      <{VALOR_NS}inDesignSpace> <{ds_uri}> ;
+      <{VALOR_NS}forPhase> "{phase_escaped}"^^<{_XSD}string> ;
+      <{VALOR_NS}sessionId> "{session_escaped}"^^<{_XSD}string> ;
+      <{_PROV}startedAtTime> "{timestamp}"^^<{_XSD}dateTime> ;
+      <{_PROV}wasStartedBy> <{user_uri}> .
+{vote_block}
+  }}
+}}"""
+
+    await sparql_update(sparql, design_space_id)
+    return transition_uri

--- a/backend/app/db/fuseki_knowledge.py
+++ b/backend/app/db/fuseki_knowledge.py
@@ -89,16 +89,17 @@ async def _find_tessera_uri_by_base_id(ds_id: str, base_id: str) -> Optional[str
 # Factor reads (SPARQL)
 # ---------------------------------------------------------------------------
 
-async def _sparql_get_factors(ds_id: str) -> list[dict]:
-    asis_graph = _ds_asis_graph(ds_id)
+async def _sparql_get_factors(ds_id: str, graph_uri: Optional[str] = None) -> list[dict]:
+    target = graph_uri or _ds_asis_graph(ds_id)
     rows = await sparql_select_global(f"""
-SELECT ?tessera ?baseId ?name ?role ?description WHERE {{
-  GRAPH <{asis_graph}> {{
+SELECT ?tessera ?baseId ?name ?role ?description ?outcome WHERE {{
+  GRAPH <{target}> {{
     ?tessera a <{VALOR_NS}Tessera> ;
              <{VALOR_NS}baseId> ?baseId ;
              <{VALOR_NS}claimContent> ?name ;
              <{VALOR_NS}factorRole> ?role .
     OPTIONAL {{ ?tessera <{VALOR_NS}description> ?description }}
+    OPTIONAL {{ ?tessera <{VALOR_NS}phaseOutcome> ?outcome }}
     FILTER NOT EXISTS {{ ?tessera <{VALOR_NS}fromFactor> ?x }}
   }}
 }}
@@ -112,6 +113,7 @@ SELECT ?tessera ?baseId ?name ?role ?description WHERE {{
             "type": row.get("role"),
             "theme_id": None,
             "thread_id": None,
+            "phase_outcome": row["outcome"].split("#")[-1] if row.get("outcome") else None,
         }
         for row in rows
     ]
@@ -226,8 +228,8 @@ WHERE {{
 # Claim reads (SPARQL)
 # ---------------------------------------------------------------------------
 
-async def _sparql_get_claims(ds_id: str, claim_type: Optional[str] = None) -> list[dict]:
-    asis_graph = _ds_asis_graph(ds_id)
+async def _sparql_get_claims(ds_id: str, claim_type: Optional[str] = None, graph_uri: Optional[str] = None) -> list[dict]:
+    target = graph_uri or _ds_asis_graph(ds_id)
     if claim_type is not None:
         claim_type_uri = f"{VALOR_NS}{claim_type}"
         claim_type_filter = f"?tessera <{VALOR_NS}claimType> <{claim_type_uri}> ."
@@ -236,8 +238,8 @@ async def _sparql_get_claims(ds_id: str, claim_type: Optional[str] = None) -> li
     rows = await sparql_select_global(f"""
 SELECT ?tessera ?baseId ?statement ?polarity ?confidence
        ?fromFactor ?sourceBaseId ?toFactor ?targetBaseId
-       ?evidenceText ?claimedAt ?manifestationCondition WHERE {{
-  GRAPH <{asis_graph}> {{
+       ?evidenceText ?claimedAt ?manifestationCondition ?outcome WHERE {{
+  GRAPH <{target}> {{
     ?tessera a <{VALOR_NS}Tessera> ;
              <{VALOR_NS}baseId> ?baseId ;
              <{VALOR_NS}claimContent> ?statement ;
@@ -251,6 +253,7 @@ SELECT ?tessera ?baseId ?statement ?polarity ?confidence
     OPTIONAL {{ ?tessera <{VALOR_NS}evidenceText> ?evidenceText }}
     OPTIONAL {{ ?tessera <{VALOR_NS}claimedAt>    ?claimedAt }}
     OPTIONAL {{ ?tessera <{_CAUSA_NS}hasManifestationCondition> ?manifestationCondition }}
+    OPTIONAL {{ ?tessera <{VALOR_NS}phaseOutcome> ?outcome }}
   }}
 }}
 """)
@@ -274,6 +277,7 @@ SELECT ?tessera ?baseId ?statement ?polarity ?confidence
             "created_by": None,
             "status": None,
             "manifestation_condition": row.get("manifestationCondition"),
+            "phase_outcome": row["outcome"].split("#")[-1] if row.get("outcome") else None,
         }
         for row in rows
     ]

--- a/backend/app/db/fuseki_phases.py
+++ b/backend/app/db/fuseki_phases.py
@@ -1,0 +1,187 @@
+"""SPARQL-operaties voor fase-snapshots in Fuseki.
+
+Na elke deliberatie-finalisatie:
+1. copy_asis_to_snapshot      — kopieert asis volledig naar phase/{session_id}
+2. annotate_snapshot          — voegt phaseOutcome (Accepted/Rejected) per tessera toe
+3. register_snapshot_in_decisions — registreert snapshot in decisions-graph
+4. prune_rejected_from_asis   — verwijdert afgewezen tesserae + afhankelijke claims uit asis
+5. get_phase_snapshots        — retourneert lijst van snapshots voor een DesignSpace
+"""
+import logging
+from datetime import datetime, timezone
+
+from app.ontology import VALOR_NS
+from app.services.fuseki import sparql_update, sparql_select_global
+
+logger = logging.getLogger(__name__)
+
+_XSD  = "http://www.w3.org/2001/XMLSchema#"
+_PROV = "https://www.w3.org/ns/prov#"
+
+
+def _asis_graph(ds_id: str) -> str:
+    return f"urn:valor:ds:{ds_id}/asis"
+
+
+def _phase_graph(ds_id: str, session_id: str) -> str:
+    return f"urn:valor:ds:{ds_id}/phase/{session_id}"
+
+
+def _decisions_graph(ds_id: str) -> str:
+    return f"urn:valor:ds:{ds_id}/decisions"
+
+
+def _tessera_uri(base_id: str) -> str:
+    return f"urn:valor:tessera:{base_id}"
+
+
+def _escape(text: str) -> str:
+    return text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "")
+
+
+async def copy_asis_to_snapshot(ds_id: str, session_id: str) -> str:
+    """Kopieert de volledige asis-graph naar een nieuwe phase-graph.
+
+    Retourneert de phase-graph URI.
+    """
+    asis  = _asis_graph(ds_id)
+    phase = _phase_graph(ds_id, session_id)
+    sparql = f"COPY <{asis}> TO <{phase}>"
+    await sparql_update(sparql, ds_id)
+    return phase
+
+
+async def annotate_snapshot(
+    ds_id: str,
+    session_id: str,
+    accepted_ids: list[str],
+    rejected_ids: list[str],
+) -> None:
+    """Voegt phaseOutcome-triples en metadata toe aan de snapshot-graph."""
+    phase = _phase_graph(ds_id, session_id)
+    snapshot_uri = f"urn:valor:phase-snapshot:{session_id}"
+    timestamp = datetime.now(timezone.utc).isoformat()
+
+    outcome_triples = []
+    for tid in accepted_ids:
+        turi = _tessera_uri(tid)
+        outcome_triples.append(f"<{turi}> <{VALOR_NS}phaseOutcome> <{VALOR_NS}Accepted> .")
+    for tid in rejected_ids:
+        turi = _tessera_uri(tid)
+        outcome_triples.append(f"<{turi}> <{VALOR_NS}phaseOutcome> <{VALOR_NS}Rejected> .")
+
+    outcomes_block = "\n    ".join(outcome_triples)
+
+    sparql = f"""INSERT DATA {{
+  GRAPH <{phase}> {{
+    <{snapshot_uri}> a <{VALOR_NS}PhaseSnapshot> ;
+      <{VALOR_NS}sessionId> "{_escape(session_id)}"^^<{_XSD}string> ;
+      <{_PROV}generatedAtTime> "{timestamp}"^^<{_XSD}dateTime> .
+    {outcomes_block}
+  }}
+}}"""
+    await sparql_update(sparql, ds_id)
+
+
+async def register_snapshot_in_decisions(
+    ds_id: str,
+    session_id: str,
+    accepted_count: int,
+    rejected_count: int,
+) -> None:
+    """Registreert de snapshot in de decisions-graph zodat die opvraagbaar is."""
+    decisions    = _decisions_graph(ds_id)
+    phase        = _phase_graph(ds_id, session_id)
+    snapshot_uri = f"urn:valor:phase-snapshot:{session_id}"
+    ds_uri       = f"urn:valor:ds:{ds_id}"
+    timestamp    = datetime.now(timezone.utc).isoformat()
+
+    sparql = f"""INSERT DATA {{
+  GRAPH <{decisions}> {{
+    <{snapshot_uri}> a <{VALOR_NS}PhaseSnapshot> ;
+      <{VALOR_NS}inDesignSpace> <{ds_uri}> ;
+      <{VALOR_NS}sessionId> "{_escape(session_id)}"^^<{_XSD}string> ;
+      <{VALOR_NS}graphUri> "{_escape(phase)}"^^<{_XSD}string> ;
+      <{VALOR_NS}acceptedCount> "{accepted_count}"^^<{_XSD}integer> ;
+      <{VALOR_NS}rejectedCount> "{rejected_count}"^^<{_XSD}integer> ;
+      <{_PROV}generatedAtTime> "{timestamp}"^^<{_XSD}dateTime> .
+  }}
+}}"""
+    await sparql_update(sparql, ds_id)
+
+
+async def prune_rejected_from_asis(ds_id: str, rejected_ids: list[str]) -> None:
+    """Verwijdert afgewezen tesserae en hun afhankelijke claims uit asis.
+
+    Stap 1: verwijder claims waarvan fromFactor of toFactor afgewezen is.
+    Stap 2: verwijder de afgewezen tesserae zelf (als subject).
+    """
+    if not rejected_ids:
+        return
+
+    asis = _asis_graph(ds_id)
+    uris = ", ".join(f"<{_tessera_uri(tid)}>" for tid in rejected_ids)
+
+    # Stap 1: verwijder claims die verwijzen naar afgewezen factoren
+    sparql_claims = f"""DELETE {{
+  GRAPH <{asis}> {{
+    ?claim ?p ?o .
+  }}
+}}
+WHERE {{
+  GRAPH <{asis}> {{
+    ?claim ?p ?o .
+    {{
+      ?claim <{VALOR_NS}fromFactor> ?factor .
+      FILTER(?factor IN ({uris}))
+    }}
+    UNION
+    {{
+      ?claim <{VALOR_NS}toFactor> ?factor .
+      FILTER(?factor IN ({uris}))
+    }}
+  }}
+}}"""
+    await sparql_update(sparql_claims, ds_id)
+
+    # Stap 2: verwijder de afgewezen tesserae zelf
+    sparql_tesserae = f"""DELETE {{
+  GRAPH <{asis}> {{
+    ?s ?p ?o .
+  }}
+}}
+WHERE {{
+  GRAPH <{asis}> {{
+    ?s ?p ?o .
+    FILTER(?s IN ({uris}))
+  }}
+}}"""
+    await sparql_update(sparql_tesserae, ds_id)
+
+
+async def get_phase_snapshots(ds_id: str) -> list[dict]:
+    """Retourneert alle fase-snapshots voor een DesignSpace, gesorteerd op tijd."""
+    decisions = _decisions_graph(ds_id)
+    rows = await sparql_select_global(f"""
+SELECT ?snapshotUri ?sessionId ?graphUri ?generatedAt ?acceptedCount ?rejectedCount WHERE {{
+  GRAPH <{decisions}> {{
+    ?snapshotUri a <{VALOR_NS}PhaseSnapshot> ;
+      <{VALOR_NS}sessionId> ?sessionId ;
+      <{VALOR_NS}graphUri> ?graphUri ;
+      <{_PROV}generatedAtTime> ?generatedAt .
+    OPTIONAL {{ ?snapshotUri <{VALOR_NS}acceptedCount> ?acceptedCount }}
+    OPTIONAL {{ ?snapshotUri <{VALOR_NS}rejectedCount> ?rejectedCount }}
+  }}
+}}
+ORDER BY ASC(?generatedAt)
+""")
+    return [
+        {
+            "session_id":     r["sessionId"],
+            "graph_uri":      r["graphUri"],
+            "created_at":     r["generatedAt"],
+            "accepted_count": int(r.get("acceptedCount", 0)),
+            "rejected_count": int(r.get("rejectedCount", 0)),
+        }
+        for r in rows
+    ]

--- a/backend/app/db/fuseki_votes.py
+++ b/backend/app/db/fuseki_votes.py
@@ -1,0 +1,55 @@
+import uuid
+import logging
+from datetime import datetime, timezone
+
+from app.ontology import VALOR_NS
+from app.services.fuseki import sparql_update
+
+logger = logging.getLogger(__name__)
+
+_XSD = "http://www.w3.org/2001/XMLSchema#"
+_PROV = "https://www.w3.org/ns/prov#"
+
+
+def _decisions_graph(ds_id: str) -> str:
+    return f"urn:valor:ds:{ds_id}/decisions"
+
+
+def _escape(text: str) -> str:
+    return text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "")
+
+
+async def write_consent_vote_to_fuseki(
+    ds_id: str,
+    session_id: str,
+    tessera_base_id: str,
+    user_id: str,
+    vote_type: str,
+    motivation: str | None = None,
+) -> None:
+    vote_id = str(uuid.uuid4())
+    vote_uri = f"urn:valor:vote:{vote_id}"
+    user_uri = f"urn:valor:user:{_escape(user_id)}"
+    tessera_uri = f"urn:valor:tessera:{_escape(tessera_base_id)}"
+    timestamp = datetime.now(timezone.utc).isoformat()
+
+    vote_type_escaped = _escape(vote_type)
+    session_escaped = _escape(session_id)
+    decisions_graph = _decisions_graph(ds_id)
+
+    motivation_triple = ""
+    if motivation:
+        motivation_triple = f'\n      <{VALOR_NS}motivation> "{_escape(motivation)}"^^<{_XSD}string> ;'
+
+    sparql = f"""INSERT DATA {{
+  GRAPH <{decisions_graph}> {{
+    <{vote_uri}> a <{VALOR_NS}Vote> ;
+      <{VALOR_NS}castBy> <{user_uri}> ;
+      <{VALOR_NS}onTessera> <{tessera_uri}> ;
+      <{VALOR_NS}voteType> "{vote_type_escaped}"^^<{_XSD}string> ;
+      <{VALOR_NS}sessionId> "{session_escaped}"^^<{_XSD}string> ;{motivation_triple}
+      <{_PROV}atTime> "{timestamp}"^^<{_XSD}dateTime> .
+  }}
+}}"""
+
+    await sparql_update(sparql, ds_id)

--- a/backend/app/db/sessions.py
+++ b/backend/app/db/sessions.py
@@ -149,6 +149,23 @@ async def get_session_context(session_id: str) -> Tuple[Optional[str], Optional[
         return None, None
 
 
+async def get_ds_id_for_session(session_id: str) -> Optional[str]:
+    """Retourneert de DesignSpace ID voor een VotingSession."""
+    driver = get_driver()
+    query = """
+    MATCH (ds:DesignSpace)-[:HAS_SESSION]->(s:VotingSession {id: $sid})
+    RETURN ds.id AS ds_id
+    """
+    try:
+        with driver.session() as session:
+            result = session.run(query, {"sid": session_id})
+            record = result.single()
+            return record["ds_id"] if record else None
+    except Exception as e:
+        logger.error(f"Error getting ds_id for session: {e}")
+        return None
+
+
 async def get_moderator_sessions(user_id: str) -> List[Dict[str, Any]]:
     """Retourneert alle actieve votingsessies waar de gebruiker moderator of admin is."""
     driver = get_driver()

--- a/backend/app/models/domain.py
+++ b/backend/app/models/domain.py
@@ -280,7 +280,7 @@ class VotingSession(BaseModel):
 class Feedback(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     session_id: str
-    claim_version_id: str
+    tessera_base_id: str
     user_id: str
     color: str # green, amber, red
     motivation: Optional[str] = None
@@ -295,7 +295,7 @@ class RankingCategory(str, Enum):
 class Ranking(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     session_id: str
-    claim_version_id: str
+    tessera_base_id: str
     user_id: str
     category: RankingCategory
     created_at: datetime = Field(default_factory=datetime.now)
@@ -307,7 +307,7 @@ class ConsentVoteType(str, Enum):
 class ConsentVote(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     session_id: str
-    claim_version_id: str
+    tessera_base_id: str
     user_id: str
     vote: ConsentVoteType
     motivation: Optional[str] = None

--- a/backend/app/models/domain.py
+++ b/backend/app/models/domain.py
@@ -280,7 +280,7 @@ class VotingSession(BaseModel):
 class Feedback(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     session_id: str
-    claim_version_id: str
+    tessera_base_id: str
     user_id: str
     color: str # green, amber, red
     motivation: Optional[str] = None
@@ -295,7 +295,7 @@ class RankingCategory(str, Enum):
 class Ranking(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     session_id: str
-    claim_version_id: str
+    tessera_base_id: str
     user_id: str
     category: RankingCategory
     created_at: datetime = Field(default_factory=datetime.now)
@@ -307,8 +307,32 @@ class ConsentVoteType(str, Enum):
 class ConsentVote(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     session_id: str
-    claim_version_id: str
+    tessera_base_id: str
     user_id: str
     vote: ConsentVoteType
     motivation: Optional[str] = None
     created_at: datetime = Field(default_factory=datetime.now)
+
+
+# --- Tessera Voting (US-5.2) ---
+
+class TesseraVoteType(str, Enum):
+    ACCEPT = "Accept"
+    REJECT = "Reject"
+    DEFER = "Defer"
+
+
+class CastVoteRequest(BaseModel):
+    design_space_id: str
+    vote_type: TesseraVoteType
+    alternative_id: Optional[str] = None  # aanwezig als Tessera in een DesignAlternative zit
+
+
+class VoteResponse(BaseModel):
+    vote_uri: str
+    episode_uri: str
+    tessera_id: str
+    tessera_uri: str
+    vote_type: str
+    quorum_reached: bool
+    new_epistemic_status: Optional[str] = None

--- a/backend/app/routers/claims.py
+++ b/backend/app/routers/claims.py
@@ -43,13 +43,15 @@ _VALID_CLAIM_TYPES = {"AsIsType", "ToBeType"}
 async def list_designspace_claims(
     ds_id: str,
     claim_type: Optional[str] = Query(None, description="Filter op claimType: 'AsIsType' of 'ToBeType'"),
+    phase: Optional[str] = Query(None, description="Session ID van een historische fase-snapshot"),
     user: dict = Depends(get_current_user),
 ):
     if claim_type is not None and claim_type not in _VALID_CLAIM_TYPES:
         raise HTTPException(status_code=422, detail=f"Ongeldig claim_type '{claim_type}'. Toegestane waarden: {sorted(_VALID_CLAIM_TYPES)}")
     if not await check_permission(user["id"], ds_id, Role.MEMBER):
         raise HTTPException(status_code=403, detail="Geen toegang tot deze DesignSpace")
-    return await fuseki_knowledge._sparql_get_claims(ds_id, claim_type=claim_type)
+    graph_uri = f"urn:valor:ds:{ds_id}/phase/{phase}" if phase else None
+    return await fuseki_knowledge._sparql_get_claims(ds_id, claim_type=claim_type, graph_uri=graph_uri)
 
 
 @router.get("/designspace/{ds_id}/cycles")

--- a/backend/app/routers/deliberation.py
+++ b/backend/app/routers/deliberation.py
@@ -16,16 +16,43 @@ from app.db.deliberation import (
     finalize_deliberation,
     validate_phase_transition
 )
-from app.db.sessions import get_session_context, get_moderator_sessions
+from app.db.sessions import get_session_context, get_moderator_sessions, get_ds_id_for_session
 from app.db.permissions import check_permission
 from app.models.domain import Role, Feedback, Ranking, DeliberationStage, ConsentVote, ConsentVoteType
+from app.db.fuseki_decisions import create_phase_transition
 from typing import List, Dict, Any, Optional
 from pydantic import BaseModel
 from app.services.connection_manager import manager
+import asyncio
 import logging
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/deliberation", tags=["deliberation"])
+
+
+async def _write_phase_transition_safe(
+    design_space_id: str,
+    session_id: str,
+    phase: str,
+    votes: list[dict],
+    user_id: str,
+) -> None:
+    """Fire-and-forget wrapper voor Fuseki dual-write. Logt fouten als WARNING."""
+    try:
+        await create_phase_transition(
+            design_space_id=design_space_id,
+            session_id=session_id,
+            phase=phase,
+            votes=votes,
+            user_id=user_id,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Fuseki dual-write mislukt voor PhaseTransition (session=%s, phase=%s): %s",
+            session_id,
+            phase,
+            exc,
+        )
 
 class FeedbackRequest(BaseModel):
     session_id: str
@@ -150,6 +177,19 @@ async def update_stage(session_id: str, data: StageUpdateRequest, user: dict = D
             }
         })
 
+    # 5. Dual-write naar Fuseki (fire-and-forget)
+    ds_id = await get_ds_id_for_session(session_id)
+    if ds_id:
+        asyncio.create_task(
+            _write_phase_transition_safe(
+                design_space_id=ds_id,
+                session_id=session_id,
+                phase=str(data.stage),
+                votes=[],
+                user_id=user.get("id", ""),
+            )
+        )
+
     return {"stage": data.stage}
 
 @router.get("/moderator/sessions")
@@ -183,9 +223,32 @@ async def post_finalize(session_id: str, user: dict = Depends(get_current_user))
             "type": "SESSION_FINALIZED",
             "payload": {
                 "session_id": session_id,
-                "next_version_id": result["next_version_id"]
+                "next_version_id": result.get("next_version_id")
             }
         })
+
+    # 5. Dual-write naar Fuseki (fire-and-forget)
+    ds_id = await get_ds_id_for_session(session_id)
+    if ds_id:
+        consent_shortlist = await get_consent_shortlist(session_id, user.get("id"))
+        votes_payload = [
+            {
+                "user_id": user.get("id", ""),
+                "tessera_id": item.get("id", ""),
+                "vote_type": item.get("user_vote") or "consent",
+            }
+            for item in consent_shortlist
+            if item.get("user_vote")
+        ]
+        asyncio.create_task(
+            _write_phase_transition_safe(
+                design_space_id=ds_id,
+                session_id=session_id,
+                phase="consent",
+                votes=votes_payload,
+                user_id=user.get("id", ""),
+            )
+        )
 
     return result
 

--- a/backend/app/routers/deliberation.py
+++ b/backend/app/routers/deliberation.py
@@ -16,16 +16,43 @@ from app.db.deliberation import (
     finalize_deliberation,
     validate_phase_transition
 )
-from app.db.sessions import get_session_context, get_moderator_sessions
+from app.db.sessions import get_session_context, get_moderator_sessions, get_ds_id_for_session
 from app.db.permissions import check_permission
 from app.models.domain import Role, Feedback, Ranking, DeliberationStage, ConsentVote, ConsentVoteType
+from app.db.fuseki_decisions import create_phase_transition
 from typing import List, Dict, Any, Optional
 from pydantic import BaseModel
 from app.services.connection_manager import manager
+import asyncio
 import logging
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/deliberation", tags=["deliberation"])
+
+
+async def _write_phase_transition_safe(
+    design_space_id: str,
+    session_id: str,
+    phase: str,
+    votes: list[dict],
+    user_id: str,
+) -> None:
+    """Fire-and-forget wrapper voor Fuseki dual-write. Logt fouten als WARNING."""
+    try:
+        await create_phase_transition(
+            design_space_id=design_space_id,
+            session_id=session_id,
+            phase=phase,
+            votes=votes,
+            user_id=user_id,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Fuseki dual-write mislukt voor PhaseTransition (session=%s, phase=%s): %s",
+            session_id,
+            phase,
+            exc,
+        )
 
 class FeedbackRequest(BaseModel):
     session_id: str
@@ -149,7 +176,20 @@ async def update_stage(session_id: str, data: StageUpdateRequest, user: dict = D
                 "stage": data.stage
             }
         })
-        
+
+    # 5. Dual-write naar Fuseki (fire-and-forget)
+    ds_id = await get_ds_id_for_session(session_id)
+    if ds_id:
+        asyncio.create_task(
+            _write_phase_transition_safe(
+                design_space_id=ds_id,
+                session_id=session_id,
+                phase=str(data.stage),
+                votes=[],
+                user_id=user.get("id", ""),
+            )
+        )
+
     return {"stage": data.stage}
 
 @router.get("/moderator/sessions")
@@ -176,17 +216,40 @@ async def post_finalize(session_id: str, user: dict = Depends(get_current_user))
     result = await finalize_deliberation(session_id, user.get("id"))
     if result["status"] == "error":
         raise HTTPException(status_code=400, detail=result["message"])
-        
+
     # 4. Broadcast
     if project_id:
         await manager.broadcast_data(project_id, {
             "type": "SESSION_FINALIZED",
             "payload": {
                 "session_id": session_id,
-                "next_version_id": result["next_version_id"]
+                "next_version_id": result.get("next_version_id")
             }
         })
-        
+
+    # 5. Dual-write naar Fuseki (fire-and-forget)
+    ds_id = await get_ds_id_for_session(session_id)
+    if ds_id:
+        consent_shortlist = await get_consent_shortlist(session_id, user.get("id"))
+        votes_payload = [
+            {
+                "user_id": user.get("id", ""),
+                "tessera_id": item.get("id", ""),
+                "vote_type": item.get("user_vote") or "consent",
+            }
+            for item in consent_shortlist
+            if item.get("user_vote")
+        ]
+        asyncio.create_task(
+            _write_phase_transition_safe(
+                design_space_id=ds_id,
+                session_id=session_id,
+                phase="consent",
+                votes=votes_payload,
+                user_id=user.get("id", ""),
+            )
+        )
+
     return result
 
 @router.get("/session/{session_id}/transition-validation")

--- a/backend/app/routers/deliberation.py
+++ b/backend/app/routers/deliberation.py
@@ -29,18 +29,18 @@ router = APIRouter(prefix="/deliberation", tags=["deliberation"])
 
 class FeedbackRequest(BaseModel):
     session_id: str
-    claim_version_id: str
+    tessera_base_id: str
     color: str
     motivation: Optional[str] = None
 
 class RankingRequest(BaseModel):
     session_id: str
-    claim_version_id: str
+    tessera_base_id: str
     category: str # high, medium, backlog, discard
 
 class ConsentVoteRequest(BaseModel):
     session_id: str
-    claim_version_id: str
+    tessera_base_id: str
     vote: ConsentVoteType
     motivation: Optional[str] = None
 
@@ -54,7 +54,7 @@ async def post_feedback(data: FeedbackRequest, user: dict = Depends(get_current_
     # 1. Create model
     feedback = Feedback(
         session_id=data.session_id,
-        claim_version_id=data.claim_version_id,
+        tessera_base_id=data.tessera_base_id,
         user_id=user_id,
         color=data.color,
         motivation=data.motivation
@@ -77,7 +77,7 @@ async def post_ranking(data: RankingRequest, user: dict = Depends(get_current_us
     
     ranking = Ranking(
         session_id=data.session_id,
-        claim_version_id=data.claim_version_id,
+        tessera_base_id=data.tessera_base_id,
         user_id=user_id,
         category=data.category
     )
@@ -106,7 +106,7 @@ async def post_consent_vote(session_id: str, data: ConsentVoteRequest, user: dic
     
     vote_obj = ConsentVote(
         session_id=session_id,
-        claim_version_id=data.claim_version_id,
+        tessera_base_id=data.tessera_base_id,
         user_id=user_id,
         vote=data.vote,
         motivation=data.motivation

--- a/backend/app/routers/deliberation.py
+++ b/backend/app/routers/deliberation.py
@@ -20,6 +20,7 @@ from app.db.sessions import get_session_context, get_moderator_sessions, get_ds_
 from app.db.permissions import check_permission
 from app.models.domain import Role, Feedback, Ranking, DeliberationStage, ConsentVote, ConsentVoteType
 from app.db.fuseki_decisions import create_phase_transition
+from app.db.fuseki_votes import write_consent_vote_to_fuseki
 from typing import List, Dict, Any, Optional
 from pydantic import BaseModel
 from app.services.connection_manager import manager
@@ -28,6 +29,32 @@ import logging
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/deliberation", tags=["deliberation"])
+
+
+async def _safe_fuseki_vote_write(
+    ds_id: str,
+    session_id: str,
+    tessera_base_id: str,
+    user_id: str,
+    vote_type: str,
+    motivation: str | None,
+) -> None:
+    try:
+        await write_consent_vote_to_fuseki(
+            ds_id=ds_id,
+            session_id=session_id,
+            tessera_base_id=tessera_base_id,
+            user_id=user_id,
+            vote_type=vote_type,
+            motivation=motivation,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Fuseki dual-write mislukt voor Vote (session=%s, tessera=%s): %s",
+            session_id,
+            tessera_base_id,
+            exc,
+        )
 
 
 async def _write_phase_transition_safe(
@@ -142,7 +169,20 @@ async def post_consent_vote(session_id: str, data: ConsentVoteRequest, user: dic
     success = await submit_consent_vote(vote_obj)
     if not success:
         raise HTTPException(status_code=500, detail="Failed to submit consent vote")
-        
+
+    ds_id = await get_ds_id_for_session(session_id)
+    if ds_id:
+        asyncio.create_task(
+            _safe_fuseki_vote_write(
+                ds_id=ds_id,
+                session_id=session_id,
+                tessera_base_id=data.tessera_base_id,
+                user_id=user_id,
+                vote_type=str(data.vote),
+                motivation=data.motivation,
+            )
+        )
+
     return {"status": "success"}
 
 @router.patch("/session/{session_id}/stage")

--- a/backend/app/routers/deliberation.py
+++ b/backend/app/routers/deliberation.py
@@ -16,43 +16,16 @@ from app.db.deliberation import (
     finalize_deliberation,
     validate_phase_transition
 )
-from app.db.sessions import get_session_context, get_moderator_sessions, get_ds_id_for_session
+from app.db.sessions import get_session_context, get_moderator_sessions
 from app.db.permissions import check_permission
 from app.models.domain import Role, Feedback, Ranking, DeliberationStage, ConsentVote, ConsentVoteType
-from app.db.fuseki_decisions import create_phase_transition
 from typing import List, Dict, Any, Optional
 from pydantic import BaseModel
 from app.services.connection_manager import manager
-import asyncio
 import logging
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/deliberation", tags=["deliberation"])
-
-
-async def _write_phase_transition_safe(
-    design_space_id: str,
-    session_id: str,
-    phase: str,
-    votes: list[dict],
-    user_id: str,
-) -> None:
-    """Fire-and-forget wrapper voor Fuseki dual-write. Logt fouten als WARNING."""
-    try:
-        await create_phase_transition(
-            design_space_id=design_space_id,
-            session_id=session_id,
-            phase=phase,
-            votes=votes,
-            user_id=user_id,
-        )
-    except Exception as exc:
-        logger.warning(
-            "Fuseki dual-write mislukt voor PhaseTransition (session=%s, phase=%s): %s",
-            session_id,
-            phase,
-            exc,
-        )
 
 class FeedbackRequest(BaseModel):
     session_id: str
@@ -177,19 +150,6 @@ async def update_stage(session_id: str, data: StageUpdateRequest, user: dict = D
             }
         })
 
-    # 5. Dual-write naar Fuseki (fire-and-forget)
-    ds_id = await get_ds_id_for_session(session_id)
-    if ds_id:
-        asyncio.create_task(
-            _write_phase_transition_safe(
-                design_space_id=ds_id,
-                session_id=session_id,
-                phase=str(data.stage),
-                votes=[],
-                user_id=user.get("id", ""),
-            )
-        )
-
     return {"stage": data.stage}
 
 @router.get("/moderator/sessions")
@@ -223,32 +183,9 @@ async def post_finalize(session_id: str, user: dict = Depends(get_current_user))
             "type": "SESSION_FINALIZED",
             "payload": {
                 "session_id": session_id,
-                "next_version_id": result.get("next_version_id")
+                "next_version_id": result["next_version_id"]
             }
         })
-
-    # 5. Dual-write naar Fuseki (fire-and-forget)
-    ds_id = await get_ds_id_for_session(session_id)
-    if ds_id:
-        consent_shortlist = await get_consent_shortlist(session_id, user.get("id"))
-        votes_payload = [
-            {
-                "user_id": user.get("id", ""),
-                "tessera_id": item.get("id", ""),
-                "vote_type": item.get("user_vote") or "consent",
-            }
-            for item in consent_shortlist
-            if item.get("user_vote")
-        ]
-        asyncio.create_task(
-            _write_phase_transition_safe(
-                design_space_id=ds_id,
-                session_id=session_id,
-                phase="consent",
-                votes=votes_payload,
-                user_id=user.get("id", ""),
-            )
-        )
 
     return result
 

--- a/backend/app/routers/designspace.py
+++ b/backend/app/routers/designspace.py
@@ -23,6 +23,7 @@ from app.models.domain import (
 )
 from app.ontology import VALOR_NS
 from app.db.fuseki_knowledge import get_condition_coverage, create_claim_coverage_assessment, get_asis_condition_coverage
+from app.db.fuseki_phases import get_phase_snapshots
 from app.services.fuseki import (
     initialize_design_space_graphs, initialize_alternative_graph,
     sparql_proxy_query, sparql_select, sparql_update,
@@ -581,3 +582,13 @@ async def list_participants(
         ))
 
     return results
+
+
+@router.get("/{design_space_id}/phase-snapshots")
+async def list_phase_snapshots(
+    design_space_id: str,
+    user: dict = Depends(get_current_user),
+):
+    if not await check_permission(user["id"], design_space_id, Role.VIEWER):
+        raise HTTPException(status_code=403, detail="Geen toegang tot deze DesignSpace")
+    return await get_phase_snapshots(design_space_id)

--- a/backend/app/routers/factors.py
+++ b/backend/app/routers/factors.py
@@ -28,10 +28,15 @@ class FactorUpdate(BaseModel):
 
 
 @router.get("/designspace/{ds_id}/factors")
-async def list_designspace_factors(ds_id: str, user: dict = Depends(get_current_user)):
+async def list_designspace_factors(
+    ds_id: str,
+    phase: Optional[str] = None,
+    user: dict = Depends(get_current_user),
+):
     if not await check_permission(user["id"], ds_id, Role.MEMBER):
         raise HTTPException(status_code=403, detail="Geen toegang tot deze DesignSpace")
-    return await fuseki_knowledge._sparql_get_factors(ds_id)
+    graph_uri = f"urn:valor:ds:{ds_id}/phase/{phase}" if phase else None
+    return await fuseki_knowledge._sparql_get_factors(ds_id, graph_uri=graph_uri)
 
 
 @router.post("/factors")

--- a/backend/app/routers/sessions.py
+++ b/backend/app/routers/sessions.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from app.auth import get_current_user
 from app.db.sessions import create_voting_session, update_voting_session, get_active_session, get_context_ids, get_session_context
+from app.db.deliberation import mark_phase_completed
 from app.db.crud import ensure_user_sync
 from app.db.permissions import check_permission
 from app.models.domain import Role, VotingSession
@@ -99,3 +100,16 @@ async def get_active_session_endpoint(theme_version_id: str, user: dict = Depend
 
     session = await get_active_session(theme_version_id)
     return session
+
+
+class CompletePhaseRequest(BaseModel):
+    phase: str
+
+
+@router.post("/{session_id}/complete-phase")
+async def complete_phase(session_id: str, data: CompletePhaseRequest, user: dict = Depends(get_current_user)):
+    user_id = user.get("id")
+    success = await mark_phase_completed(session_id, user_id, data.phase)
+    if not success:
+        raise HTTPException(status_code=500, detail="Kon fase niet markeren als afgerond")
+    return {"status": "ok"}

--- a/backend/app/routers/tessera.py
+++ b/backend/app/routers/tessera.py
@@ -8,8 +8,9 @@ from pydantic import BaseModel
 
 from app.auth import get_current_user
 from app.db.permissions import check_permission
-from app.models.domain import Role
+from app.models.domain import Role, CastVoteRequest, VoteResponse
 from app.services.fuseki import sparql_select, sparql_update, sparql_shacl_validate, named_graph_uri, record_provenance_activity
+from app.services.fuseki_decisions import create_or_get_decision_episode, cast_vote, evaluate_quorum
 from app.services.ontology_cache import (
     get_evidence_label_to_uri,
     get_status_label_to_uri,
@@ -19,6 +20,7 @@ from app.services.ontology_cache import (
     get_argue_label_to_uri,
     get_shacl_shapes_graph,
     get_uncertainty_label_to_uri,
+    get_participant_role_data,
 )
 from app.ontology import VALOR_NS
 
@@ -854,3 +856,124 @@ SELECT ?activity ?used WHERE {{
         ))
 
     return results
+
+
+# --- Stemmen op een Tessera via DecisionEpisode (US-5.2) ---
+
+_VOTING_VALOR_ROLES = {"Initiator", "Contributor"}
+
+
+@router.post("/{tessera_id}/vote", response_model=VoteResponse, status_code=201)
+async def cast_tessera_vote(
+    tessera_id: str,
+    request: CastVoteRequest,
+    user: dict = Depends(get_current_user),
+):
+    """Brengt een stem (Accept/Reject/Defer) uit op een Tessera via een DecisionEpisode.
+
+    Alleen gebruikers met VALOR-O rol Initiator of Contributor mogen stemmen (HTTP 403 anders).
+    Na elke stem wordt quorum geëvalueerd; bij quorum wijzigt de epistemische status automatisch.
+    """
+    user_id = user["id"]
+    user_uri = f"urn:valor:user:{user_id}"
+
+    # Basis leesrecht op de DesignSpace
+    if not await check_permission(user_id, request.design_space_id, Role.MEMBER):
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten voor deze DesignSpace.")
+
+    # Controleer stemrecht via VALOR-O rol
+    participant_role_data = get_participant_role_data()
+    voting_role_uris = {
+        data["uri"]
+        for label, data in participant_role_data.items()
+        if label in _VOTING_VALOR_ROLES
+    }
+
+    decisions_graph = f"urn:valor:ds:{request.design_space_id}/decisions"
+    participant_rows = await sparql_select(
+        f"""SELECT ?role WHERE {{
+          GRAPH <{decisions_graph}> {{
+            ?participant <{VALOR_NS}hasUser> <{user_uri}> ;
+                         <{VALOR_NS}hasValorRole> ?role .
+          }}
+        }}""",
+        request.design_space_id,
+    )
+
+    voter_has_right = any(
+        row["role"] in voting_role_uris for row in participant_rows
+    )
+    if not voter_has_right:
+        raise HTTPException(
+            status_code=403,
+            detail="Alleen Initiator of Contributor mag stemmen op een Tessera.",
+        )
+
+    tessera_uri = f"urn:valor:tessera:{tessera_id}"
+
+    # Bepaal de graph waar de Tessera in staat
+    if request.alternative_id:
+        tessera_graph = f"urn:valor:ds:{request.design_space_id}/alternative/{request.alternative_id}"
+    else:
+        tessera_graph = named_graph_uri(request.design_space_id)
+
+    # Controleer dat de Tessera bestaat
+    exist_rows = await sparql_select(
+        f"""SELECT ?t WHERE {{
+          GRAPH <{tessera_graph}> {{
+            <{tessera_uri}> a <{VALOR_NS}Tessera> .
+            BIND(<{tessera_uri}> AS ?t)
+          }}
+        }}""",
+        request.design_space_id,
+    )
+    if not exist_rows:
+        raise HTTPException(status_code=404, detail="Tessera niet gevonden in deze DesignSpace.")
+
+    # DecisionEpisode ophalen of aanmaken
+    episode_uri = await create_or_get_decision_episode(
+        request.design_space_id,
+        tessera_uri,
+        user_uri,
+    )
+
+    # Stem uitbrengen
+    vote_uri = await cast_vote(
+        request.design_space_id,
+        episode_uri,
+        tessera_uri,
+        user_uri,
+        request.vote_type.value,
+    )
+
+    # Provenance vastleggen
+    await record_provenance_activity(
+        request.design_space_id,
+        "VoteCast",
+        user_uri,
+        generated=vote_uri,
+        used=[tessera_uri, episode_uri],
+    )
+
+    # Quorum evalueren
+    new_status = await evaluate_quorum(
+        request.design_space_id,
+        episode_uri,
+        tessera_uri,
+        tessera_graph,
+    )
+
+    logger.info(
+        "Stem uitgebracht: %s op Tessera %s (episode %s) door %s — quorum: %s",
+        request.vote_type.value, tessera_uri, episode_uri, user_id, new_status is not None,
+    )
+
+    return VoteResponse(
+        vote_uri=vote_uri,
+        episode_uri=episode_uri,
+        tessera_id=tessera_id,
+        tessera_uri=tessera_uri,
+        vote_type=request.vote_type.value,
+        quorum_reached=new_status is not None,
+        new_epistemic_status=new_status,
+    )

--- a/backend/app/routers/tessera.py
+++ b/backend/app/routers/tessera.py
@@ -17,6 +17,7 @@ from app.services.ontology_cache import (
     get_valid_transitions,
     requires_decision_episode,
     get_argue_label_to_uri,
+    get_argue_uri_to_labels,
     get_shacl_shapes_graph,
     get_uncertainty_label_to_uri,
 )
@@ -227,6 +228,15 @@ INSERT DATA {{
         in_phase=request.in_phase,
         manifestation_condition=request.manifestation_condition,
     )
+
+
+@router.get("/argue-types")
+async def get_argue_types(user: dict = Depends(get_current_user)) -> list[dict]:
+    """Retourneert alle argue-relatietypes uit de ontologie met EN én NL labels."""
+    return [
+        {"uri": uri, "label_en": labels["en"], "label_nl": labels["nl"]}
+        for uri, labels in get_argue_uri_to_labels().items()
+    ]
 
 
 @router.get("/missing-realisation-basis", response_model=list[TesseraResponse])

--- a/backend/app/routers/threads.py
+++ b/backend/app/routers/threads.py
@@ -198,29 +198,20 @@ async def resolve_thread(
     graph_uri = named_graph_uri(request.design_space_id)
     status_rows = await sparql_select(
         f"""SELECT ?status WHERE {{
-          <{tessera_uri}> <{VALOR_NS}epistemicStatus> ?status .
+          GRAPH <{graph_uri}> {{
+            <{tessera_uri}> <{VALOR_NS}epistemicStatus> ?status .
+          }}
         }}""",
         request.design_space_id,
     )
-    if not status_rows:
-        raise HTTPException(status_code=404, detail="Tessera niet gevonden in deze DesignSpace.")
+    # Als de tessera nog geen epistemicStatus heeft (bijv. Neo4j-factor waarvoor nog geen
+    # Fuseki-Tessera bestaat), val terug op "Proposed" als initiële status.
+    proposed_uri = status_label_to_uri.get("Proposed", f"{VALOR_NS}ProposedStatus")
 
-    current_uri = status_rows[0]["status"]
-    current_label = get_status_uri_to_label().get(current_uri, current_uri)
-
-    # Schrijf disc:ThreadResolution naar Fuseki
-    resolution_id = await create_thread_resolution(
-        thread_id=thread_id,
-        design_space_id=request.design_space_id,
-        user_id=user_id,
-        resolution_outcome_uri=new_status_uri,
-        resolution_rationale=request.resolution_rationale,
-        tessera_uri=tessera_uri,
-    )
-
-    # Wijzig epistemische status van de Tessera
-    await sparql_update(
-        f"""DELETE {{
+    if status_rows:
+        current_uri = status_rows[0]["status"]
+        current_label = get_status_uri_to_label().get(current_uri, current_uri)
+        status_sparql = f"""DELETE {{
   GRAPH <{graph_uri}> {{
     <{tessera_uri}> <{VALOR_NS}epistemicStatus> <{current_uri}> .
   }}
@@ -234,9 +225,28 @@ WHERE {{
   GRAPH <{graph_uri}> {{
     <{tessera_uri}> <{VALOR_NS}epistemicStatus> <{current_uri}> .
   }}
-}}""",
-        request.design_space_id,
+}}"""
+    else:
+        current_uri = proposed_uri
+        current_label = "Proposed"
+        status_sparql = f"""INSERT DATA {{
+  GRAPH <{graph_uri}> {{
+    <{tessera_uri}> <{VALOR_NS}epistemicStatus> <{new_status_uri}> .
+  }}
+}}"""
+
+    # Schrijf disc:ThreadResolution naar Fuseki
+    resolution_id = await create_thread_resolution(
+        thread_id=thread_id,
+        design_space_id=request.design_space_id,
+        user_id=user_id,
+        resolution_outcome_uri=new_status_uri,
+        resolution_rationale=request.resolution_rationale,
+        tessera_uri=tessera_uri,
     )
+
+    # Wijzig epistemische status van de Tessera
+    await sparql_update(status_sparql, request.design_space_id)
 
     # PROV-O record
     await record_provenance_activity(

--- a/backend/app/services/fuseki.py
+++ b/backend/app/services/fuseki.py
@@ -72,7 +72,10 @@ async def sparql_proxy_query(query: str, ds_id: str) -> dict[str, Any]:
     zodat de query alleen data van die DesignSpace kan zien (isolatie gegarandeerd).
     UPDATE/INSERT/DELETE queries worden geweigerd.
     """
-    query_type = query.strip().split()[0].lower() if query.strip() else ""
+    # Sla PREFIX/BASE declaraties over om het echte querytype te vinden
+    import re as _re
+    _stripped = _re.sub(r'(PREFIX|BASE)\s+\S*\s*<[^>]*>\s*', '', query, flags=_re.IGNORECASE).strip()
+    query_type = _stripped.split()[0].lower() if _stripped else ""
     if query_type not in _READONLY_QUERY_TYPES:
         raise HTTPException(
             status_code=400,

--- a/backend/app/services/fuseki_decisions.py
+++ b/backend/app/services/fuseki_decisions.py
@@ -1,0 +1,260 @@
+"""Fuseki-operaties voor DecisionEpisodes en stemmen (US-5.2).
+
+Alle schrijfoperaties gaan naar de `decisions` named graph van de DesignSpace.
+Quorumdrempel is configureerbaar via env var VALOR_QUORUM_THRESHOLD (default 0.5).
+"""
+import logging
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from app.ontology import VALOR_NS
+from app.services.fuseki import sparql_select, sparql_update, record_provenance_activity
+
+logger = logging.getLogger(__name__)
+
+PROV_NS = "https://www.w3.org/ns/prov#"
+XSD_NS = "http://www.w3.org/2001/XMLSchema#"
+
+QUORUM_THRESHOLD = float(os.getenv("VALOR_QUORUM_THRESHOLD", "0.5"))
+
+_VOTE_TYPE_URIS = {
+    "Accept": f"{VALOR_NS}AcceptVote",
+    "Reject": f"{VALOR_NS}RejectVote",
+    "Defer":  f"{VALOR_NS}DeferVote",
+}
+
+_VOTE_URI_TO_TYPE = {v: k for k, v in _VOTE_TYPE_URIS.items()}
+
+
+def _decisions_graph(ds_id: str) -> str:
+    return f"urn:valor:ds:{ds_id}/decisions"
+
+
+async def create_or_get_decision_episode(
+    ds_id: str,
+    tessera_uri: str,
+    created_by_uri: str,
+) -> str:
+    """Geeft de URI van een bestaande open DecisionEpisode voor de Tessera,
+    of maakt een nieuwe aan als er nog geen is.
+
+    Retourneert episode_uri.
+    """
+    decisions_graph = _decisions_graph(ds_id)
+
+    rows = await sparql_select(
+        f"""SELECT ?episode WHERE {{
+          GRAPH <{decisions_graph}> {{
+            ?episode a <{VALOR_NS}DecisionEpisode> ;
+                     <{VALOR_NS}concernsTessera> <{tessera_uri}> ;
+                     <{VALOR_NS}episodeStatus> <{VALOR_NS}OpenEpisode> .
+          }}
+        }}""",
+        ds_id,
+    )
+
+    if rows:
+        return rows[0]["episode"]
+
+    episode_id = str(uuid.uuid4())
+    episode_uri = f"urn:valor:episode:{episode_id}"
+    created_at = datetime.now(timezone.utc).isoformat()
+
+    update = f"""INSERT DATA {{
+  GRAPH <{decisions_graph}> {{
+    <{episode_uri}> a <{VALOR_NS}DecisionEpisode> ;
+      <{VALOR_NS}concernsTessera> <{tessera_uri}> ;
+      <{VALOR_NS}episodeStatus> <{VALOR_NS}OpenEpisode> ;
+      <{VALOR_NS}createdBy> <{created_by_uri}> ;
+      <{VALOR_NS}createdAt> "{created_at}"^^<{XSD_NS}dateTime> .
+  }}
+}}"""
+    await sparql_update(update, ds_id)
+
+    logger.info("DecisionEpisode aangemaakt: %s voor Tessera %s", episode_uri, tessera_uri)
+    return episode_uri
+
+
+async def cast_vote(
+    ds_id: str,
+    episode_uri: str,
+    tessera_uri: str,
+    voter_uri: str,
+    vote_type: str,
+) -> str:
+    """Schrijft een valor:Vote naar de decisions graph.
+
+    Een gebruiker kan per episode maar één stem uitbrengen — bestaande stem
+    wordt vervangen (idempotent per kiezer per episode).
+
+    Retourneert vote_uri.
+    """
+    vote_type_uri = _VOTE_TYPE_URIS.get(vote_type)
+    if not vote_type_uri:
+        raise ValueError(f"Ongeldig vote_type '{vote_type}'. Geldige waarden: {sorted(_VOTE_TYPE_URIS)}.")
+
+    decisions_graph = _decisions_graph(ds_id)
+    voted_at = datetime.now(timezone.utc).isoformat()
+
+    # Verwijder bestaande stem van dezelfde kiezer op hetzelfde episode
+    delete_existing = f"""DELETE {{
+  GRAPH <{decisions_graph}> {{
+    ?existing_vote a <{VALOR_NS}Vote> ;
+      <{VALOR_NS}castBy> <{voter_uri}> ;
+      <{VALOR_NS}inEpisode> <{episode_uri}> ;
+      <{VALOR_NS}voteType> ?old_type ;
+      <{VALOR_NS}votedAt> ?old_at .
+  }}
+}}
+WHERE {{
+  GRAPH <{decisions_graph}> {{
+    ?existing_vote a <{VALOR_NS}Vote> ;
+      <{VALOR_NS}castBy> <{voter_uri}> ;
+      <{VALOR_NS}inEpisode> <{episode_uri}> ;
+      <{VALOR_NS}voteType> ?old_type ;
+      <{VALOR_NS}votedAt> ?old_at .
+  }}
+}}"""
+    await sparql_update(delete_existing, ds_id)
+
+    vote_id = str(uuid.uuid4())
+    vote_uri = f"urn:valor:vote:{vote_id}"
+
+    insert = f"""INSERT DATA {{
+  GRAPH <{decisions_graph}> {{
+    <{vote_uri}> a <{VALOR_NS}Vote> ;
+      <{VALOR_NS}castBy> <{voter_uri}> ;
+      <{VALOR_NS}inEpisode> <{episode_uri}> ;
+      <{VALOR_NS}voteType> <{vote_type_uri}> ;
+      <{VALOR_NS}votedAt> "{voted_at}"^^<{XSD_NS}dateTime> .
+    <{episode_uri}> <{VALOR_NS}hasVote> <{vote_uri}> .
+  }}
+}}"""
+    await sparql_update(insert, ds_id)
+
+    logger.info("Vote %s uitgebracht: %s door %s op episode %s", vote_uri, vote_type, voter_uri, episode_uri)
+    return vote_uri
+
+
+async def evaluate_quorum(
+    ds_id: str,
+    episode_uri: str,
+    tessera_uri: str,
+    graph_uri: str,
+) -> Optional[str]:
+    """Berekent of quorum bereikt is en past epistemische status aan indien nodig.
+
+    Telt Accept en Reject stemmen. Als één van de twee > QUORUM_THRESHOLD van het
+    totaal aantal stemmen, sluit het episode en wijzigt de epistemische status.
+
+    Retourneert de nieuwe status-label als quorum bereikt is, anders None.
+    """
+    from app.services.ontology_cache import get_status_label_to_uri, get_status_uri_to_label
+
+    decisions_graph = _decisions_graph(ds_id)
+
+    vote_rows = await sparql_select(
+        f"""SELECT ?voteType (COUNT(?vote) AS ?count) WHERE {{
+          GRAPH <{decisions_graph}> {{
+            ?vote a <{VALOR_NS}Vote> ;
+              <{VALOR_NS}inEpisode> <{episode_uri}> ;
+              <{VALOR_NS}voteType> ?voteType .
+          }}
+        }}
+        GROUP BY ?voteType""",
+        ds_id,
+    )
+
+    counts: dict[str, int] = {}
+    for row in vote_rows:
+        vtype_uri = row["voteType"]
+        label = _VOTE_URI_TO_TYPE.get(vtype_uri, vtype_uri)
+        counts[label] = int(row["count"])
+
+    total = sum(counts.values())
+    if total == 0:
+        return None
+
+    accept_count = counts.get("Accept", 0)
+    reject_count = counts.get("Reject", 0)
+
+    new_status_label: Optional[str] = None
+    if accept_count / total > QUORUM_THRESHOLD:
+        new_status_label = "Accepted"
+    elif reject_count / total > QUORUM_THRESHOLD:
+        new_status_label = "Rejected"
+
+    if not new_status_label:
+        return None
+
+    status_label_to_uri = get_status_label_to_uri()
+    new_status_uri = status_label_to_uri.get(new_status_label)
+    if not new_status_uri:
+        logger.warning("Status '%s' niet gevonden in ontologie, quorum niet toegepast.", new_status_label)
+        return None
+
+    # Haal huidige status op uit de correcte graph
+    status_rows = await sparql_select(
+        f"""SELECT ?status WHERE {{
+          GRAPH <{graph_uri}> {{
+            <{tessera_uri}> <{VALOR_NS}epistemicStatus> ?status .
+          }}
+        }}""",
+        ds_id,
+    )
+    if not status_rows:
+        logger.warning("Tessera %s niet gevonden in graph %s voor quorum-update.", tessera_uri, graph_uri)
+        return None
+
+    current_uri = status_rows[0]["status"]
+
+    # Update epistemische status in de tessera-graph
+    await sparql_update(
+        f"""DELETE {{
+  GRAPH <{graph_uri}> {{
+    <{tessera_uri}> <{VALOR_NS}epistemicStatus> <{current_uri}> .
+  }}
+}}
+INSERT {{
+  GRAPH <{graph_uri}> {{
+    <{tessera_uri}> <{VALOR_NS}epistemicStatus> <{new_status_uri}> .
+  }}
+}}
+WHERE {{
+  GRAPH <{graph_uri}> {{
+    <{tessera_uri}> <{VALOR_NS}epistemicStatus> <{current_uri}> .
+  }}
+}}""",
+        ds_id,
+    )
+
+    # Sluit het episode
+    closed_at = datetime.now(timezone.utc).isoformat()
+    await sparql_update(
+        f"""DELETE {{
+  GRAPH <{decisions_graph}> {{
+    <{episode_uri}> <{VALOR_NS}episodeStatus> <{VALOR_NS}OpenEpisode> .
+  }}
+}}
+INSERT {{
+  GRAPH <{decisions_graph}> {{
+    <{episode_uri}> <{VALOR_NS}episodeStatus> <{VALOR_NS}ClosedEpisode> ;
+                    <{VALOR_NS}closedAt> "{closed_at}"^^<{XSD_NS}dateTime> ;
+                    <{VALOR_NS}resolvedWith> <{new_status_uri}> .
+  }}
+}}
+WHERE {{
+  GRAPH <{decisions_graph}> {{
+    <{episode_uri}> <{VALOR_NS}episodeStatus> <{VALOR_NS}OpenEpisode> .
+  }}
+}}""",
+        ds_id,
+    )
+
+    logger.info(
+        "Quorum bereikt op episode %s: Tessera %s → %s",
+        episode_uri, tessera_uri, new_status_label,
+    )
+    return new_status_label

--- a/backend/app/services/ontology_cache.py
+++ b/backend/app/services/ontology_cache.py
@@ -25,6 +25,7 @@ _status_uri_to_label: dict[str, str] = {}
 _valid_transitions: dict[str, set[str]] = {}
 _requires_decision_episode: set[str] = set()
 _argue_label_to_uri: dict[str, str] = {}        # "undermines" → URI
+_argue_uri_to_labels: dict[str, dict] = {}      # URI → {en, nl}
 _uncertainty_label_to_uri: dict[str, str] = {}  # "StatisticalRisk" → URI
 # Participant roles: label → {uri, rbac_role, weight, voting_right}
 _participant_role_data: dict[str, dict] = {}
@@ -40,7 +41,7 @@ _DISC_GRAPH = f"{VALOR_NS}disc"
 
 async def load_ontology_cache() -> None:
     global _evidence_label_to_uri, _status_label_to_uri, _status_uri_to_label
-    global _valid_transitions, _requires_decision_episode, _argue_label_to_uri
+    global _valid_transitions, _requires_decision_episode, _argue_label_to_uri, _argue_uri_to_labels
     global _uncertainty_label_to_uri, _participant_role_data, _rbac_role_weights
     global _disc_contribution_type_label_to_uri, _status_uri_to_nl_label
     global _system_situation_uris
@@ -123,17 +124,21 @@ async def load_ontology_cache() -> None:
         PREFIX valor: <{VALOR_NS}>
         PREFIX owl:   <{PREFIX_OWL}>
         PREFIX rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
-        SELECT ?uri ?label WHERE {{
+        SELECT ?uri ?labelEn ?labelNl WHERE {{
           GRAPH <{_TESSERA_GRAPH}> {{
             ?uri a owl:ObjectProperty ;
                  rdfs:domain valor:Tessera ;
-                 rdfs:range  valor:Tessera ;
-                 rdfs:label ?label .
-            FILTER(lang(?label) = "en")
+                 rdfs:range  valor:Tessera .
+            ?uri rdfs:label ?labelEn . FILTER(lang(?labelEn) = "en")
+            OPTIONAL {{ ?uri rdfs:label ?labelNl . FILTER(lang(?labelNl) = "nl") }}
           }}
         }}
     """)
-    _argue_label_to_uri = {row["label"]: row["uri"] for row in argue_rows}
+    _argue_label_to_uri = {row["labelEn"]: row["uri"] for row in argue_rows}
+    _argue_uri_to_labels = {
+        row["uri"]: {"en": row["labelEn"], "nl": row.get("labelNl", row["labelEn"])}
+        for row in argue_rows
+    }
     logger.info("[ontology-cache] Argumentatierelaties: %s", list(_argue_label_to_uri.keys()))
 
     uncertainty_rows = await sparql_select_global(f"""
@@ -240,6 +245,10 @@ def requires_decision_episode(status_uri: str) -> bool:
 
 def get_argue_label_to_uri() -> dict[str, str]:
     return _argue_label_to_uri
+
+
+def get_argue_uri_to_labels() -> dict[str, dict]:
+    return _argue_uri_to_labels
 
 
 def get_uncertainty_label_to_uri() -> dict[str, str]:

--- a/backend/verify_backend_deliberation.py
+++ b/backend/verify_backend_deliberation.py
@@ -22,7 +22,7 @@ async def main():
     f = Feedback(
         id=str(uuid.uuid4()),
         session_id=sid,
-        claim_version_id=cvid,
+        tessera_base_id=cvid,
         user_id=uid,
         color='green',
         motivation='Looks promising for the pilot.',
@@ -41,7 +41,7 @@ async def main():
     r = Ranking(
         id=str(uuid.uuid4()),
         session_id=sid,
-        claim_version_id=cvid,
+        tessera_base_id=cvid,
         user_id=uid,
         category='high',
         created_at=datetime.now()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import { VersionLayout } from './components/layout/VersionLayout';
 import { VersionDashboard } from './pages/VersionDashboard';
 import { VersionChat } from './pages/VersionChat';
 import { RefinementBoardComponent } from './components/deliberation/RefinementBoard';
+import { ArgumentationDiagram } from './components/deliberation/ArgumentationDiagram';
 import { DesignSpaceProvider } from './context/DesignSpaceContext';
 
 function App() {
@@ -122,6 +123,7 @@ function App() {
             <Route element={<VersionLayout />}>
               <Route path="overview" element={<VersionDashboard />} />
               <Route path="claims" element={<RefinementBoardComponent />} />
+              <Route path="argumentatie" element={<ArgumentationDiagram />} />
               <Route path="chat" element={<VersionChat />} />
               <Route path="members" element={<div className="p-8">Members (Coming Soon)</div>} />
               <Route path="settings" element={<div className="p-8">Version Settings (Coming Soon)</div>} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -199,7 +199,7 @@ const WorkspaceWrapper = () => {
         projectName={found.project.name}
         dsId={found.theme.id}
         themeName={found.theme.name}
-        onBack={() => window.history.length > 1 ? navigate(-1) : navigate('/')}
+        onBack={() => navigate('/')}
       />
     </DesignSpaceProvider>
   );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -199,7 +199,7 @@ const WorkspaceWrapper = () => {
         projectName={found.project.name}
         dsId={found.theme.id}
         themeName={found.theme.name}
-        onBack={() => navigate(-1)}
+        onBack={() => window.history.length > 1 ? navigate(-1) : navigate('/')}
       />
     </DesignSpaceProvider>
   );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,7 +21,6 @@ import { VersionChat } from './pages/VersionChat';
 import { RefinementBoardComponent } from './components/deliberation/RefinementBoard';
 import { ArgumentationDiagram } from './components/deliberation/ArgumentationDiagram';
 import { DecisionTimeline } from './components/deliberation/DecisionTimeline';
-import { DesignSpaceProvider } from './context/DesignSpaceContext';
 
 function App() {
   const { session, isLoading: authLoading } = useAuth();
@@ -118,18 +117,16 @@ function App() {
             </DashboardLayout>
           } />
 
-          {/* DesignSpace Routes */}
-          <Route path="/designspace/:dsId">
+          {/* DesignSpace Routes — VersionLayout wraps alles inclusief workspace */}
+          <Route path="/designspace/:dsId" element={<VersionLayout />}>
             <Route index element={<WorkspaceWrapper />} />
-            <Route element={<VersionLayout />}>
-              <Route path="overview" element={<VersionDashboard />} />
-              <Route path="claims" element={<RefinementBoardComponent />} />
-              <Route path="argumentatie" element={<ArgumentationDiagram />} />
-              <Route path="tijdlijn" element={<DecisionTimeline />} />
-              <Route path="chat" element={<VersionChat />} />
-              <Route path="members" element={<div className="p-8">Members (Coming Soon)</div>} />
-              <Route path="settings" element={<div className="p-8">Version Settings (Coming Soon)</div>} />
-            </Route>
+            <Route path="overview" element={<VersionDashboard />} />
+            <Route path="claims" element={<RefinementBoardComponent />} />
+            <Route path="argumentatie" element={<ArgumentationDiagram />} />
+            <Route path="tijdlijn" element={<DecisionTimeline />} />
+            <Route path="chat" element={<VersionChat />} />
+            <Route path="members" element={<div className="p-8">Leden (Coming Soon)</div>} />
+            <Route path="settings" element={<div className="p-8">Instellingen (Coming Soon)</div>} />
           </Route>
 
 
@@ -174,36 +171,22 @@ const ThemeListWrapper = () => {
 
 const WorkspaceWrapper = () => {
   const { dsId } = useParams();
-  const navigate = useNavigate();
-  const { organizations, isLoading } = useOrganization();
+  const { organizations } = useOrganization();
 
-  const found = organizations.flatMap(org =>
-    org.projects.flatMap(proj =>
-      proj.themes.map(theme => ({
-        project: proj,
-        theme
-      }))
-    )
-  ).find(item => item.theme.id === dsId);
+  const found = organizations
+    .flatMap(org => org.projects.flatMap(proj =>
+      proj.themes.map(theme => ({ project: proj, theme }))
+    ))
+    .find(item => item.theme.id === dsId);
 
-  if (isLoading) {
-    return <div className="flex items-center justify-center h-screen">Laden...</div>;
-  }
-
-  if (!found) {
-    return <div className="flex items-center justify-center h-screen">DesignSpace niet gevonden of geen toegang.</div>;
-  }
+  if (!found) return null;
 
   return (
-    <DesignSpaceProvider dsId={found.theme.id}>
-      <ValorWorkspace
-        projectId={found.project.id}
-        projectName={found.project.name}
-        dsId={found.theme.id}
-        themeName={found.theme.name}
-        onBack={() => navigate(-1)}
-      />
-    </DesignSpaceProvider>
+    <ValorWorkspace
+      projectId={found.project.id}
+      dsId={found.theme.id}
+      themeName={found.theme.name}
+    />
   );
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -201,7 +201,7 @@ const WorkspaceWrapper = () => {
         projectName={found.project.name}
         dsId={found.theme.id}
         themeName={found.theme.name}
-        onBack={() => navigate('/')}
+        onBack={() => navigate(-1)}
       />
     </DesignSpaceProvider>
   );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ import { VersionDashboard } from './pages/VersionDashboard';
 import { VersionChat } from './pages/VersionChat';
 import { RefinementBoardComponent } from './components/deliberation/RefinementBoard';
 import { ArgumentationDiagram } from './components/deliberation/ArgumentationDiagram';
+import { DecisionTimeline } from './components/deliberation/DecisionTimeline';
 import { DesignSpaceProvider } from './context/DesignSpaceContext';
 
 function App() {
@@ -124,6 +125,7 @@ function App() {
               <Route path="overview" element={<VersionDashboard />} />
               <Route path="claims" element={<RefinementBoardComponent />} />
               <Route path="argumentatie" element={<ArgumentationDiagram />} />
+              <Route path="tijdlijn" element={<DecisionTimeline />} />
               <Route path="chat" element={<VersionChat />} />
               <Route path="members" element={<div className="p-8">Members (Coming Soon)</div>} />
               <Route path="settings" element={<div className="p-8">Version Settings (Coming Soon)</div>} />

--- a/frontend/src/components/Chat/FloatingThreadPanel.tsx
+++ b/frontend/src/components/Chat/FloatingThreadPanel.tsx
@@ -87,6 +87,7 @@ export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
     const [resolveRationale, setResolveRationale] = useState('');
     const [resolving, setResolving] = useState(false);
     const [resolveResult, setResolveResult] = useState<{ label_nl: string } | null>(null);
+    const [resolveError, setResolveError] = useState<string | null>(null);
 
     useEffect(() => {
         if (designSpaceId) loadThreads();
@@ -168,6 +169,7 @@ export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
         e.preventDefault();
         if (!activeThread || !resolveOutcome || !resolveRationale.trim()) return;
         setResolving(true);
+        setResolveError(null);
         try {
             await api.resolveDiscThread(activeThread.thread_id, {
                 design_space_id: designSpaceId!,
@@ -176,8 +178,11 @@ export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
             });
             const status = epistemicStatuses.find(s => s.label_en === resolveOutcome);
             setResolveResult({ label_nl: status?.label_nl ?? resolveOutcome });
-        } catch (e) {
-            console.error('[FloatingThreadPanel] handleResolve:', e);
+        } catch (err: unknown) {
+            console.error('[FloatingThreadPanel] handleResolve:', err);
+            const msg = (err as { response?: { data?: { detail?: string } }; message?: string })
+                ?.response?.data?.detail ?? (err as { message?: string })?.message ?? 'Onbekende fout';
+            setResolveError(msg);
         } finally {
             setResolving(false);
         }
@@ -424,6 +429,9 @@ export const FloatingThreadPanel: React.FC<FloatingThreadPanelProps> = ({
                                     <Gavel className="h-3 w-3 mr-1.5" />
                                     {resolving ? 'Bezig...' : 'Thread Afsluiten'}
                                 </Button>
+                                {resolveError && (
+                                    <p className="text-[10px] text-destructive">{resolveError}</p>
+                                )}
                             </form>
                         )}
                     </>

--- a/frontend/src/components/Theme/ThemeContextPanel.tsx
+++ b/frontend/src/components/Theme/ThemeContextPanel.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useDesignSpace } from '../../context/DesignSpaceContext';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import { CheckCircle2, Target } from 'lucide-react';
 
 export const ThemeContextPanel: React.FC = () => {
@@ -24,11 +23,6 @@ export const ThemeContextPanel: React.FC = () => {
                 <span className="hidden md:inline">
                     {activeVotingSession ? `Stemming: ${activeVersion.name}` : `Actief: ${activeVersion.name}`}
                 </span>
-                {activeVersion.current_phase && (
-                    <Badge variant="outline" className="text-[10px] h-4 px-1 py-0">
-                        {activeVersion.current_phase}
-                    </Badge>
-                )}
             </Button>
         </div>
     );

--- a/frontend/src/components/Workspace/ValorWorkspace.tsx
+++ b/frontend/src/components/Workspace/ValorWorkspace.tsx
@@ -1,52 +1,30 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { CausaShell } from '../../perspectives/causa';
 import { api, type Claim } from '../../services/api';
-import { Maximize2, Minimize2, ArrowLeft, Settings } from 'lucide-react';
-import { Button } from "@/components/ui/button";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { useSearchParams } from 'react-router-dom';
-import {
-    Dialog,
-    DialogContent,
-    DialogHeader,
-    DialogTitle,
-} from "@/components/ui/dialog";
 import type { ConversationContext } from '../../types/conversation';
 import { ConversationPane } from '../shell/ConversationPane';
-import { MemberManagement } from '../Settings/MemberManagement';
-
-interface ValorWorkspaceProps {
-    projectId: string;
-    projectName: string;
-    dsId: string;
-    themeName: string;
-    onBack: () => void;
-}
+import { useWebSocket } from '../../hooks/useWebSocket';
+import { useDesignSpace } from '../../context/DesignSpaceContext';
 
 type AgentType = 'CAUSA' | 'AXIA' | 'ACTOR' | 'PRAXIS';
 
-import { useWebSocket } from '../../hooks/useWebSocket';
+interface ValorWorkspaceProps {
+    projectId: string;
+    dsId: string;
+    themeName: string;
+}
 
-// ... imports
-import { useDesignSpace } from '../../context/DesignSpaceContext';
-import { PhaseSelector } from '../deliberation/PhaseSelector';
+export const ValorWorkspace: React.FC<ValorWorkspaceProps> = ({ projectId, dsId, themeName }) => {
+    const [searchParams] = useSearchParams();
+    const activeAgent = (searchParams.get('mode') as AgentType) || 'CAUSA';
 
-export const ValorWorkspace: React.FC<ValorWorkspaceProps> = ({ projectId, dsId, projectName, themeName, onBack }) => {
-    const [searchParams, setSearchParams] = useSearchParams();
-    const mode = searchParams.get('mode') as AgentType | null;
-
-    const [activeAgent, setActiveAgent] = useState<AgentType>(mode || 'CAUSA');
-
-    // WebSocket Integration
     const { lastMessage, sendMessage } = useWebSocket(projectId);
     const websocketContext = useMemo(() => ({ lastMessage, sendMessage }), [lastMessage, sendMessage]);
     const [currentUser, setCurrentUser] = useState<any>(null);
 
-    // Context Integration
-    const { currentViewedVersion, isReadOnly, setActiveVotingSession, phaseSnapshots, activePhaseId, setActivePhaseId } = useDesignSpace();
+    const { currentViewedVersion, isReadOnly, setActiveVotingSession, activePhaseId } = useDesignSpace();
 
-    // dsId IS de ds_id — direct gebruiken, geen lookup nodig
-    const activeDesignSpaceId = dsId;
     const [userCanResolve, setUserCanResolve] = useState(false);
 
     useEffect(() => {
@@ -63,202 +41,86 @@ export const ValorWorkspace: React.FC<ValorWorkspaceProps> = ({ projectId, dsId,
         if (msg.type === 'SESSION_STARTED') {
             setActiveVotingSession(msg.payload);
         }
-
         if (msg.type === 'STAGE_UPDATED') {
             setActiveVotingSession(prev => prev ? { ...prev, stage: msg.payload.stage } : null);
         }
-
         if (msg.type === 'SESSION_CLOSED') {
             setActiveVotingSession(null);
         }
     }, [lastMessage, setActiveVotingSession]);
 
-    // Fetch user on mount for identity
     useEffect(() => {
-        // Simple fetch or use context
-        // We can decode the session token or use API
-        // For now, let's use the local storage session or API
-        // Better: supabase.auth.getUser()
         const fetchUser = async () => {
             try {
-                // Ensure auth session exists first (handled by AuthContext generally, but safe to check)
                 const { data: { session } } = await import('../../lib/supabase').then(m => m.supabase.auth.getSession());
-
                 if (session) {
                     const profile = await api.getProfile();
-                    // Use Username if available, fallback to name, then email
                     const displayName = profile.username || profile.name || profile.email;
                     setCurrentUser({ ...profile, displayName });
                 }
             } catch (err) {
-                console.error("Failed to fetch user profile", err);
+                console.error('Failed to fetch user profile', err);
             }
         };
         fetchUser();
     }, []);
 
-    // Sync state to URL if changed via UI
-    useEffect(() => {
-        if (activeAgent) {
-            setSearchParams(prev => {
-                prev.set('mode', activeAgent);
-                return prev;
-            });
-        }
-    }, [activeAgent, setSearchParams]);
-    // const [factors, setFactors] = useState<any[]>([]); // Cleaned up unused state
-    const [activeConversation, setActiveConversation] = useState<ConversationContext | null>(null);
-    const [focusMode, setFocusMode] = useState(false);
-    const [isSettingsOpen, setIsSettingsOpen] = useState(false);
-
     const refreshData = useCallback(async () => {
         if (!currentViewedVersion) return;
+        console.log('Refreshing data for version:', currentViewedVersion.id);
+    }, [currentViewedVersion]);
 
-        try {
-            // Fetch data specific to the CURRENTLY VIEWED version
-            // For historical versions, this fetches historical data.
-            // For active version, this fetches current data (which is conceptually 'active version data')
-
-            // NOTE: CausaShell likely fetches its own data or needs props. 
-            // Currently CausaShell fetches data via api calls internally or we pass it? 
-            // Checking CausaShell props: it takes themeId. 
-            // We need to pass the versionId to CausaShell so IT can fetch the right data!
-            // OR we fetch here and pass data down.
-            // CausaShell usually handles the graph.
-
-            // For now, we just ensure we can fetch. 
-            // The CausaShell component needs to be updated to accept `versionId` and `isReadOnly`.
-            console.log('Refreshing data for version:', currentViewedVersion.id);
-
-        } catch (error) {
-            console.error('Failed to fetch theme data:', error);
-        }
-    }, [currentViewedVersion]); // Depend on the viewed version
-
-    // Fetch data when viewed version changes
     useEffect(() => {
         refreshData();
     }, [refreshData]);
 
+    const [activeConversation, setActiveConversation] = useState<ConversationContext | null>(null);
+
     const handleOpenConversation = useCallback((context: ConversationContext) => {
         setActiveConversation(context);
     }, []);
-
-    const handleCloseConversation = () => {
-        setActiveConversation(null);
-    };
 
     const handleClaimsUpdate = async (_newClaims: Claim[]) => {
         await refreshData();
     };
 
     return (
-        <div className="flex flex-col h-screen bg-background overflow-hidden relative">
-            <header className="h-14 border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 flex items-center justify-between px-4 shrink-0 z-30">
-                <div className="flex items-center gap-4">
-                    <Button variant="ghost" size="icon" onClick={onBack} title="Terug">
-                        <ArrowLeft className="h-4 w-4" />
-                    </Button>
-                    <div className="flex flex-col">
-                        <span className="text-[10px] text-muted-foreground uppercase tracking-widest font-bold leading-none mb-1">{projectName}</span>
-                        <span className="text-sm font-bold leading-none">{themeName}</span>
+        <div className="flex h-full bg-background overflow-hidden relative">
+            {activeAgent === 'CAUSA' ? (
+                <div className="flex-1 flex overflow-hidden">
+                    <div className="flex-1 bg-muted/30 h-full relative overflow-hidden">
+                        <CausaShell
+                            themeId={dsId}
+                            projectId={projectId}
+                            onOpenConversation={handleOpenConversation}
+                            websocket={websocketContext}
+                            currentUserId={currentUser?.id || null}
+                            versionId={currentViewedVersion?.id}
+                            isReadOnly={isReadOnly}
+                            designSpaceId={dsId}
+                            canResolveThread={userCanResolve && !activePhaseId}
+                        />
                     </div>
                 </div>
-
-                <div className="flex items-center gap-4">
-                    <ToggleGroup
-                        type="single"
-                        value={activeAgent}
-                        onValueChange={(val) => val && setActiveAgent(val as AgentType)}
-                    >
-                        <ToggleGroupItem value="CAUSA" aria-label="Toggle CAUSA">CAUSA</ToggleGroupItem>
-                        <ToggleGroupItem value="AXIA" disabled aria-label="Toggle AXIA">
-                            AXIA <span className="ml-1.5 text-[9px] opacity-70">SOON</span>
-                        </ToggleGroupItem>
-                        <ToggleGroupItem value="ACTOR" disabled aria-label="Toggle ACTOR">
-                            ACTOR <span className="ml-1.5 text-[9px] opacity-70">SOON</span>
-                        </ToggleGroupItem>
-                        <ToggleGroupItem value="PRAXIS" disabled aria-label="Toggle PRAXIS">
-                            PRAXIS <span className="ml-1.5 text-[9px] opacity-70">SOON</span>
-                        </ToggleGroupItem>
-                    </ToggleGroup>
-                </div>
-
-                <div className="flex items-center gap-2">
-                    <PhaseSelector
-                        snapshots={phaseSnapshots}
-                        activePhaseId={activePhaseId}
-                        onSelect={setActivePhaseId}
-                    />
-                    <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => setIsSettingsOpen(true)}
-                        title="Thema Instellingen & Leden"
-                    >
-                        <Settings size={18} />
-                    </Button>
-                    <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => setFocusMode(!focusMode)}
-                        title={focusMode ? "Exit Focus Mode" : "Enter Focus Mode"}
-                        className={focusMode ? 'text-primary bg-primary/10' : ''}
-                    >
-                        {focusMode ? <Minimize2 size={18} /> : <Maximize2 size={18} />}
-                    </Button>
-                </div>
-            </header>
-
-            <main className="flex-1 flex overflow-hidden relative">
-                {activeAgent === 'CAUSA' ? (
-                    <div className="flex-1 flex overflow-hidden">
-                        <div className="flex-1 bg-muted/30 h-full relative overflow-hidden">
-                            {/* Pass version context to CausaShell */}
-                            <CausaShell
-                                themeId={dsId}
-                                projectId={projectId}
-                                onOpenConversation={handleOpenConversation}
-                                websocket={websocketContext}
-                                currentUserId={currentUser?.id || null}
-                                versionId={currentViewedVersion?.id}
-                                isReadOnly={isReadOnly}
-                                designSpaceId={activeDesignSpaceId}
-                                canResolveThread={userCanResolve && !activePhaseId}
-                            />
-                        </div>
+            ) : (
+                <div className="flex-1 flex flex-col items-center justify-center bg-muted/10 text-muted-foreground">
+                    <div className="w-16 h-16 bg-muted rounded-full flex items-center justify-center mb-4 text-muted-foreground/50">
+                        ?
                     </div>
-                ) : (
-                    <div className="flex-1 flex flex-col items-center justify-center bg-muted/10 text-muted-foreground">
-                        <div className="w-16 h-16 bg-muted rounded-full flex items-center justify-center mb-4 text-muted-foreground/50">
-                            ?
-                        </div>
-                        <p className="font-medium">Module {activeAgent} is nog in ontwikkeling.</p>
-                        <p className="text-sm">We werken hard aan de volgende stap in de analyse.</p>
-                    </div>
-                )}
-            </main>
+                    <p className="font-medium">Module {activeAgent} is nog in ontwikkeling.</p>
+                    <p className="text-sm">We werken hard aan de volgende stap in de analyse.</p>
+                </div>
+            )}
 
             <ConversationPane
                 isOpen={!!activeConversation}
-                onClose={handleCloseConversation}
+                onClose={() => setActiveConversation(null)}
                 context={activeConversation}
                 topicId={dsId}
                 topicLabel={themeName}
                 onClaimsUpdate={handleClaimsUpdate}
                 isReadOnly={isReadOnly}
             />
-
-            <Dialog open={isSettingsOpen} onOpenChange={setIsSettingsOpen}>
-                <DialogContent className="max-w-4xl max-h-[85vh] overflow-y-auto" aria-describedby={undefined}>
-                    <DialogHeader>
-                        <DialogTitle>Thema Instellingen: {themeName}</DialogTitle>
-                    </DialogHeader>
-                    <div className="py-4">
-                        <MemberManagement entityId={dsId} entityType="theme" />
-                    </div>
-                </DialogContent>
-            </Dialog>
         </div>
     );
 };

--- a/frontend/src/components/Workspace/ValorWorkspace.tsx
+++ b/frontend/src/components/Workspace/ValorWorkspace.tsx
@@ -29,7 +29,6 @@ import { useWebSocket } from '../../hooks/useWebSocket';
 
 // ... imports
 import { useDesignSpace } from '../../context/DesignSpaceContext';
-import { ThemeContextPanel } from '../Theme/ThemeContextPanel';
 import { PhaseSelector } from '../deliberation/PhaseSelector';
 
 export const ValorWorkspace: React.FC<ValorWorkspaceProps> = ({ projectId, dsId, projectName, themeName, onBack }) => {
@@ -191,9 +190,6 @@ export const ValorWorkspace: React.FC<ValorWorkspaceProps> = ({ projectId, dsId,
                         activePhaseId={activePhaseId}
                         onSelect={setActivePhaseId}
                     />
-                    {/* Theme Context Panel (Version Switcher) */}
-                    <ThemeContextPanel />
-
                     <Button
                         variant="ghost"
                         size="icon"

--- a/frontend/src/components/Workspace/ValorWorkspace.tsx
+++ b/frontend/src/components/Workspace/ValorWorkspace.tsx
@@ -224,7 +224,7 @@ export const ValorWorkspace: React.FC<ValorWorkspaceProps> = ({ projectId, dsId,
                                 versionId={currentViewedVersion?.id}
                                 isReadOnly={isReadOnly}
                                 designSpaceId={activeDesignSpaceId}
-                                canResolveThread={userCanResolve}
+                                canResolveThread={userCanResolve && !activePhaseId}
                             />
                         </div>
                     </div>

--- a/frontend/src/components/Workspace/ValorWorkspace.tsx
+++ b/frontend/src/components/Workspace/ValorWorkspace.tsx
@@ -30,6 +30,7 @@ import { useWebSocket } from '../../hooks/useWebSocket';
 // ... imports
 import { useDesignSpace } from '../../context/DesignSpaceContext';
 import { ThemeContextPanel } from '../Theme/ThemeContextPanel';
+import { PhaseSelector } from '../deliberation/PhaseSelector';
 
 export const ValorWorkspace: React.FC<ValorWorkspaceProps> = ({ projectId, dsId, projectName, themeName, onBack }) => {
     const [searchParams, setSearchParams] = useSearchParams();
@@ -43,7 +44,7 @@ export const ValorWorkspace: React.FC<ValorWorkspaceProps> = ({ projectId, dsId,
     const [currentUser, setCurrentUser] = useState<any>(null);
 
     // Context Integration
-    const { currentViewedVersion, isReadOnly, setActiveVotingSession } = useDesignSpace();
+    const { currentViewedVersion, isReadOnly, setActiveVotingSession, phaseSnapshots, activePhaseId, setActivePhaseId } = useDesignSpace();
 
     // dsId IS de ds_id — direct gebruiken, geen lookup nodig
     const activeDesignSpaceId = dsId;
@@ -185,6 +186,11 @@ export const ValorWorkspace: React.FC<ValorWorkspaceProps> = ({ projectId, dsId,
                 </div>
 
                 <div className="flex items-center gap-2">
+                    <PhaseSelector
+                        snapshots={phaseSnapshots}
+                        activePhaseId={activePhaseId}
+                        onSelect={setActivePhaseId}
+                    />
                     {/* Theme Context Panel (Version Switcher) */}
                     <ThemeContextPanel />
 

--- a/frontend/src/components/deliberation/ArgumentationDiagram.tsx
+++ b/frontend/src/components/deliberation/ArgumentationDiagram.tsx
@@ -1,0 +1,231 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useParams } from 'react-router-dom';
+import ReactFlow, {
+    Background,
+    Controls,
+    MiniMap,
+    type Node,
+    type Edge,
+    type NodeMouseHandler,
+    MarkerType,
+    useNodesState,
+    useEdgesState,
+} from 'reactflow';
+import 'reactflow/dist/style.css';
+import { AlertCircle, Loader2 } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { api, type TesseraNode, type ArgueRelationType } from '@/services/api';
+import { TesseraDetailPanel } from '@/components/deliberation/TesseraDetailPanel';
+
+// Kleurcodering per relatietype
+const RELATION_COLORS: Record<ArgueRelationType | string, string> = {
+    supports: '#22c55e',    // groen
+    undermines: '#ef4444',  // rood
+    qualifies: '#f59e0b',   // amber
+    presupposes: '#8b5cf6', // paars
+};
+
+const RELATION_LABELS_NL: Record<ArgueRelationType | string, string> = {
+    supports: 'Ondersteunt',
+    undermines: 'Ondermijnt',
+    qualifies: 'Nuanceert',
+    presupposes: 'Veronderstelt',
+};
+
+const STATUS_COLORS: Record<string, string> = {
+    Proposed: '#71717a',
+    Contested: '#f59e0b',
+    Accepted: '#22c55e',
+    Rejected: '#ef4444',
+    Deprecated: '#a1a1aa',
+};
+
+const NODE_WIDTH = 200;
+const NODE_HEIGHT = 80;
+
+function buildLayout(
+    tesseraNodes: TesseraNode[],
+): Map<string, { x: number; y: number }> {
+    const positions = new Map<string, { x: number; y: number }>();
+    const cols = Math.ceil(Math.sqrt(tesseraNodes.length));
+    tesseraNodes.forEach((n, i) => {
+        const col = i % cols;
+        const row = Math.floor(i / cols);
+        positions.set(n.id, {
+            x: col * (NODE_WIDTH + 80),
+            y: row * (NODE_HEIGHT + 60),
+        });
+    });
+    return positions;
+}
+
+interface ArgumentationDiagramProps {
+    dsId?: string;
+}
+
+export const ArgumentationDiagram: React.FC<ArgumentationDiagramProps> = ({ dsId: dsProp }) => {
+    const { dsId: dsParam } = useParams<{ dsId: string }>();
+    const dsId = dsProp ?? dsParam ?? '';
+
+    const { data, isLoading, isError } = useQuery({
+        queryKey: ['argumentation-network', dsId],
+        queryFn: () => api.getArgumentationNetwork(dsId),
+        enabled: !!dsId,
+    });
+
+    const [selectedTessera, setSelectedTessera] = useState<TesseraNode | null>(null);
+    const [sheetOpen, setSheetOpen] = useState(false);
+
+    const rfNodes = useMemo<Node[]>(() => {
+        if (!data) return [];
+        const positions = buildLayout(data.nodes);
+        return data.nodes.map((n) => {
+            const pos = positions.get(n.id) ?? { x: 0, y: 0 };
+            const statusColor = STATUS_COLORS[n.epistemicStatus] ?? '#71717a';
+            return {
+                id: n.id,
+                position: pos,
+                type: 'default',
+                data: {
+                    label: (
+                        <div className="flex flex-col gap-1 text-left p-1">
+                            <p className="text-xs font-medium leading-tight line-clamp-3 text-foreground">
+                                {n.claimContent}
+                            </p>
+                        </div>
+                    ),
+                    tessera: n,
+                },
+                style: {
+                    width: NODE_WIDTH,
+                    minHeight: NODE_HEIGHT,
+                    borderRadius: 8,
+                    border: `2px solid ${statusColor}`,
+                    background: 'hsl(var(--background))',
+                    padding: 8,
+                    cursor: 'pointer',
+                },
+            };
+        });
+    }, [data]);
+
+    const rfEdges = useMemo<Edge[]>(() => {
+        if (!data) return [];
+        return data.edges.map((e, i) => {
+            const color = RELATION_COLORS[e.relationType] ?? '#94a3b8';
+            return {
+                id: `edge-${i}-${e.sourceId}-${e.targetId}`,
+                source: e.sourceId,
+                target: e.targetId,
+                type: 'smoothstep',
+                label: RELATION_LABELS_NL[e.relationType] ?? e.relationType,
+                labelStyle: { fill: color, fontWeight: 500, fontSize: 11 },
+                labelBgStyle: { fill: 'hsl(var(--background))', fillOpacity: 0.85 },
+                style: { stroke: color, strokeWidth: 2 },
+                markerEnd: {
+                    type: MarkerType.ArrowClosed,
+                    color,
+                },
+                data: { relationType: e.relationType },
+            };
+        });
+    }, [data]);
+
+    const [nodes, , onNodesChange] = useNodesState(rfNodes);
+    const [edges, , onEdgesChange] = useEdgesState(rfEdges);
+
+    const handleNodeClick: NodeMouseHandler = useCallback(
+        (_event, node) => {
+            const tessera = (node.data as { tessera: TesseraNode }).tessera;
+            setSelectedTessera(tessera);
+            setSheetOpen(true);
+        },
+        [],
+    );
+
+    if (isLoading) {
+        return (
+            <div className="flex items-center justify-center h-64 gap-2 text-muted-foreground">
+                <Loader2 className="h-5 w-5 animate-spin" />
+                <span className="text-sm">Argumentatienetwerk laden...</span>
+            </div>
+        );
+    }
+
+    if (isError) {
+        return (
+            <Alert variant="destructive" className="m-6">
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription>
+                    Het argumentatienetwerk kon niet worden geladen. Controleer de verbinding en probeer het opnieuw.
+                </AlertDescription>
+            </Alert>
+        );
+    }
+
+    if (!data || data.nodes.length === 0) {
+        return (
+            <div className="flex items-center justify-center h-64 text-muted-foreground text-sm">
+                Nog geen tesserae of argumentatierelaties gevonden in deze DesignSpace.
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex flex-col h-full gap-0">
+            {/* Legenda */}
+            <div className="flex items-center gap-4 px-4 py-2 border-b bg-background flex-wrap">
+                <span className="text-xs font-medium text-muted-foreground">Relatietype:</span>
+                {(Object.entries(RELATION_LABELS_NL) as [ArgueRelationType, string][]).map(([type, label]) => (
+                    <div key={type} className="flex items-center gap-1.5">
+                        <span
+                            className="inline-block w-3 h-0.5 rounded-full"
+                            style={{ backgroundColor: RELATION_COLORS[type], height: 3 }}
+                        />
+                        <Badge
+                            variant="outline"
+                            className="text-xs px-1.5 py-0"
+                            style={{ borderColor: RELATION_COLORS[type], color: RELATION_COLORS[type] }}
+                        >
+                            {label}
+                        </Badge>
+                    </div>
+                ))}
+            </div>
+
+            {/* React Flow canvas */}
+            <div className="flex-1 relative">
+                <ReactFlow
+                    nodes={nodes}
+                    edges={edges}
+                    onNodesChange={onNodesChange}
+                    onEdgesChange={onEdgesChange}
+                    onNodeClick={handleNodeClick}
+                    fitView
+                    fitViewOptions={{ padding: 0.2 }}
+                    minZoom={0.2}
+                    maxZoom={2}
+                    attributionPosition="bottom-right"
+                >
+                    <Background gap={16} size={1} />
+                    <Controls showInteractive={false} />
+                    <MiniMap
+                        nodeColor={(n) => {
+                            const tessera = (n.data as { tessera?: TesseraNode }).tessera;
+                            return tessera ? (STATUS_COLORS[tessera.epistemicStatus] ?? '#71717a') : '#71717a';
+                        }}
+                        maskColor="hsl(var(--background) / 0.6)"
+                    />
+                </ReactFlow>
+            </div>
+
+            <TesseraDetailPanel
+                tessera={selectedTessera}
+                open={sheetOpen}
+                onClose={() => setSheetOpen(false)}
+            />
+        </div>
+    );
+};

--- a/frontend/src/components/deliberation/ArgumentationDiagram.tsx
+++ b/frontend/src/components/deliberation/ArgumentationDiagram.tsx
@@ -62,16 +62,35 @@ export const ArgumentationDiagram: React.FC<ArgumentationDiagramProps> = ({ dsId
     const { dsId: dsParam } = useParams<{ dsId: string }>();
     const dsId = dsProp ?? dsParam ?? '';
 
-    const { data: argueTypes = [] } = useQuery({
+    const { data: argueTypes = [], isSuccess: argueTypesLoaded } = useQuery({
         queryKey: ['argue-types'],
         queryFn: () => api.getArgueTypes(),
     });
 
-    const { data, isLoading, isError } = useQuery({
+    const { data: allTesserae = [], isLoading: tesseraeLoading } = useQuery({
+        queryKey: ['design-space-tesserae', dsId],
+        queryFn: () => api.getDesignSpaceTesserae(dsId),
+        enabled: !!dsId,
+    });
+
+    const { data: networkData, isLoading: networkLoading, isError } = useQuery({
         queryKey: ['argumentation-network', dsId, argueTypes.length],
         queryFn: () => api.getArgumentationNetwork(dsId, argueTypes),
-        enabled: !!dsId && argueTypes.length > 0,
+        enabled: !!dsId && argueTypesLoaded && argueTypes.length > 0,
     });
+
+    const isLoading = tesseraeLoading || networkLoading;
+
+    // Combineer: alle tesserae als nodes, argue-relaties als edges
+    const data = React.useMemo(() => {
+        if (allTesserae.length === 0) return null;
+        const connectedIds = new Set(networkData?.nodes.map(n => n.id) ?? []);
+        const extraNodes = allTesserae.filter(t => !connectedIds.has(t.id));
+        return {
+            nodes: [...(networkData?.nodes ?? []), ...extraNodes],
+            edges: networkData?.edges ?? [],
+        };
+    }, [allTesserae, networkData]);
 
     const [selectedTessera, setSelectedTessera] = useState<TesseraNode | null>(null);
     const [sheetOpen, setSheetOpen] = useState(false);
@@ -166,7 +185,7 @@ export const ArgumentationDiagram: React.FC<ArgumentationDiagramProps> = ({ dsId
     if (!data || data.nodes.length === 0) {
         return (
             <div className="flex items-center justify-center h-64 text-muted-foreground text-sm">
-                Nog geen tesserae of argumentatierelaties gevonden in deze DesignSpace.
+                Nog geen tesserae gevonden in deze DesignSpace.
             </div>
         );
     }

--- a/frontend/src/components/deliberation/ArgumentationDiagram.tsx
+++ b/frontend/src/components/deliberation/ArgumentationDiagram.tsx
@@ -19,12 +19,13 @@ import { Badge } from '@/components/ui/badge';
 import { api, type TesseraNode } from '@/services/api';
 import { TesseraDetailPanel } from '@/components/deliberation/TesseraDetailPanel';
 
-// Kleurcodering per relatietype (op basis van EN label / URI-fragment)
+// Kleurcodering per polarity (CAUSA: valor:polarity op CausalClaim-Tessera)
+// Conform VALOR-O 00h-causa.trig: ReinforcingPolarity (+) = supports, BalancingPolarity (-) = undermines
 const RELATION_COLORS: Record<string, string> = {
-    supports: '#22c55e',    // groen
-    undermines: '#ef4444',  // rood
-    qualifies: '#f59e0b',   // amber
-    presupposes: '#8b5cf6', // paars
+    supports: '#22c55e',    // groen  — versterkende causaliteit (+)
+    undermines: '#ef4444',  // rood   — dempende causaliteit (-)
+    qualifies: '#f59e0b',   // amber  — nuancerende argue-relatie (IBIS overlay)
+    presupposes: '#8b5cf6', // paars  — veronderstelde argue-relatie (IBIS overlay)
 };
 
 const STATUS_COLORS: Record<string, string> = {
@@ -62,24 +63,26 @@ export const ArgumentationDiagram: React.FC<ArgumentationDiagramProps> = ({ dsId
     const { dsId: dsParam } = useParams<{ dsId: string }>();
     const dsId = dsProp ?? dsParam ?? '';
 
-    const { data: argueTypes = [], isSuccess: argueTypesLoaded } = useQuery({
-        queryKey: ['argue-types'],
-        queryFn: () => api.getArgueTypes(),
-    });
-
+    // Factor-tesserae als fallback-nodes (inclusief factors zonder claims)
     const { data: allTesserae = [], isLoading: tesseraeLoading } = useQuery({
         queryKey: ['design-space-tesserae', dsId],
         queryFn: () => api.getDesignSpaceTesserae(dsId),
         enabled: !!dsId,
     });
 
+    // CausalClaim-tesserae als edges tussen Factor-nodes (CAUSA-structuur)
     const { data: networkData, isLoading: networkLoading, isError } = useQuery({
-        queryKey: ['argumentation-network', dsId, argueTypes.length],
-        queryFn: () => api.getArgumentationNetwork(dsId, argueTypes),
-        enabled: !!dsId && argueTypesLoaded && argueTypes.length > 0,
+        queryKey: ['argumentation-network', dsId],
+        queryFn: () => api.getArgumentationNetwork(dsId),
+        enabled: !!dsId,
     });
 
     const isLoading = tesseraeLoading || networkLoading;
+
+    const POLARITY_LEGEND = [
+        { key: 'supports', label: 'Versterkt (+)', color: RELATION_COLORS.supports },
+        { key: 'undermines', label: 'Dempt (-)', color: RELATION_COLORS.undermines },
+    ];
 
     // Combineer: alle tesserae als nodes, argue-relaties als edges
     const data = React.useMemo(() => {
@@ -194,26 +197,22 @@ export const ArgumentationDiagram: React.FC<ArgumentationDiagramProps> = ({ dsId
         <div className="flex flex-col h-full gap-0">
             {/* Legenda */}
             <div className="flex items-center gap-4 px-4 py-2 border-b bg-background flex-wrap">
-                <span className="text-xs font-medium text-muted-foreground">Relatietype:</span>
-                {argueTypes.map((t) => {
-                    const typeKey = t.uri.split('/').pop() ?? t.uri;
-                    const color = RELATION_COLORS[typeKey] ?? '#94a3b8';
-                    return (
-                        <div key={t.uri} className="flex items-center gap-1.5">
-                            <span
-                                className="inline-block w-3 rounded-full"
-                                style={{ backgroundColor: color, height: 3 }}
-                            />
-                            <Badge
-                                variant="outline"
-                                className="text-xs px-1.5 py-0"
-                                style={{ borderColor: color, color }}
-                            >
-                                {t.label_nl}
-                            </Badge>
-                        </div>
-                    );
-                })}
+                <span className="text-xs font-medium text-muted-foreground">Polariteit:</span>
+                {POLARITY_LEGEND.map(({ key, label, color }) => (
+                    <div key={key} className="flex items-center gap-1.5">
+                        <span
+                            className="inline-block w-3 rounded-full"
+                            style={{ backgroundColor: color, height: 3 }}
+                        />
+                        <Badge
+                            variant="outline"
+                            className="text-xs px-1.5 py-0"
+                            style={{ borderColor: color, color }}
+                        >
+                            {label}
+                        </Badge>
+                    </div>
+                ))}
             </div>
 
             {/* React Flow canvas */}

--- a/frontend/src/components/deliberation/ArgumentationDiagram.tsx
+++ b/frontend/src/components/deliberation/ArgumentationDiagram.tsx
@@ -16,22 +16,15 @@ import 'reactflow/dist/style.css';
 import { AlertCircle, Loader2 } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
-import { api, type TesseraNode, type ArgueRelationType } from '@/services/api';
+import { api, type TesseraNode } from '@/services/api';
 import { TesseraDetailPanel } from '@/components/deliberation/TesseraDetailPanel';
 
-// Kleurcodering per relatietype
-const RELATION_COLORS: Record<ArgueRelationType | string, string> = {
+// Kleurcodering per relatietype (op basis van EN label / URI-fragment)
+const RELATION_COLORS: Record<string, string> = {
     supports: '#22c55e',    // groen
     undermines: '#ef4444',  // rood
     qualifies: '#f59e0b',   // amber
     presupposes: '#8b5cf6', // paars
-};
-
-const RELATION_LABELS_NL: Record<ArgueRelationType | string, string> = {
-    supports: 'Ondersteunt',
-    undermines: 'Ondermijnt',
-    qualifies: 'Nuanceert',
-    presupposes: 'Veronderstelt',
 };
 
 const STATUS_COLORS: Record<string, string> = {
@@ -69,10 +62,15 @@ export const ArgumentationDiagram: React.FC<ArgumentationDiagramProps> = ({ dsId
     const { dsId: dsParam } = useParams<{ dsId: string }>();
     const dsId = dsProp ?? dsParam ?? '';
 
+    const { data: argueTypes = [] } = useQuery({
+        queryKey: ['argue-types'],
+        queryFn: () => api.getArgueTypes(),
+    });
+
     const { data, isLoading, isError } = useQuery({
-        queryKey: ['argumentation-network', dsId],
-        queryFn: () => api.getArgumentationNetwork(dsId),
-        enabled: !!dsId,
+        queryKey: ['argumentation-network', dsId, argueTypes.length],
+        queryFn: () => api.getArgumentationNetwork(dsId, argueTypes),
+        enabled: !!dsId && argueTypes.length > 0,
     });
 
     const [selectedTessera, setSelectedTessera] = useState<TesseraNode | null>(null);
@@ -120,7 +118,7 @@ export const ArgumentationDiagram: React.FC<ArgumentationDiagramProps> = ({ dsId
                 source: e.sourceId,
                 target: e.targetId,
                 type: 'smoothstep',
-                label: RELATION_LABELS_NL[e.relationType] ?? e.relationType,
+                label: e.relationLabel,
                 labelStyle: { fill: color, fontWeight: 500, fontSize: 11 },
                 labelBgStyle: { fill: 'hsl(var(--background))', fillOpacity: 0.85 },
                 style: { stroke: color, strokeWidth: 2 },
@@ -178,21 +176,25 @@ export const ArgumentationDiagram: React.FC<ArgumentationDiagramProps> = ({ dsId
             {/* Legenda */}
             <div className="flex items-center gap-4 px-4 py-2 border-b bg-background flex-wrap">
                 <span className="text-xs font-medium text-muted-foreground">Relatietype:</span>
-                {(Object.entries(RELATION_LABELS_NL) as [ArgueRelationType, string][]).map(([type, label]) => (
-                    <div key={type} className="flex items-center gap-1.5">
-                        <span
-                            className="inline-block w-3 h-0.5 rounded-full"
-                            style={{ backgroundColor: RELATION_COLORS[type], height: 3 }}
-                        />
-                        <Badge
-                            variant="outline"
-                            className="text-xs px-1.5 py-0"
-                            style={{ borderColor: RELATION_COLORS[type], color: RELATION_COLORS[type] }}
-                        >
-                            {label}
-                        </Badge>
-                    </div>
-                ))}
+                {argueTypes.map((t) => {
+                    const typeKey = t.uri.split('/').pop() ?? t.uri;
+                    const color = RELATION_COLORS[typeKey] ?? '#94a3b8';
+                    return (
+                        <div key={t.uri} className="flex items-center gap-1.5">
+                            <span
+                                className="inline-block w-3 rounded-full"
+                                style={{ backgroundColor: color, height: 3 }}
+                            />
+                            <Badge
+                                variant="outline"
+                                className="text-xs px-1.5 py-0"
+                                style={{ borderColor: color, color }}
+                            >
+                                {t.label_nl}
+                            </Badge>
+                        </div>
+                    );
+                })}
             </div>
 
             {/* React Flow canvas */}

--- a/frontend/src/components/deliberation/ConsentBoard.tsx
+++ b/frontend/src/components/deliberation/ConsentBoard.tsx
@@ -32,7 +32,7 @@ export const ConsentBoard: React.FC<ConsentBoardProps> = ({ sessionId, onClose }
         mutationFn: async ({ claimId, type, motivation }: { claimId: string; type: 'approve' | 'object'; motivation?: string }) => {
             await sessionService.submitConsentVote(sessionId, {
                 session_id: sessionId,
-                claim_version_id: claimId,
+                tessera_base_id: claimId,
                 vote: type,
                 motivation
             });

--- a/frontend/src/components/deliberation/DecisionTimeline.tsx
+++ b/frontend/src/components/deliberation/DecisionTimeline.tsx
@@ -1,0 +1,191 @@
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useParams } from 'react-router-dom';
+import { AlertCircle, Loader2, Clock, User, Tag } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { api, type DecisionEpisodeRaw } from '@/services/api';
+
+const FASE_LABELS: Record<string, string> = {
+    refine: 'Verfijnen',
+    Refine: 'Verfijnen',
+    ranking: 'Prioritering',
+    Ranking: 'Prioritering',
+    consent: 'Instemming',
+    Consent: 'Instemming',
+};
+
+const VOTE_TYPE_LABELS: Record<string, string> = {
+    Accept: 'Akkoord',
+    accept: 'Akkoord',
+    Reject: 'Afwijzen',
+    reject: 'Afwijzen',
+    Defer: 'Uitstellen',
+    defer: 'Uitstellen',
+};
+
+const VOTE_TYPE_VARIANT: Record<string, 'default' | 'destructive' | 'outline' | 'secondary'> = {
+    Accept: 'default',
+    accept: 'default',
+    Reject: 'destructive',
+    reject: 'destructive',
+    Defer: 'secondary',
+    defer: 'secondary',
+};
+
+const TYPE_LABELS: Record<string, string> = {
+    DecisionEpisode: 'Beslissing',
+    PhaseTransition: 'Faseovergang',
+};
+
+function formatDateTime(iso: string): string {
+    try {
+        return new Intl.DateTimeFormat('nl-NL', {
+            dateStyle: 'medium',
+            timeStyle: 'short',
+        }).format(new Date(iso));
+    } catch {
+        return iso;
+    }
+}
+
+function formatUri(uri: string): string {
+    const fragment = uri.split('/').pop()?.split('#').pop() ?? uri;
+    // Verwijder UUID-achtige suffixen en toon alleen leesbaar deel
+    if (fragment.length > 36 && fragment.includes('-')) {
+        return fragment.substring(0, 8) + '…';
+    }
+    return fragment;
+}
+
+interface EpisodeCardProps {
+    episode: DecisionEpisodeRaw;
+}
+
+const EpisodeCard: React.FC<EpisodeCardProps> = ({ episode }) => {
+    const typeLabel = TYPE_LABELS[episode.type] ?? episode.type;
+    const faseLabel = episode.phase ? (FASE_LABELS[episode.phase] ?? episode.phase) : null;
+
+    return (
+        <div className="flex gap-4">
+            {/* Tijdlijn indicator */}
+            <div className="flex flex-col items-center">
+                <div className="w-3 h-3 rounded-full bg-primary mt-1 shrink-0" />
+                <div className="w-px flex-1 bg-border mt-1" />
+            </div>
+
+            {/* Kaartinhoud */}
+            <div className="pb-6 flex-1 min-w-0">
+                <div className="rounded-lg border bg-card p-4 shadow-sm">
+                    {/* Header */}
+                    <div className="flex flex-wrap items-center gap-2 mb-2">
+                        <Badge variant="outline" className="text-xs">
+                            {typeLabel}
+                        </Badge>
+                        {faseLabel && (
+                            <Badge variant="secondary" className="text-xs">
+                                <Tag className="h-3 w-3 mr-1" />
+                                {faseLabel}
+                            </Badge>
+                        )}
+                    </div>
+
+                    {/* Metadata */}
+                    <div className="flex flex-wrap gap-4 text-xs text-muted-foreground mt-2">
+                        {episode.startedAt && (
+                            <span className="flex items-center gap-1">
+                                <Clock className="h-3 w-3" />
+                                {formatDateTime(episode.startedAt)}
+                            </span>
+                        )}
+                        {episode.startedBy && (
+                            <span className="flex items-center gap-1">
+                                <User className="h-3 w-3" />
+                                {formatUri(episode.startedBy)}
+                            </span>
+                        )}
+                    </div>
+
+                    {/* Stemmen */}
+                    {episode.votes.length > 0 && (
+                        <div className="mt-3 pt-3 border-t">
+                            <p className="text-xs font-medium text-muted-foreground mb-2">
+                                Stemmen ({episode.votes.length})
+                            </p>
+                            <div className="flex flex-wrap gap-2">
+                                {episode.votes.map((vote) => {
+                                    const label = VOTE_TYPE_LABELS[vote.voteType] ?? vote.voteType;
+                                    const variant = VOTE_TYPE_VARIANT[vote.voteType] ?? 'outline';
+                                    return (
+                                        <div key={vote.voteUri} className="flex items-center gap-1.5">
+                                            <Badge variant={variant} className="text-xs">
+                                                {label}
+                                            </Badge>
+                                            <span className="text-xs text-muted-foreground">
+                                                {formatUri(vote.castBy)}
+                                            </span>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+interface DecisionTimelineProps {
+    dsId?: string;
+}
+
+export const DecisionTimeline: React.FC<DecisionTimelineProps> = ({ dsId: dsProp }) => {
+    const { dsId: dsParam } = useParams<{ dsId: string }>();
+    const dsId = dsProp ?? dsParam ?? '';
+
+    const { data, isLoading, isError } = useQuery({
+        queryKey: ['decision-timeline', dsId],
+        queryFn: () => api.getDecisionTimeline(dsId),
+        enabled: !!dsId,
+    });
+
+    if (isLoading) {
+        return (
+            <div className="flex items-center justify-center h-64 gap-2 text-muted-foreground">
+                <Loader2 className="h-5 w-5 animate-spin" />
+                <span className="text-sm">Beslissingen laden...</span>
+            </div>
+        );
+    }
+
+    if (isError) {
+        return (
+            <Alert variant="destructive" className="m-6">
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription>
+                    De beslissingstijdlijn kon niet worden geladen. Controleer de verbinding en probeer het opnieuw.
+                </AlertDescription>
+            </Alert>
+        );
+    }
+
+    if (!data || data.length === 0) {
+        return (
+            <div className="flex items-center justify-center h-64 text-muted-foreground text-sm">
+                Nog geen beslissingen vastgelegd.
+            </div>
+        );
+    }
+
+    return (
+        <div className="max-w-2xl mx-auto px-6 py-8">
+            <h1 className="text-xl font-semibold mb-6">Beslissingstijdlijn</h1>
+            <div className="flex flex-col">
+                {data.map((episode) => (
+                    <EpisodeCard key={episode.episodeUri} episode={episode} />
+                ))}
+            </div>
+        </div>
+    );
+};

--- a/frontend/src/components/deliberation/ModeratorDashboard.tsx
+++ b/frontend/src/components/deliberation/ModeratorDashboard.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { Button } from '@/components/ui/button';
-import { useContext } from 'react';
 import { DesignSpaceContext } from '@/context/DesignSpaceContext';
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/services/api';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { X, Shield } from 'lucide-react';
 import { useSessionParticipation, useUpdateSessionStage, useFinalizeDeliberation, useSessionValidation } from '@/hooks/queries/useSessions';
@@ -29,6 +30,13 @@ export const ModeratorDashboard: React.FC<ModeratorDashboardProps> = ({
 }) => {
     const designSpace = useContext(DesignSpaceContext);
     const refreshVersions = designSpace?.refreshVersions ?? (() => Promise.resolve());
+    const dsId = designSpace?.dsId ?? null;
+
+    const { data: members = [] } = useQuery({
+        queryKey: ['ds-members', dsId],
+        queryFn: () => api.getDesignSpaceMembers(dsId!),
+        enabled: !!dsId,
+    });
 
     // Stage Mapping for Tabs
     const [activeTab, setActiveTab] = useState<string>('start');
@@ -113,7 +121,7 @@ export const ModeratorDashboard: React.FC<ModeratorDashboardProps> = ({
                             <PhaseStart
                                 onStart={(config: VotingSessionConfig) => onStartSession?.(config)}
                                 isStarting={isStartingSession}
-                                participantCount={0} // TODO: Pass potential participants count?
+                                members={members}
                             />
                         ) : (
                             <div className="p-8 text-center border rounded-lg bg-muted/10">

--- a/frontend/src/components/deliberation/ModeratorDashboard.tsx
+++ b/frontend/src/components/deliberation/ModeratorDashboard.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
-import { useDesignSpace } from '@/context/DesignSpaceContext';
+import { useContext } from 'react';
+import { DesignSpaceContext } from '@/context/DesignSpaceContext';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { X, Shield } from 'lucide-react';
 import { useSessionParticipation, useUpdateSessionStage, useFinalizeDeliberation, useSessionValidation } from '@/hooks/queries/useSessions';
@@ -26,7 +27,8 @@ export const ModeratorDashboard: React.FC<ModeratorDashboardProps> = ({
     onStartSession,
     isStartingSession = false
 }) => {
-    const { refreshVersions } = useDesignSpace();
+    const designSpace = useContext(DesignSpaceContext);
+    const refreshVersions = designSpace?.refreshVersions ?? (() => Promise.resolve());
 
     // Stage Mapping for Tabs
     const [activeTab, setActiveTab] = useState<string>('start');

--- a/frontend/src/components/deliberation/ParticipantDashboard.tsx
+++ b/frontend/src/components/deliberation/ParticipantDashboard.tsx
@@ -69,6 +69,7 @@ export const ParticipantDashboard: React.FC<ParticipantDashboardProps> = ({
                 return (
                     <VotingRanking
                         sessionId={sessionId}
+                        dsId={versionId}
                         onComplete={() => handlePhaseComplete('ranking')}
                     />
                 );

--- a/frontend/src/components/deliberation/ParticipantDashboard.tsx
+++ b/frontend/src/components/deliberation/ParticipantDashboard.tsx
@@ -77,6 +77,7 @@ export const ParticipantDashboard: React.FC<ParticipantDashboardProps> = ({
                 return (
                     <VotingConsent
                         sessionId={sessionId}
+                        dsId={versionId}
                         onComplete={() => handlePhaseComplete('consent')}
                     />
                 );

--- a/frontend/src/components/deliberation/PhaseSelector.tsx
+++ b/frontend/src/components/deliberation/PhaseSelector.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { History } from 'lucide-react';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Badge } from '@/components/ui/badge';
+import { type PhaseSnapshot } from '@/services/api';
+
+interface PhaseSelectorProps {
+    snapshots: PhaseSnapshot[];
+    activePhaseId: string | null;
+    onSelect: (phaseId: string | null) => void;
+}
+
+export const PhaseSelector: React.FC<PhaseSelectorProps> = ({ snapshots, activePhaseId, onSelect }) => {
+    if (snapshots.length === 0) return null;
+
+    return (
+        <div className="flex items-center gap-2">
+            <History className="h-4 w-4 text-muted-foreground shrink-0" />
+            <Select
+                value={activePhaseId ?? 'current'}
+                onValueChange={(v) => onSelect(v === 'current' ? null : v)}
+            >
+                <SelectTrigger className="w-52 h-8 text-sm">
+                    <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                    <SelectItem value="current">
+                        <span className="font-medium">Huidige fase</span>
+                    </SelectItem>
+                    {snapshots.map((s, i) => (
+                        <SelectItem key={s.session_id} value={s.session_id}>
+                            <div className="flex items-center gap-1.5">
+                                <span>Fase {i + 1}</span>
+                                <span className="text-xs text-muted-foreground">
+                                    {new Date(s.created_at).toLocaleDateString('nl-NL')}
+                                </span>
+                                <Badge variant="secondary" className="text-xs px-1 py-0">
+                                    {s.accepted_count}✓
+                                </Badge>
+                                <Badge variant="destructive" className="text-xs px-1 py-0">
+                                    {s.rejected_count}✗
+                                </Badge>
+                            </div>
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+            {activePhaseId && (
+                <Badge variant="outline" className="text-xs text-amber-600 border-amber-400 shrink-0">
+                    Alleen-lezen
+                </Badge>
+            )}
+        </div>
+    );
+};

--- a/frontend/src/components/deliberation/RankingBoard.tsx
+++ b/frontend/src/components/deliberation/RankingBoard.tsx
@@ -56,8 +56,8 @@ export const RankingBoard: React.FC<RankingBoardProps> = ({ sessionId, onClose, 
             const rankedIds = new Set();
             existingRankings.forEach((r: any) => {
                 if (initialItems[r.category as Category]) {
-                    initialItems[r.category as Category].push(r.claim_version_id);
-                    rankedIds.add(r.claim_version_id);
+                    initialItems[r.category as Category].push(r.tessera_base_id);
+                    rankedIds.add(r.tessera_base_id);
                 }
             });
 

--- a/frontend/src/components/deliberation/RefinementBoard.tsx
+++ b/frontend/src/components/deliberation/RefinementBoard.tsx
@@ -102,7 +102,7 @@ export const RefinementBoardComponent: React.FC<RefinementBoardProps> = ({
     const myFeedback = useMemo(() => {
         if (!currentUserId || currentUserId === 'anon') return null;
         return feedbackData.find(f =>
-            f.claim_version_id === selectedClaim?.version_id &&
+            f.tessera_base_id === selectedClaim?.version_id &&
             f.user_id === currentUserId
         ) || null;
     }, [feedbackData, selectedClaim?.version_id, currentUserId]);

--- a/frontend/src/components/deliberation/RefinementBoard.tsx
+++ b/frontend/src/components/deliberation/RefinementBoard.tsx
@@ -28,7 +28,7 @@ export const RefinementBoardComponent: React.FC<RefinementBoardProps> = ({
     currentUserId,
     isModerator
 }) => {
-    const { versionId: routeVersionId } = useParams<{ versionId: string }>();
+    const { versionId: routeVersionId, dsId } = useParams<{ versionId: string; dsId: string }>();
     const versionId = propVersionId || routeVersionId;
     const navigate = useNavigate();
     const queryClient = useQueryClient();
@@ -187,6 +187,7 @@ export const RefinementBoardComponent: React.FC<RefinementBoardProps> = ({
                     claim={selectedClaim}
                     allClaims={claims}
                     factors={factors}
+                    designSpaceId={dsId}
                 />
             </main>
 

--- a/frontend/src/components/deliberation/RefinementDetail.tsx
+++ b/frontend/src/components/deliberation/RefinementDetail.tsx
@@ -12,10 +12,11 @@ interface RefinementDetailProps {
     claim: Claim | null;
     allClaims: Claim[];
     factors?: Factor[];
+    designSpaceId?: string;
 }
 
-export const RefinementDetail: React.FC<RefinementDetailProps> = ({ claim, allClaims, factors = [] }) => {
-    const [activeThread, setActiveThread] = React.useState<{ targetId: string; label: string; designSpaceId?: string } | null>(null);
+export const RefinementDetail: React.FC<RefinementDetailProps> = ({ claim, allClaims, factors = [], designSpaceId }) => {
+    const [activeThread, setActiveThread] = React.useState<{ targetId: string; label: string } | null>(null);
 
     const factorMap = React.useMemo(() => {
         const map = new Map<string, string>();
@@ -36,6 +37,7 @@ export const RefinementDetail: React.FC<RefinementDetailProps> = ({ claim, allCl
     }
 
     const openThread = (targetId: string, label: string) => {
+        if (!designSpaceId) return;
         setActiveThread({ targetId, label });
     };
 
@@ -157,10 +159,10 @@ export const RefinementDetail: React.FC<RefinementDetailProps> = ({ claim, allCl
                 </Tabs>
             </div>
 
-            {activeThread && activeThread.designSpaceId && (
+            {activeThread && designSpaceId && (
                 <FloatingThreadPanel
                     tesseraId={activeThread.targetId}
-                    designSpaceId={activeThread.designSpaceId}
+                    designSpaceId={designSpaceId}
                     targetLabel={activeThread.label}
                     onClose={() => setActiveThread(null)}
                     readOnly={true}

--- a/frontend/src/components/deliberation/RefinementSidebar.tsx
+++ b/frontend/src/components/deliberation/RefinementSidebar.tsx
@@ -28,7 +28,7 @@ export const RefinementSidebar: React.FC<RefinementSidebarProps> = ({
     const getClaimStatus = (claimVersionId: string) => {
         if (!currentUserId || currentUserId === 'anon') return 'pending';
         const feedback = feedbackData.find(f =>
-            f.claim_version_id === claimVersionId &&
+            f.tessera_base_id === claimVersionId &&
             f.user_id === currentUserId
         );
         return feedback ? (feedback.color as 'green' | 'amber' | 'red') : 'pending';
@@ -37,7 +37,7 @@ export const RefinementSidebar: React.FC<RefinementSidebarProps> = ({
     const getFullFeedback = (claimVersionId: string) => {
         if (!currentUserId || currentUserId === 'anon') return null;
         return feedbackData.find(f =>
-            f.claim_version_id === claimVersionId &&
+            f.tessera_base_id === claimVersionId &&
             f.user_id === currentUserId
         ) || null;
     };

--- a/frontend/src/components/deliberation/TesseraDetailPanel.tsx
+++ b/frontend/src/components/deliberation/TesseraDetailPanel.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet';
+import { Badge } from '@/components/ui/badge';
+import { Separator } from '@/components/ui/separator';
+import { type TesseraNode } from '@/services/api';
+
+interface TesseraDetailPanelProps {
+    tessera: TesseraNode | null;
+    open: boolean;
+    onClose: () => void;
+}
+
+const STATUS_LABELS: Record<string, string> = {
+    Proposed: 'Voorgesteld',
+    Contested: 'Betwist',
+    Accepted: 'Geaccepteerd',
+    Rejected: 'Afgewezen',
+    Deprecated: 'Verouderd',
+};
+
+const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+    Proposed: 'secondary',
+    Contested: 'outline',
+    Accepted: 'default',
+    Rejected: 'destructive',
+    Deprecated: 'outline',
+};
+
+const TYPE_LABELS: Record<string, string> = {
+    AsIs: 'Huidige situatie',
+    AsIsType: 'Huidige situatie',
+    ToBe: 'Gewenste situatie',
+    ToBeType: 'Gewenste situatie',
+};
+
+export const TesseraDetailPanel: React.FC<TesseraDetailPanelProps> = ({ tessera, open, onClose }) => {
+    const statusKey = tessera?.epistemicStatus ?? '';
+    const statusLabel = STATUS_LABELS[statusKey] ?? statusKey;
+    const statusVariant = STATUS_VARIANT[statusKey] ?? 'secondary';
+    const typeLabel = tessera ? (TYPE_LABELS[tessera.claimType] ?? tessera.claimType) : '';
+
+    return (
+        <Sheet open={open} onOpenChange={(isOpen) => { if (!isOpen) onClose(); }}>
+            <SheetContent side="right" className="w-full sm:max-w-md flex flex-col gap-0 p-0">
+                <SheetHeader className="px-6 pt-6 pb-4">
+                    <SheetTitle className="text-base">Tessera detail</SheetTitle>
+                    <SheetDescription className="sr-only">
+                        Informatie over de geselecteerde tessera
+                    </SheetDescription>
+                </SheetHeader>
+                <Separator />
+                {tessera ? (
+                    <div className="flex flex-col gap-5 px-6 py-5 flex-1 overflow-y-auto">
+                        <div className="flex items-center gap-2 flex-wrap">
+                            <Badge variant={statusVariant}>{statusLabel}</Badge>
+                            <Badge variant="outline" className="text-muted-foreground">
+                                {typeLabel}
+                            </Badge>
+                        </div>
+
+                        <div className="flex flex-col gap-1">
+                            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                                Claim
+                            </span>
+                            <p className="text-sm text-foreground leading-relaxed">
+                                {tessera.claimContent}
+                            </p>
+                        </div>
+
+                        <Separator />
+
+                        <div className="flex flex-col gap-1">
+                            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                                Tessera ID
+                            </span>
+                            <code className="text-xs text-muted-foreground font-mono break-all">
+                                {tessera.id}
+                            </code>
+                        </div>
+                    </div>
+                ) : (
+                    <div className="flex items-center justify-center flex-1 text-muted-foreground text-sm px-6">
+                        Geen tessera geselecteerd.
+                    </div>
+                )}
+            </SheetContent>
+        </Sheet>
+    );
+};

--- a/frontend/src/components/deliberation/dashboard/PhaseConsent.tsx
+++ b/frontend/src/components/deliberation/dashboard/PhaseConsent.tsx
@@ -67,10 +67,10 @@ export const PhaseConsent: React.FC<PhaseConsentProps> = ({
                                     <div key={p.user_id} className="flex items-center justify-between p-2 rounded-md bg-muted/30">
                                         <div className="flex items-center gap-2">
                                             <div className="w-6 h-6 rounded-full bg-primary/10 flex items-center justify-center text-[10px] font-bold text-primary">
-                                                {p.user_name?.[0]?.toUpperCase() || '?'}
+                                                {p.user_name ?? p.name?.[0]?.toUpperCase() || '?'}
                                             </div>
                                             <div className="text-sm truncate max-w-[150px]">
-                                                {p.user_name || 'Onbekend'}
+                                                {p.user_name ?? p.name || 'Onbekend'}
                                             </div>
                                         </div>
                                         {(p.has_completed_consent || p.has_consent) ? (

--- a/frontend/src/components/deliberation/dashboard/PhaseConsent.tsx
+++ b/frontend/src/components/deliberation/dashboard/PhaseConsent.tsx
@@ -67,10 +67,10 @@ export const PhaseConsent: React.FC<PhaseConsentProps> = ({
                                     <div key={p.user_id} className="flex items-center justify-between p-2 rounded-md bg-muted/30">
                                         <div className="flex items-center gap-2">
                                             <div className="w-6 h-6 rounded-full bg-primary/10 flex items-center justify-center text-[10px] font-bold text-primary">
-                                                {p.user_name ?? p.name?.[0]?.toUpperCase() || '?'}
+                                                {(p.user_name ?? p.name)?.[0]?.toUpperCase() || '?'}
                                             </div>
                                             <div className="text-sm truncate max-w-[150px]">
-                                                {p.user_name ?? p.name || 'Onbekend'}
+                                                {(p.user_name ?? p.name) || 'Onbekend'}
                                             </div>
                                         </div>
                                         {(p.has_completed_consent || p.has_consent) ? (

--- a/frontend/src/components/deliberation/dashboard/PhaseRanking.tsx
+++ b/frontend/src/components/deliberation/dashboard/PhaseRanking.tsx
@@ -63,10 +63,10 @@ export const PhaseRanking = ({ participants, onAdvance, canAdvance, isAdvancing,
                                     <div key={p.user_id} className="flex items-center justify-between p-2 rounded-md bg-muted/30">
                                         <div className="flex items-center gap-2">
                                             <div className="w-6 h-6 rounded-full bg-primary/10 flex items-center justify-center text-[10px] font-bold text-primary">
-                                                {p.user_name?.[0]?.toUpperCase() || '?'}
+                                                {p.user_name ?? p.name?.[0]?.toUpperCase() || '?'}
                                             </div>
                                             <div className="text-sm truncate max-w-[150px]">
-                                                {p.user_name || 'Onbekend'}
+                                                {p.user_name ?? p.name || 'Onbekend'}
                                             </div>
                                         </div>
                                         {(p.has_completed_ranking || p.has_ranking) ? (

--- a/frontend/src/components/deliberation/dashboard/PhaseRanking.tsx
+++ b/frontend/src/components/deliberation/dashboard/PhaseRanking.tsx
@@ -63,10 +63,10 @@ export const PhaseRanking = ({ participants, onAdvance, canAdvance, isAdvancing,
                                     <div key={p.user_id} className="flex items-center justify-between p-2 rounded-md bg-muted/30">
                                         <div className="flex items-center gap-2">
                                             <div className="w-6 h-6 rounded-full bg-primary/10 flex items-center justify-center text-[10px] font-bold text-primary">
-                                                {p.user_name ?? p.name?.[0]?.toUpperCase() || '?'}
+                                                {(p.user_name ?? p.name)?.[0]?.toUpperCase() || '?'}
                                             </div>
                                             <div className="text-sm truncate max-w-[150px]">
-                                                {p.user_name ?? p.name || 'Onbekend'}
+                                                {(p.user_name ?? p.name) || 'Onbekend'}
                                             </div>
                                         </div>
                                         {(p.has_completed_ranking || p.has_ranking) ? (

--- a/frontend/src/components/deliberation/dashboard/PhaseRefine.tsx
+++ b/frontend/src/components/deliberation/dashboard/PhaseRefine.tsx
@@ -69,10 +69,10 @@ export const PhaseRefine: React.FC<PhaseRefineProps> = ({
                                     <div key={p.user_id} className="flex items-center justify-between p-2 rounded-md bg-muted/30">
                                         <div className="flex items-center gap-2">
                                             <div className="w-6 h-6 rounded-full bg-primary/10 flex items-center justify-center text-[10px] font-bold text-primary">
-                                                {p.user_name?.[0]?.toUpperCase() || '?'}
+                                                {p.user_name ?? p.name?.[0]?.toUpperCase() || '?'}
                                             </div>
                                             <div className="text-sm truncate max-w-[150px]">
-                                                {p.user_name || 'Onbekend'}
+                                                {p.user_name ?? p.name || 'Onbekend'}
                                             </div>
                                         </div>
                                         {(p.has_completed_refinement || p.feedback_count > 0) ? (

--- a/frontend/src/components/deliberation/dashboard/PhaseRefine.tsx
+++ b/frontend/src/components/deliberation/dashboard/PhaseRefine.tsx
@@ -69,10 +69,10 @@ export const PhaseRefine: React.FC<PhaseRefineProps> = ({
                                     <div key={p.user_id} className="flex items-center justify-between p-2 rounded-md bg-muted/30">
                                         <div className="flex items-center gap-2">
                                             <div className="w-6 h-6 rounded-full bg-primary/10 flex items-center justify-center text-[10px] font-bold text-primary">
-                                                {p.user_name ?? p.name?.[0]?.toUpperCase() || '?'}
+                                                {(p.user_name ?? p.name)?.[0]?.toUpperCase() || '?'}
                                             </div>
                                             <div className="text-sm truncate max-w-[150px]">
-                                                {p.user_name ?? p.name || 'Onbekend'}
+                                                {(p.user_name ?? p.name) || 'Onbekend'}
                                             </div>
                                         </div>
                                         {(p.has_completed_refinement || p.feedback_count > 0) ? (

--- a/frontend/src/components/deliberation/dashboard/PhaseStart.tsx
+++ b/frontend/src/components/deliberation/dashboard/PhaseStart.tsx
@@ -4,15 +4,23 @@ import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import { Loader2, Play, Users } from 'lucide-react';
+import { ScrollArea } from '@/components/ui/scroll-area';
 import type { VotingSessionConfig } from '@/types/session';
+
+interface Member {
+    id: string;
+    name: string;
+    email: string;
+    role: string;
+}
 
 interface PhaseStartProps {
     onStart: (config: VotingSessionConfig) => void;
     isStarting: boolean;
-    participantCount?: number;
+    members?: Member[];
 }
 
-export const PhaseStart: React.FC<PhaseStartProps> = ({ onStart, isStarting, participantCount = 0 }) => {
+export const PhaseStart: React.FC<PhaseStartProps> = ({ onStart, isStarting, members = [] }) => {
     const [dots, setDots] = useState<number>(3);
     const [timeLimit, setTimeLimit] = useState<number | ''>('');
 
@@ -62,22 +70,33 @@ export const PhaseStart: React.FC<PhaseStartProps> = ({ onStart, isStarting, par
                     </CardContent>
                 </Card>
 
-                <Card>
+                <Card className="flex flex-col">
                     <CardHeader>
-                        <CardTitle>Deelnemers</CardTitle>
-                        <CardDescription>Overzicht van genodigden.</CardDescription>
+                        <CardTitle className="flex items-center gap-2">
+                            <Users className="h-4 w-4" />
+                            Deelnemers ({members.length})
+                        </CardTitle>
+                        <CardDescription>Leden van deze DesignSpace.</CardDescription>
                     </CardHeader>
-                    <CardContent>
-                        <div className="flex items-center gap-4 mb-4">
-                            <div className="p-3 bg-primary/10 rounded-full">
-                                <Users className="h-6 w-6 text-primary" />
+                    <CardContent className="flex-1 flex flex-col gap-3">
+                        <ScrollArea className="h-[160px]">
+                            <div className="space-y-1.5 pr-2">
+                                {members.length === 0 && (
+                                    <p className="text-sm text-muted-foreground py-4 text-center">Geen leden gevonden.</p>
+                                )}
+                                {members.map(m => (
+                                    <div key={m.id} className="flex items-center justify-between p-2 rounded-md bg-muted/30 text-sm">
+                                        <div className="flex items-center gap-2 min-w-0">
+                                            <div className="w-6 h-6 rounded-full bg-primary/10 flex items-center justify-center text-[10px] font-bold text-primary shrink-0">
+                                                {(m.name || m.email)?.[0]?.toUpperCase() ?? '?'}
+                                            </div>
+                                            <span className="truncate">{m.name || m.email}</span>
+                                        </div>
+                                        <span className="text-xs text-muted-foreground shrink-0 ml-2 capitalize">{m.role}</span>
+                                    </div>
+                                ))}
                             </div>
-                            <div>
-                                <div className="text-2xl font-bold">{participantCount}</div>
-                                <div className="text-sm text-muted-foreground">Geregistreerde gebruikers</div>
-                            </div>
-                        </div>
-
+                        </ScrollArea>
                         <div className="bg-amber-50 border border-amber-200 rounded p-3 text-sm text-amber-800">
                             <strong>Let op:</strong> Zodra je start, wordt de sessie actief voor alle deelnemers.
                         </div>

--- a/frontend/src/components/deliberation/dashboard/VotingConsent.tsx
+++ b/frontend/src/components/deliberation/dashboard/VotingConsent.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { sessionService } from '@/services/sessions';
+import { api } from '@/services/api';
 import type { ShortlistClaim } from '@/services/api';
 import { toast } from 'sonner';
 import { Loader2, CheckCircle2, XCircle } from 'lucide-react';
@@ -12,17 +13,32 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 
 interface VotingConsentProps {
     sessionId: string;
+    dsId: string;
     onComplete?: () => void;
 }
 
-export const VotingConsent: React.FC<VotingConsentProps> = ({ sessionId, onComplete }) => {
+export const VotingConsent: React.FC<VotingConsentProps> = ({ sessionId, dsId, onComplete }) => {
     const queryClient = useQueryClient();
     const [objectionTarget, setObjectionTarget] = useState<ShortlistClaim | null>(null);
     const [motivation, setMotivation] = useState('');
 
-    const { data: claims = [], isLoading } = useQuery({
+    const { data: shortlist = [], isLoading: isLoadingShortlist } = useQuery({
         queryKey: ['consent-shortlist', sessionId],
         queryFn: () => sessionService.getConsentShortlist(sessionId)
+    });
+
+    const { data: allClaims = [], isLoading: isLoadingClaims } = useQuery({
+        queryKey: ['claims', dsId],
+        queryFn: () => api.getThemeVersionClaims(dsId),
+        enabled: !!dsId,
+    });
+
+    const isLoading = isLoadingShortlist || isLoadingClaims;
+
+    // Merge statements from full claims into shortlist items
+    const claims: ShortlistClaim[] = shortlist.map(item => {
+        const full = allClaims.find(c => c.id === item.id);
+        return { ...item, statement: full?.statement ?? item.statement ?? '' };
     });
 
     const { mutate: vote, isPending: isVoting } = useMutation({
@@ -46,15 +62,17 @@ export const VotingConsent: React.FC<VotingConsentProps> = ({ sessionId, onCompl
 
     if (isLoading) return <div className="flex justify-center p-8"><Loader2 className="animate-spin" /></div>;
 
-    const sortedClaims = [...claims].sort((a, b) => {
+    const visibleClaims = claims.filter(c => c.status !== 'rejected');
+
+    const sortedClaims = [...visibleClaims].sort((a, b) => {
         // Unvoted first
         if (!a.user_vote && b.user_vote) return -1;
         if (a.user_vote && !b.user_vote) return 1;
         return 0;
     });
 
-    const voteCount = claims.filter(c => c.user_vote).length;
-    const isComplete = voteCount === claims.length;
+    const voteCount = visibleClaims.filter(c => c.user_vote).length;
+    const isComplete = voteCount === visibleClaims.length && visibleClaims.length > 0;
 
     return (
         <div className="flex flex-col h-full bg-background overflow-hidden relative">
@@ -65,7 +83,7 @@ export const VotingConsent: React.FC<VotingConsentProps> = ({ sessionId, onCompl
 
             <ScrollArea className="flex-1 p-4">
                 <div className="space-y-4">
-                    {sortedClaims.filter(c => c.status !== 'rejected').map(claim => (
+                    {sortedClaims.map(claim => (
                         <Card key={claim.id} className={`transition-all ${claim.user_vote ? 'opacity-70' : ''}`}>
                             <CardContent className="p-4 space-y-3">
                                 <div className="flex justify-between items-start gap-2">
@@ -136,7 +154,7 @@ export const VotingConsent: React.FC<VotingConsentProps> = ({ sessionId, onCompl
             <div className="p-4 border-t bg-background flex flex-col gap-2">
                 {!isComplete && (
                     <p className="text-[10px] text-muted-foreground text-center px-2 leading-tight">
-                        Stem op alle {claims.length} claims om af te kunnen ronden ({claims.length - voteCount} te gaan).
+                        Stem op alle {visibleClaims.length} claims om af te kunnen ronden ({visibleClaims.length - voteCount} te gaan).
                     </p>
                 )}
                 <div className="flex justify-end w-full">

--- a/frontend/src/components/deliberation/dashboard/VotingConsent.tsx
+++ b/frontend/src/components/deliberation/dashboard/VotingConsent.tsx
@@ -29,7 +29,7 @@ export const VotingConsent: React.FC<VotingConsentProps> = ({ sessionId, onCompl
         mutationFn: async ({ claimId, type, motivation }: { claimId: string; type: 'approve' | 'object'; motivation?: string }) => {
             await sessionService.submitConsentVote(sessionId, {
                 session_id: sessionId,
-                claim_version_id: claimId,
+                tessera_base_id: claimId,
                 vote: type,
                 motivation
             });

--- a/frontend/src/components/deliberation/dashboard/VotingRanking.tsx
+++ b/frontend/src/components/deliberation/dashboard/VotingRanking.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Button } from "@/components/ui/button";
 import { sessionService } from '@/services/sessions';
+import { api } from '@/services/api';
 import { toast } from 'sonner';
 import { Loader2 } from 'lucide-react';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
@@ -11,6 +12,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 
 interface VotingRankingProps {
     sessionId: string;
+    dsId: string;
     onComplete?: () => void;
 }
 
@@ -23,7 +25,7 @@ const CATEGORIES: { id: Category; label: string; color: string }[] = [
     { id: 'discard', label: 'Verwijderen', color: 'bg-red-500/10 border-red-500/20 text-red-700' }
 ];
 
-export const VotingRanking: React.FC<VotingRankingProps> = ({ sessionId, onComplete }) => {
+export const VotingRanking: React.FC<VotingRankingProps> = ({ sessionId, dsId, onComplete }) => {
     const queryClient = useQueryClient();
     const [items, setItems] = useState<Record<Category, string[]>>({
         high: [],
@@ -32,21 +34,40 @@ export const VotingRanking: React.FC<VotingRankingProps> = ({ sessionId, onCompl
         discard: []
     });
 
-    const { data: claims = [], isLoading } = useQuery({
+    // Fetch full claim objects (id + statement) from the DesignSpace
+    const { data: allClaims = [], isLoading: isLoadingClaims } = useQuery({
+        queryKey: ['claims', dsId],
+        queryFn: () => api.getThemeVersionClaims(dsId),
+        enabled: !!dsId,
+    });
+
+    // Fetch eligible claim IDs (claims without red feedback)
+    const { data: eligibleRaw = [], isLoading: isLoadingEligible } = useQuery({
         queryKey: ['eligible-claims', sessionId],
-        queryFn: () => sessionService.getEligibleClaims(sessionId)
+        queryFn: () => sessionService.getEligibleClaims(sessionId),
     });
 
     const { data: existingRankings = [] } = useQuery({
         queryKey: ['rankings', sessionId],
-        queryFn: () => sessionService.getRankings(sessionId)
+        queryFn: () => sessionService.getRankings(sessionId),
     });
+
+    // Build eligible claim set from the raw IDs
+    const eligibleIds = new Set(eligibleRaw.map((r: any) => r.tessera_base_id));
+
+    // Filter full claims to only those eligible
+    const claims = allClaims.filter(c => eligibleIds.has(c.id));
+
+    const isLoading = isLoadingClaims || isLoadingEligible;
 
     const isInitializedRef = useRef(false);
 
-    // Initialize items
+    // Initialize items — wait until both queries have finished loading
     useEffect(() => {
-        if (claims.length > 0 && !isInitializedRef.current) {
+        if (!isLoadingClaims && !isLoadingEligible && !isInitializedRef.current) {
+            const ids = new Set(eligibleRaw.map((r: any) => r.tessera_base_id));
+            const eligible = allClaims.filter(c => ids.has(c.id));
+
             const initialItems: Record<Category, string[]> = {
                 high: [],
                 medium: [],
@@ -54,15 +75,15 @@ export const VotingRanking: React.FC<VotingRankingProps> = ({ sessionId, onCompl
                 discard: []
             };
 
-            const rankedIds = new Set();
-            existingRankings.forEach((r) => {
+            const rankedIds = new Set<string>();
+            existingRankings.forEach((r: any) => {
                 if (initialItems[r.category as Category]) {
                     initialItems[r.category as Category].push(r.tessera_base_id);
                     rankedIds.add(r.tessera_base_id);
                 }
             });
 
-            claims.forEach(c => {
+            eligible.forEach(c => {
                 if (!rankedIds.has(c.id)) {
                     initialItems.backlog.push(c.id);
                 }
@@ -71,7 +92,7 @@ export const VotingRanking: React.FC<VotingRankingProps> = ({ sessionId, onCompl
             setItems(initialItems);
             isInitializedRef.current = true;
         }
-    }, [claims, existingRankings]);
+    }, [isLoadingClaims, isLoadingEligible, allClaims, eligibleRaw, existingRankings]);
 
     const { mutate: submitRankings, isPending } = useMutation({
         mutationFn: async () => {
@@ -111,8 +132,9 @@ export const VotingRanking: React.FC<VotingRankingProps> = ({ sessionId, onCompl
 
     if (isLoading) return <div className="flex justify-center p-8"><Loader2 className="animate-spin" /></div>;
 
-    const categorizedCount = Object.values(items).reduce((acc, curr) => acc + curr.length, 0);
-    const isComplete = categorizedCount === claims.length;
+    const totalItems = Object.values(items).reduce((acc, curr) => acc + curr.length, 0);
+    const backlogCount = items.backlog.length;
+    const isComplete = totalItems === claims.length && backlogCount < claims.length;
 
     return (
         <div className="flex flex-col h-full bg-background p-4 gap-4">
@@ -121,7 +143,7 @@ export const VotingRanking: React.FC<VotingRankingProps> = ({ sessionId, onCompl
                 <div className="flex items-center gap-2">
                     {!isComplete && (
                         <span className="text-xs text-muted-foreground">
-                            {claims.length - categorizedCount} items te plaatsen
+                            {backlogCount} items te plaatsen
                         </span>
                     )}
                     <Button size="sm" onClick={() => submitRankings()} disabled={isPending || !isComplete}>

--- a/frontend/src/components/deliberation/dashboard/VotingRanking.tsx
+++ b/frontend/src/components/deliberation/dashboard/VotingRanking.tsx
@@ -57,8 +57,8 @@ export const VotingRanking: React.FC<VotingRankingProps> = ({ sessionId, onCompl
             const rankedIds = new Set();
             existingRankings.forEach((r) => {
                 if (initialItems[r.category as Category]) {
-                    initialItems[r.category as Category].push(r.claim_version_id);
-                    rankedIds.add(r.claim_version_id);
+                    initialItems[r.category as Category].push(r.tessera_base_id);
+                    rankedIds.add(r.tessera_base_id);
                 }
             });
 

--- a/frontend/src/components/deliberation/dashboard/VotingRefine.tsx
+++ b/frontend/src/components/deliberation/dashboard/VotingRefine.tsx
@@ -55,7 +55,7 @@ export const VotingRefine: React.FC<RefinementViewProps> = ({ sessionId, version
     const myFeedback = useMemo(() => {
         if (!currentUser?.id) return null;
         return feedbackData.find(f =>
-            f.claim_version_id === selectedClaim?.version_id &&
+            f.tessera_base_id === selectedClaim?.version_id &&
             f.user_id === currentUser.id
         ) || null;
     }, [feedbackData, selectedClaim?.version_id, currentUser?.id]);

--- a/frontend/src/components/deliberation/dashboard/VotingRefine.tsx
+++ b/frontend/src/components/deliberation/dashboard/VotingRefine.tsx
@@ -86,6 +86,7 @@ export const VotingRefine: React.FC<RefinementViewProps> = ({ sessionId, version
                     claim={selectedClaim}
                     allClaims={claims}
                     factors={factors}
+                    designSpaceId={versionId}
                 />
             </main>
 

--- a/frontend/src/components/layout/VersionLayout.tsx
+++ b/frontend/src/components/layout/VersionLayout.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Sidebar, type NavItem } from '@/components/ui/Sidebar';
 import { DashboardHeader } from '@/components/dashboard/DashboardHeader';
-import { LayoutDashboard, MessageSquare, FileText, Settings, Users, GitBranch } from 'lucide-react';
+import { LayoutDashboard, MessageSquare, FileText, Settings, Users, GitBranch, Clock } from 'lucide-react';
 import { useParams, Outlet } from 'react-router-dom';
 
 interface VersionLayoutProps {
@@ -30,6 +30,12 @@ export const VersionLayout: React.FC<VersionLayoutProps> = ({ children }) => {
             icon: GitBranch,
             label: 'Argumentatie',
             path: `/designspace/${dsId}/argumentatie`
+        },
+        {
+            id: 'tijdlijn',
+            icon: Clock,
+            label: 'Tijdlijn',
+            path: `/designspace/${dsId}/tijdlijn`
         },
         {
             id: 'chat',

--- a/frontend/src/components/layout/VersionLayout.tsx
+++ b/frontend/src/components/layout/VersionLayout.tsx
@@ -1,16 +1,54 @@
 import React, { useState } from 'react';
 import { Sidebar, type NavItem } from '@/components/ui/Sidebar';
-import { DashboardHeader } from '@/components/dashboard/DashboardHeader';
-import { LayoutDashboard, MessageSquare, FileText, Settings, Users, GitBranch, Clock } from 'lucide-react';
-import { useParams, Outlet } from 'react-router-dom';
+import {
+    LayoutDashboard,
+    MessageSquare,
+    FileText,
+    Settings,
+    Users,
+    GitBranch,
+    Clock,
+    Workflow,
+    Maximize2,
+    Minimize2,
+} from 'lucide-react';
+import { useParams, Outlet, useSearchParams, useNavigate } from 'react-router-dom';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { PhaseSelector } from '@/components/deliberation/PhaseSelector';
+import { MemberManagement } from '@/components/Settings/MemberManagement';
+import { DesignSpaceProvider } from '@/context/DesignSpaceContext';
+import { useDesignSpace } from '@/context/DesignSpaceContext';
+import { useOrganization } from '@/context/OrganizationContext';
 
-interface VersionLayoutProps {
-    children?: React.ReactNode;
+type AgentType = 'CAUSA' | 'AXIA' | 'ACTOR' | 'PRAXIS';
+
+interface VersionLayoutInnerProps {
+    projectName: string;
+    themeName: string;
+    dsId: string;
 }
 
-export const VersionLayout: React.FC<VersionLayoutProps> = ({ children }) => {
-    const { dsId } = useParams();
-    const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+const VersionLayoutInner: React.FC<VersionLayoutInnerProps> = ({ projectName, themeName, dsId }) => {
+    const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
+    const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+    const [focusMode, setFocusMode] = useState(false);
+
+    const { phaseSnapshots, activePhaseId, setActivePhaseId } = useDesignSpace();
+
+    const activeAgent = (searchParams.get('mode') as AgentType) || 'CAUSA';
+
+    const handleAgentChange = (val: string) => {
+        if (!val) return;
+        navigate(`/designspace/${dsId}?mode=${val}`);
+    };
 
     const versionNavItems: NavItem[] = [
         {
@@ -20,58 +58,168 @@ export const VersionLayout: React.FC<VersionLayoutProps> = ({ children }) => {
             path: `/designspace/${dsId}/overview`,
         },
         {
+            id: 'workspace',
+            icon: Workflow,
+            label: 'Werkruimte',
+            path: `/designspace/${dsId}`,
+            exact: true,
+        },
+        {
             id: 'claims',
             icon: FileText,
             label: 'Verfijn',
-            path: `/designspace/${dsId}/claims`
+            path: `/designspace/${dsId}/claims`,
         },
         {
             id: 'argumentatie',
             icon: GitBranch,
             label: 'Argumentatie',
-            path: `/designspace/${dsId}/argumentatie`
+            path: `/designspace/${dsId}/argumentatie`,
         },
         {
             id: 'tijdlijn',
             icon: Clock,
             label: 'Tijdlijn',
-            path: `/designspace/${dsId}/tijdlijn`
+            path: `/designspace/${dsId}/tijdlijn`,
         },
         {
             id: 'chat',
             icon: MessageSquare,
             label: 'Chat',
-            path: `/designspace/${dsId}/chat`
+            path: `/designspace/${dsId}/chat`,
         },
         {
             id: 'members',
             icon: Users,
-            label: 'Members',
-            path: `/designspace/${dsId}/members`
+            label: 'Leden',
+            path: `/designspace/${dsId}/members`,
         },
         {
             id: 'settings',
             icon: Settings,
-            label: 'Settings',
-            path: `/designspace/${dsId}/settings`
+            label: 'Instellingen',
+            path: `/designspace/${dsId}/settings`,
         },
     ];
 
     return (
         <div className="h-screen flex bg-background overflow-hidden font-sans text-foreground">
-            {/* Version Context Sidebar */}
             <Sidebar className="hidden lg:flex z-50" items={versionNavItems} />
 
-            {/* Main Content Area */}
-            <div className="flex-1 flex flex-col overflow-hidden relative">
-                <DashboardHeader
-                    onMenuClick={() => setIsSidebarOpen(!isSidebarOpen)}
-                />
+            <div className="flex-1 flex flex-col overflow-hidden">
+                {!focusMode && (
+                    <header className="h-14 border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 flex items-center justify-between px-4 shrink-0 z-30">
+                        <div className="flex flex-col">
+                            <span className="text-[10px] text-muted-foreground uppercase tracking-widest font-bold leading-none mb-1">
+                                {projectName}
+                            </span>
+                            <span className="text-sm font-bold leading-none">{themeName}</span>
+                        </div>
 
-                <main className="flex-1 overflow-y-auto bg-muted/10 relative">
-                    {children || <Outlet />}
+                        <div className="flex items-center gap-4">
+                            <ToggleGroup
+                                type="single"
+                                value={activeAgent}
+                                onValueChange={handleAgentChange}
+                            >
+                                <ToggleGroupItem value="CAUSA" aria-label="Toggle CAUSA">CAUSA</ToggleGroupItem>
+                                <ToggleGroupItem value="AXIA" disabled aria-label="Toggle AXIA">
+                                    AXIA <span className="ml-1.5 text-[9px] opacity-70">SOON</span>
+                                </ToggleGroupItem>
+                                <ToggleGroupItem value="ACTOR" disabled aria-label="Toggle ACTOR">
+                                    ACTOR <span className="ml-1.5 text-[9px] opacity-70">SOON</span>
+                                </ToggleGroupItem>
+                                <ToggleGroupItem value="PRAXIS" disabled aria-label="Toggle PRAXIS">
+                                    PRAXIS <span className="ml-1.5 text-[9px] opacity-70">SOON</span>
+                                </ToggleGroupItem>
+                            </ToggleGroup>
+                        </div>
+
+                        <div className="flex items-center gap-2">
+                            <PhaseSelector
+                                snapshots={phaseSnapshots}
+                                activePhaseId={activePhaseId}
+                                onSelect={setActivePhaseId}
+                            />
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => setIsSettingsOpen(true)}
+                                title="Thema Instellingen & Leden"
+                            >
+                                <Settings size={18} />
+                            </Button>
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => setFocusMode(!focusMode)}
+                                title={focusMode ? 'Focusmodus verlaten' : 'Focusmodus'}
+                                className={focusMode ? 'text-primary bg-primary/10' : ''}
+                            >
+                                {focusMode ? <Minimize2 size={18} /> : <Maximize2 size={18} />}
+                            </Button>
+                        </div>
+                    </header>
+                )}
+
+                {focusMode && (
+                    <div className="absolute top-2 right-2 z-50">
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => setFocusMode(false)}
+                            title="Focusmodus verlaten"
+                            className="text-primary bg-primary/10"
+                        >
+                            <Minimize2 size={18} />
+                        </Button>
+                    </div>
+                )}
+
+                <main className="flex-1 overflow-hidden relative">
+                    <Outlet />
                 </main>
             </div>
+
+            <Dialog open={isSettingsOpen} onOpenChange={setIsSettingsOpen}>
+                <DialogContent className="max-w-4xl max-h-[85vh] overflow-y-auto" aria-describedby={undefined}>
+                    <DialogHeader>
+                        <DialogTitle>Thema Instellingen: {themeName}</DialogTitle>
+                    </DialogHeader>
+                    <div className="py-4">
+                        <MemberManagement entityId={dsId} entityType="theme" />
+                    </div>
+                </DialogContent>
+            </Dialog>
         </div>
+    );
+};
+
+export const VersionLayout: React.FC = () => {
+    const { dsId } = useParams<{ dsId: string }>();
+    const { organizations, isLoading } = useOrganization();
+
+    const found = organizations
+        .flatMap(org => org.projects.flatMap(proj =>
+            proj.themes.map(theme => ({ project: proj, theme }))
+        ))
+        .find(item => item.theme.id === dsId);
+
+    if (isLoading) {
+        return <div className="flex items-center justify-center h-screen text-muted-foreground">Laden...</div>;
+    }
+
+    if (!found) {
+        return <div className="flex items-center justify-center h-screen text-muted-foreground">DesignSpace niet gevonden of geen toegang.</div>;
+    }
+
+    return (
+        <DesignSpaceProvider dsId={found.theme.id}>
+            <VersionLayoutInner
+                projectName={found.project.name}
+                themeName={found.theme.name}
+                dsId={found.theme.id}
+            />
+        </DesignSpaceProvider>
     );
 };

--- a/frontend/src/components/layout/VersionLayout.tsx
+++ b/frontend/src/components/layout/VersionLayout.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Sidebar, type NavItem } from '@/components/ui/Sidebar';
 import { DashboardHeader } from '@/components/dashboard/DashboardHeader';
-import { LayoutDashboard, MessageSquare, FileText, Settings, Users } from 'lucide-react';
+import { LayoutDashboard, MessageSquare, FileText, Settings, Users, GitBranch } from 'lucide-react';
 import { useParams, Outlet } from 'react-router-dom';
 
 interface VersionLayoutProps {
@@ -24,6 +24,12 @@ export const VersionLayout: React.FC<VersionLayoutProps> = ({ children }) => {
             icon: FileText,
             label: 'Verfijn',
             path: `/designspace/${dsId}/claims`
+        },
+        {
+            id: 'argumentatie',
+            icon: GitBranch,
+            label: 'Argumentatie',
+            path: `/designspace/${dsId}/argumentatie`
         },
         {
             id: 'chat',

--- a/frontend/src/context/DesignSpaceContext.tsx
+++ b/frontend/src/context/DesignSpaceContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
-import { api, type ThemeVersion } from '../services/api';
+import { api, type ThemeVersion, type PhaseSnapshot } from '../services/api';
 import { type VotingSession } from '../types/session';
 import { useActiveSession } from '../hooks/queries/useSessions';
 
@@ -14,6 +14,9 @@ interface DesignSpaceContextType {
     setActiveVotingSession: React.Dispatch<React.SetStateAction<VotingSession | null>>;
     switchVersion: (versionId: string) => void;
     refreshVersions: () => Promise<void>;
+    phaseSnapshots: PhaseSnapshot[];
+    activePhaseId: string | null;
+    setActivePhaseId: (id: string | null) => void;
 }
 
 export const DesignSpaceContext = createContext<DesignSpaceContextType | undefined>(undefined);
@@ -28,19 +31,23 @@ export const DesignSpaceProvider: React.FC<DesignSpaceProviderProps> = ({ dsId, 
     const [currentViewedVersion, setCurrentViewedVersion] = useState<ThemeVersion | null>(null);
     const [versions, setVersions] = useState<ThemeVersion[]>([]);
     const [isLoading, setIsLoading] = useState(true);
+    const [phaseSnapshots, setPhaseSnapshots] = useState<PhaseSnapshot[]>([]);
+    const [activePhaseId, setActivePhaseId] = useState<string | null>(null);
 
     const { data: activeVotingSession } = useActiveSession(activeVersion?.id || null);
 
     const fetchData = useCallback(async () => {
         setIsLoading(true);
         try {
-            const [fetchedActive, fetchedVersions] = await Promise.all([
+            const [fetchedActive, fetchedVersions, fetchedSnapshots] = await Promise.all([
                 api.getThemeActiveVersion(dsId),
-                api.getThemeVersions(dsId)
+                api.getThemeVersions(dsId),
+                api.getPhaseSnapshots(dsId),
             ]);
 
             setActiveVersion(fetchedActive);
             setVersions(fetchedVersions);
+            setPhaseSnapshots(fetchedSnapshots);
 
             if (!currentViewedVersion || !fetchedVersions.find(v => v.id === currentViewedVersion.id)) {
                 setCurrentViewedVersion(fetchedActive);
@@ -71,9 +78,9 @@ export const DesignSpaceProvider: React.FC<DesignSpaceProviderProps> = ({ dsId, 
         }
     };
 
-    const isReadOnly = activeVersion && currentViewedVersion
+    const isReadOnly = (activeVersion && currentViewedVersion
         ? activeVersion.id !== currentViewedVersion.id
-        : false;
+        : false) || activePhaseId !== null;
 
     return (
         <DesignSpaceContext.Provider value={{
@@ -88,7 +95,10 @@ export const DesignSpaceProvider: React.FC<DesignSpaceProviderProps> = ({ dsId, 
                 console.warn("setActiveVotingSession is deprecated. Session state is now managed by React Query.");
             },
             switchVersion,
-            refreshVersions
+            refreshVersions,
+            phaseSnapshots,
+            activePhaseId,
+            setActivePhaseId,
         }}>
             {children}
         </DesignSpaceContext.Provider>

--- a/frontend/src/context/DesignSpaceContext.tsx
+++ b/frontend/src/context/DesignSpaceContext.tsx
@@ -16,7 +16,7 @@ interface DesignSpaceContextType {
     refreshVersions: () => Promise<void>;
 }
 
-const DesignSpaceContext = createContext<DesignSpaceContextType | undefined>(undefined);
+export const DesignSpaceContext = createContext<DesignSpaceContextType | undefined>(undefined);
 
 interface DesignSpaceProviderProps {
     dsId: string;

--- a/frontend/src/perspectives/causa/Shell.tsx
+++ b/frontend/src/perspectives/causa/Shell.tsx
@@ -55,9 +55,9 @@ export const CausaShell = ({ themeId, websocket, currentUserId, onSelect, onOpen
 
     // Derived state
     const { activeVersion, activeVotingSession } = themeState;
-    // TODO: Verify if activeVersion has role. Use role 'moderator' check if available, or fallback.
-    // Ideally user role should be joined. For now assuming activeVersion carries role context or we check activeVersion.role
-    const isModerator = (activeVersion as any)?.role === 'moderator' || (activeVersion as any)?.role === 'admin';
+    // canResolveThread wordt opgehaald via GET /designspace/{id}/can-resolve in ValorWorkspace
+    // en controleert de MODERATOR-rol — identiek aan wat isModerator nodig heeft.
+    const isModerator = canResolveThread;
 
     // const [showDeliberation, setShowDeliberation] = useState(false); // Removed
     const [showModeratorDashboard, setShowModeratorDashboard] = useState(false);

--- a/frontend/src/perspectives/causa/Shell.tsx
+++ b/frontend/src/perspectives/causa/Shell.tsx
@@ -54,7 +54,7 @@ export const CausaShell = ({ themeId, websocket, currentUserId, onSelect, onOpen
     const [layoutMode, setLayoutMode] = useState<'free' | 'system'>('free');
 
     // Derived state
-    const { activeVersion, activeVotingSession } = themeState;
+    const { activeVersion, activeVotingSession, activePhaseId } = themeState;
     // canResolveThread wordt opgehaald via GET /designspace/{id}/can-resolve in ValorWorkspace
     // en controleert de MODERATOR-rol — identiek aan wat isModerator nodig heeft.
     const isModerator = canResolveThread;
@@ -140,7 +140,7 @@ export const CausaShell = ({ themeId, websocket, currentUserId, onSelect, onOpen
 
     // B. Fetch Data
     // console.log('[CausaShell] Props:', { themeId, versionId, activeVersionId: themeState.activeVersion?.id });
-    const { nodes, links, factors, cycleNodeIds, refresh, loading, viewFilter, setViewFilter } = useCausaData(themeId, versionId || themeState.activeVersion?.id);
+    const { nodes, links, factors, cycleNodeIds, refresh, loading, viewFilter, setViewFilter } = useCausaData(themeId, versionId || themeState.activeVersion?.id, activePhaseId);
 
     // C. Initialize Session
     // Re-create session ONLY when layoutMode changes

--- a/frontend/src/perspectives/causa/hooks/useCausaData.ts
+++ b/frontend/src/perspectives/causa/hooks/useCausaData.ts
@@ -16,7 +16,7 @@ interface CausaData {
     setViewFilter: (filter: ClaimViewType | null) => void;
 }
 
-export const useCausaData = (themeId: string, versionId?: string): CausaData => {
+export const useCausaData = (themeId: string, versionId?: string, phase?: string | null): CausaData => {
     const [nodes, setNodes] = useState<CausalNode[]>([]);
     const [links, setLinks] = useState<CausalLink[]>([]);
     const [factors, setFactors] = useState<Factor[]>([]);
@@ -29,7 +29,7 @@ export const useCausaData = (themeId: string, versionId?: string): CausaData => 
     const lastFetchRef = useRef<string | null>(null);
 
     const refresh = useCallback(async (force = false) => {
-        const fetchKey = `${themeId}-${versionId || 'active'}`;
+        const fetchKey = `${themeId}-${versionId || 'active'}-${phase || 'current'}`;
         if (!force && lastFetchRef.current === fetchKey && !loading) return;
 
         try {
@@ -42,13 +42,13 @@ export const useCausaData = (themeId: string, versionId?: string): CausaData => 
 
             if (versionId) {
                 [claimsData, factorsData] = await Promise.all([
-                    api.getThemeVersionClaims(versionId),
-                    api.getThemeVersionFactors(versionId)
+                    api.getThemeVersionClaims(versionId, phase ?? undefined),
+                    api.getThemeVersionFactors(versionId, phase ?? undefined)
                 ]);
             } else {
                 [claimsData, factorsData] = await Promise.all([
-                    api.getThemeClaims(themeId),
-                    api.getThemeFactors(themeId)
+                    api.getThemeVersionClaims(themeId, phase ?? undefined),
+                    api.getThemeFactors(themeId, phase ?? undefined)
                 ]);
             }
 
@@ -71,7 +71,7 @@ export const useCausaData = (themeId: string, versionId?: string): CausaData => 
         } finally {
             setLoading(false);
         }
-    }, [themeId, versionId]);
+    }, [themeId, versionId, phase]);
 
     // Initial Load
     useEffect(() => {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -649,6 +649,39 @@ export const api = {
         return response.data;
     },
 
+    // Argumentatiediagram (IBIS-stijl) — US-5.1
+    getArgumentationNetwork: async (dsId: string): Promise<ArgumentationNetwork> => {
+        const VALOR_NS = 'https://valor-ecosystem.nl/ontology/';
+        const query = `
+PREFIX valor: <${VALOR_NS}>
+SELECT ?source ?sourceContent ?sourceStatus ?sourceType ?rel ?relLabel ?target ?targetContent ?targetStatus ?targetType
+WHERE {
+  GRAPH <urn:valor:ds:${dsId}> {
+    ?source a valor:Tessera ;
+            valor:claimContent ?sourceContent ;
+            valor:epistemicStatus ?sourceStatus .
+    OPTIONAL { ?source valor:claimType ?sourceType . }
+    ?source ?rel ?target .
+    ?target a valor:Tessera ;
+            valor:claimContent ?targetContent ;
+            valor:epistemicStatus ?targetStatus .
+    OPTIONAL { ?target valor:claimType ?targetType . }
+  }
+  GRAPH <urn:valor:tessera> {
+    ?rel a <http://www.w3.org/2002/07/owl#ObjectProperty> ;
+         <http://www.w3.org/2000/01/rdf-schema#domain> valor:Tessera ;
+         <http://www.w3.org/2000/01/rdf-schema#range> valor:Tessera ;
+         <http://www.w3.org/2000/01/rdf-schema#label> ?relLabel .
+    FILTER(lang(?relLabel) = "en")
+  }
+}`.trim();
+        const response = await apiClient.get<ArgumentationNetworkRaw>(
+            `/designspace/${dsId}/sparql`,
+            { params: { query } }
+        );
+        return parseArgumentationNetwork(response.data);
+    },
+
     advanceSession: async (sessionId: string) => {
         const response = await apiClient.post(`/sessions/${sessionId}/advance`);
         return response.data;
@@ -691,6 +724,92 @@ export interface DiscContribution {
     contributed_by_name: string;
     contributed_at: string;
     evidence_id: string | null;
+}
+
+// Argumentatiediagram types (US-5.1)
+export type ArgueRelationType = 'supports' | 'undermines' | 'qualifies' | 'presupposes';
+
+export interface TesseraNode {
+    id: string;
+    uri: string;
+    claimContent: string;
+    epistemicStatus: string;
+    claimType: string;
+}
+
+export interface ArgumentEdge {
+    sourceId: string;
+    targetId: string;
+    relationType: ArgueRelationType;
+    relationUri: string;
+}
+
+export interface ArgumentationNetwork {
+    nodes: TesseraNode[];
+    edges: ArgumentEdge[];
+}
+
+interface SparqlBinding {
+    type: string;
+    value: string;
+    'xml:lang'?: string;
+}
+
+interface ArgumentationNetworkRaw {
+    results: {
+        bindings: Array<{
+            source: SparqlBinding;
+            sourceContent: SparqlBinding;
+            sourceStatus: SparqlBinding;
+            sourceType?: SparqlBinding;
+            rel: SparqlBinding;
+            relLabel: SparqlBinding;
+            target: SparqlBinding;
+            targetContent: SparqlBinding;
+            targetStatus: SparqlBinding;
+            targetType?: SparqlBinding;
+        }>;
+    };
+}
+
+function parseArgumentationNetwork(raw: ArgumentationNetworkRaw): ArgumentationNetwork {
+    const nodesMap = new Map<string, TesseraNode>();
+    const edges: ArgumentEdge[] = [];
+
+    for (const b of raw.results.bindings) {
+        const sourceUri = b.source.value;
+        const sourceId = sourceUri.split(':').pop() ?? sourceUri;
+        const targetUri = b.target.value;
+        const targetId = targetUri.split(':').pop() ?? targetUri;
+
+        if (!nodesMap.has(sourceId)) {
+            nodesMap.set(sourceId, {
+                id: sourceId,
+                uri: sourceUri,
+                claimContent: b.sourceContent.value,
+                epistemicStatus: b.sourceStatus.value.split('/').pop()?.split('#').pop() ?? b.sourceStatus.value,
+                claimType: b.sourceType ? (b.sourceType.value.split('/').pop() ?? 'AsIs') : 'AsIs',
+            });
+        }
+        if (!nodesMap.has(targetId)) {
+            nodesMap.set(targetId, {
+                id: targetId,
+                uri: targetUri,
+                claimContent: b.targetContent.value,
+                epistemicStatus: b.targetStatus.value.split('/').pop()?.split('#').pop() ?? b.targetStatus.value,
+                claimType: b.targetType ? (b.targetType.value.split('/').pop() ?? 'AsIs') : 'AsIs',
+            });
+        }
+
+        edges.push({
+            sourceId,
+            targetId,
+            relationType: b.relLabel.value as ArgueRelationType,
+            relationUri: b.rel.value,
+        });
+    }
+
+    return { nodes: Array.from(nodesMap.values()), edges };
 }
 
 export type LifecycleStatus = 'draft' | 'proposed' | 'accepted' | 'rejected' | 'deprecated';

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -471,18 +471,26 @@ export const api = {
         return response.data.cycle_node_ids;
     },
 
-    getThemeVersionClaims: async (dsId: string) => {
-        const response = await apiClient.get<Claim[]>(`/designspace/${dsId}/claims`);
+    getThemeVersionClaims: async (dsId: string, phase?: string) => {
+        const params = phase ? { phase } : {};
+        const response = await apiClient.get<Claim[]>(`/designspace/${dsId}/claims`, { params });
         return response.data;
     },
 
-    getThemeFactors: async (dsId: string) => {
-        const response = await apiClient.get<Factor[]>(`/designspace/${dsId}/factors`);
+    getThemeFactors: async (dsId: string, phase?: string) => {
+        const params = phase ? { phase } : {};
+        const response = await apiClient.get<Factor[]>(`/designspace/${dsId}/factors`, { params });
         return response.data;
     },
 
-    getThemeVersionFactors: async (dsId: string) => {
-        const response = await apiClient.get<Factor[]>(`/designspace/${dsId}/factors`);
+    getThemeVersionFactors: async (dsId: string, phase?: string) => {
+        const params = phase ? { phase } : {};
+        const response = await apiClient.get<Factor[]>(`/designspace/${dsId}/factors`, { params });
+        return response.data;
+    },
+
+    getPhaseSnapshots: async (dsId: string): Promise<PhaseSnapshot[]> => {
+        const response = await apiClient.get<PhaseSnapshot[]>(`/designspace/${dsId}/phase-snapshots`);
         return response.data;
     },
 
@@ -852,6 +860,15 @@ function parseArgumentationNetwork(raw: ArgumentationNetworkRaw, argueTypes: Arg
     }
 
     return { nodes: Array.from(nodesMap.values()), edges };
+}
+
+// PhaseSnapshot types
+export interface PhaseSnapshot {
+    session_id: string;
+    graph_uri: string;
+    created_at: string;
+    accepted_count: number;
+    rejected_count: number;
 }
 
 // DecisionTimeline types (US-5.4)

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -696,7 +696,7 @@ ORDER BY DESC(?startedAt)`.trim();
         return response.data;
     },
 
-    // Alle tesserae in een DesignSpace — US-5.1
+    // Alle Factor-tesserae in een DesignSpace (zonder CausalClaims) — US-5.1
     getDesignSpaceTesserae: async (dsId: string): Promise<TesseraNode[]> => {
         const VALOR_NS = 'https://valor-ecosystem.nl/ontology/';
         const query = `
@@ -706,6 +706,7 @@ SELECT ?node ?content ?status ?type WHERE {
         valor:claimContent ?content ;
         valor:epistemicStatus ?status .
   OPTIONAL { ?node valor:claimType ?type . }
+  FILTER NOT EXISTS { ?node valor:fromFactor ?any }
 }`.trim();
         const response = await apiClient.get<{ results: { bindings: Array<{ node: { value: string }; content: { value: string }; status: { value: string }; type?: { value: string } }> } }>(
             `/designspace/${dsId}/sparql`,
@@ -724,32 +725,36 @@ SELECT ?node ?content ?status ?type WHERE {
         });
     },
 
-    // Argumentatiediagram (IBIS-stijl) — US-5.1
-    getArgumentationNetwork: async (dsId: string, argueTypes: ArgueType[]): Promise<ArgumentationNetwork> => {
+    // Argumentatiediagram — CAUSA: Factors als nodes, CausalClaims als edges — US-5.1
+    // Structuur conform VALOR-O 00h-causa.trig:
+    //   causa:CausalClaim subclasseert valor:Tessera en heeft valor:fromFactor / valor:toFactor / valor:polarity.
+    //   Elke perspectief-module heeft eigen domein-predicaten; dit patroon geldt voor CAUSA.
+    //   De valor:supports/undermines/qualifies/presupposes predicaten (00j-tessera §E) zijn de
+    //   cross-perspectief epistemische overlay — een apart laag bovenop de domeinstructuur.
+    getArgumentationNetwork: async (dsId: string): Promise<ArgumentationNetwork> => {
         const VALOR_NS = 'https://valor-ecosystem.nl/ontology/';
-        const uriValues = argueTypes.map(t => `<${t.uri}>`).join('\n    ');
         const query = `
 PREFIX valor: <${VALOR_NS}>
-SELECT ?source ?sourceContent ?sourceStatus ?sourceType ?rel ?target ?targetContent ?targetStatus ?targetType
+SELECT ?claim ?claimContent ?claimStatus ?polarity ?source ?sourceContent ?sourceStatus ?target ?targetContent ?targetStatus
 WHERE {
+  ?claim a valor:Tessera ;
+         valor:claimContent ?claimContent ;
+         valor:epistemicStatus ?claimStatus ;
+         valor:fromFactor ?source ;
+         valor:toFactor ?target ;
+         valor:polarity ?polarity .
   ?source a valor:Tessera ;
           valor:claimContent ?sourceContent ;
           valor:epistemicStatus ?sourceStatus .
-  OPTIONAL { ?source valor:claimType ?sourceType . }
-  ?source ?rel ?target .
   ?target a valor:Tessera ;
           valor:claimContent ?targetContent ;
           valor:epistemicStatus ?targetStatus .
-  OPTIONAL { ?target valor:claimType ?targetType . }
-  VALUES ?rel {
-    ${uriValues}
-  }
 }`.trim();
-        const response = await apiClient.get<ArgumentationNetworkRaw>(
+        const response = await apiClient.get<CausalNetworkRaw>(
             `/designspace/${dsId}/sparql`,
             { params: { query } }
         );
-        return parseArgumentationNetwork(response.data, argueTypes);
+        return parseCausalNetwork(response.data);
     },
 
     advanceSession: async (sessionId: string) => {
@@ -832,24 +837,25 @@ interface SparqlBinding {
     'xml:lang'?: string;
 }
 
-interface ArgumentationNetworkRaw {
+// CAUSA-specifiek: CausalClaim-Tesserae als edges tussen Factor-Tesserae
+interface CausalNetworkRaw {
     results: {
         bindings: Array<{
+            claim: SparqlBinding;
+            claimContent: SparqlBinding;
+            claimStatus: SparqlBinding;
+            polarity: SparqlBinding;
             source: SparqlBinding;
             sourceContent: SparqlBinding;
             sourceStatus: SparqlBinding;
-            sourceType?: SparqlBinding;
-            rel: SparqlBinding;
             target: SparqlBinding;
             targetContent: SparqlBinding;
             targetStatus: SparqlBinding;
-            targetType?: SparqlBinding;
         }>;
     };
 }
 
-function parseArgumentationNetwork(raw: ArgumentationNetworkRaw, argueTypes: ArgueType[]): ArgumentationNetwork {
-    const uriToLabel = new Map(argueTypes.map(t => [t.uri, t.label_nl]));
+function parseCausalNetwork(raw: CausalNetworkRaw): ArgumentationNetwork {
     const nodesMap = new Map<string, TesseraNode>();
     const edges: ArgumentEdge[] = [];
 
@@ -865,7 +871,7 @@ function parseArgumentationNetwork(raw: ArgumentationNetworkRaw, argueTypes: Arg
                 uri: sourceUri,
                 claimContent: b.sourceContent.value,
                 epistemicStatus: b.sourceStatus.value.split('/').pop()?.split('#').pop() ?? b.sourceStatus.value,
-                claimType: b.sourceType ? (b.sourceType.value.split('/').pop() ?? 'AsIs') : 'AsIs',
+                claimType: 'AsIs',
             });
         }
         if (!nodesMap.has(targetId)) {
@@ -874,16 +880,21 @@ function parseArgumentationNetwork(raw: ArgumentationNetworkRaw, argueTypes: Arg
                 uri: targetUri,
                 claimContent: b.targetContent.value,
                 epistemicStatus: b.targetStatus.value.split('/').pop()?.split('#').pop() ?? b.targetStatus.value,
-                claimType: b.targetType ? (b.targetType.value.split('/').pop() ?? 'AsIs') : 'AsIs',
+                claimType: 'AsIs',
             });
         }
+
+        const polarity = b.polarity.value;
+        const label = b.claimContent.value.length > 45
+            ? b.claimContent.value.slice(0, 45) + '…'
+            : b.claimContent.value;
 
         edges.push({
             sourceId,
             targetId,
-            relationType: b.rel.value.split('/').pop() ?? b.rel.value,
-            relationUri: b.rel.value,
-            relationLabel: uriToLabel.get(b.rel.value) ?? b.rel.value.split('/').pop() ?? b.rel.value,
+            relationType: polarity,
+            relationUri: polarity,
+            relationLabel: label,
         });
     }
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -696,6 +696,34 @@ ORDER BY DESC(?startedAt)`.trim();
         return response.data;
     },
 
+    // Alle tesserae in een DesignSpace — US-5.1
+    getDesignSpaceTesserae: async (dsId: string): Promise<TesseraNode[]> => {
+        const VALOR_NS = 'https://valor-ecosystem.nl/ontology/';
+        const query = `
+PREFIX valor: <${VALOR_NS}>
+SELECT ?node ?content ?status ?type WHERE {
+  ?node a valor:Tessera ;
+        valor:claimContent ?content ;
+        valor:epistemicStatus ?status .
+  OPTIONAL { ?node valor:claimType ?type . }
+}`.trim();
+        const response = await apiClient.get<{ results: { bindings: Array<{ node: { value: string }; content: { value: string }; status: { value: string }; type?: { value: string } }> } }>(
+            `/designspace/${dsId}/sparql`,
+            { params: { query } }
+        );
+        return response.data.results.bindings.map(b => {
+            const uri = b.node.value;
+            const id = uri.split(':').pop() ?? uri;
+            return {
+                id,
+                uri,
+                claimContent: b.content.value,
+                epistemicStatus: b.status.value.split('/').pop()?.split('#').pop() ?? b.status.value,
+                claimType: b.type ? (b.type.value.split('/').pop() ?? 'AsIs') : 'AsIs',
+            };
+        });
+    },
+
     // Argumentatiediagram (IBIS-stijl) — US-5.1
     getArgumentationNetwork: async (dsId: string, argueTypes: ArgueType[]): Promise<ArgumentationNetwork> => {
         const VALOR_NS = 'https://valor-ecosystem.nl/ontology/';

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -605,6 +605,11 @@ export const api = {
     },
 
     // Threads (Fuseki-backed disc endpoints, Epic 16)
+    getDesignSpaceMembers: async (dsId: string): Promise<{ id: string; name: string; email: string; role: string }[]> => {
+        const response = await apiClient.get(`/designspace/${dsId}/members`);
+        return response.data;
+    },
+
     getCanResolveThread: async (designSpaceId: string): Promise<{ can_resolve: boolean }> => {
         const response = await apiClient.get<{ can_resolve: boolean }>(`/designspace/${designSpaceId}/can-resolve`);
         return response.data;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -649,37 +649,38 @@ export const api = {
         return response.data;
     },
 
+    // Argue-relatietypes uit de ontologie — US-5.1
+    getArgueTypes: async (): Promise<ArgueType[]> => {
+        const response = await apiClient.get<ArgueType[]>('/tessera/argue-types');
+        return response.data;
+    },
+
     // Argumentatiediagram (IBIS-stijl) — US-5.1
-    getArgumentationNetwork: async (dsId: string): Promise<ArgumentationNetwork> => {
+    getArgumentationNetwork: async (dsId: string, argueTypes: ArgueType[]): Promise<ArgumentationNetwork> => {
         const VALOR_NS = 'https://valor-ecosystem.nl/ontology/';
+        const uriValues = argueTypes.map(t => `<${t.uri}>`).join('\n    ');
         const query = `
 PREFIX valor: <${VALOR_NS}>
-SELECT ?source ?sourceContent ?sourceStatus ?sourceType ?rel ?relLabel ?target ?targetContent ?targetStatus ?targetType
+SELECT ?source ?sourceContent ?sourceStatus ?sourceType ?rel ?target ?targetContent ?targetStatus ?targetType
 WHERE {
-  GRAPH <urn:valor:ds:${dsId}> {
-    ?source a valor:Tessera ;
-            valor:claimContent ?sourceContent ;
-            valor:epistemicStatus ?sourceStatus .
-    OPTIONAL { ?source valor:claimType ?sourceType . }
-    ?source ?rel ?target .
-    ?target a valor:Tessera ;
-            valor:claimContent ?targetContent ;
-            valor:epistemicStatus ?targetStatus .
-    OPTIONAL { ?target valor:claimType ?targetType . }
-  }
-  GRAPH <urn:valor:tessera> {
-    ?rel a <http://www.w3.org/2002/07/owl#ObjectProperty> ;
-         <http://www.w3.org/2000/01/rdf-schema#domain> valor:Tessera ;
-         <http://www.w3.org/2000/01/rdf-schema#range> valor:Tessera ;
-         <http://www.w3.org/2000/01/rdf-schema#label> ?relLabel .
-    FILTER(lang(?relLabel) = "en")
+  ?source a valor:Tessera ;
+          valor:claimContent ?sourceContent ;
+          valor:epistemicStatus ?sourceStatus .
+  OPTIONAL { ?source valor:claimType ?sourceType . }
+  ?source ?rel ?target .
+  ?target a valor:Tessera ;
+          valor:claimContent ?targetContent ;
+          valor:epistemicStatus ?targetStatus .
+  OPTIONAL { ?target valor:claimType ?targetType . }
+  VALUES ?rel {
+    ${uriValues}
   }
 }`.trim();
         const response = await apiClient.get<ArgumentationNetworkRaw>(
             `/designspace/${dsId}/sparql`,
             { params: { query } }
         );
-        return parseArgumentationNetwork(response.data);
+        return parseArgumentationNetwork(response.data, argueTypes);
     },
 
     advanceSession: async (sessionId: string) => {
@@ -727,7 +728,13 @@ export interface DiscContribution {
 }
 
 // Argumentatiediagram types (US-5.1)
-export type ArgueRelationType = 'supports' | 'undermines' | 'qualifies' | 'presupposes';
+export type ArgueRelationType = string;
+
+export interface ArgueType {
+    uri: string;
+    label_en: string;
+    label_nl: string;
+}
 
 export interface TesseraNode {
     id: string;
@@ -742,6 +749,7 @@ export interface ArgumentEdge {
     targetId: string;
     relationType: ArgueRelationType;
     relationUri: string;
+    relationLabel: string;
 }
 
 export interface ArgumentationNetwork {
@@ -763,7 +771,6 @@ interface ArgumentationNetworkRaw {
             sourceStatus: SparqlBinding;
             sourceType?: SparqlBinding;
             rel: SparqlBinding;
-            relLabel: SparqlBinding;
             target: SparqlBinding;
             targetContent: SparqlBinding;
             targetStatus: SparqlBinding;
@@ -772,7 +779,8 @@ interface ArgumentationNetworkRaw {
     };
 }
 
-function parseArgumentationNetwork(raw: ArgumentationNetworkRaw): ArgumentationNetwork {
+function parseArgumentationNetwork(raw: ArgumentationNetworkRaw, argueTypes: ArgueType[]): ArgumentationNetwork {
+    const uriToLabel = new Map(argueTypes.map(t => [t.uri, t.label_nl]));
     const nodesMap = new Map<string, TesseraNode>();
     const edges: ArgumentEdge[] = [];
 
@@ -804,8 +812,9 @@ function parseArgumentationNetwork(raw: ArgumentationNetworkRaw): ArgumentationN
         edges.push({
             sourceId,
             targetId,
-            relationType: b.relLabel.value as ArgueRelationType,
+            relationType: b.rel.value.split('/').pop() ?? b.rel.value,
             relationUri: b.rel.value,
+            relationLabel: uriToLabel.get(b.rel.value) ?? b.rel.value.split('/').pop() ?? b.rel.value,
         });
     }
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -91,7 +91,7 @@ export type ConsentVoteType = 'approve' | 'object';
 
 export interface ConsentVotePayload {
     session_id: string;
-    claim_version_id: string;
+    tessera_base_id: string;
     vote: ConsentVoteType;
     motivation?: string;
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -654,6 +654,34 @@ export const api = {
         return response.data;
     },
 
+    // DecisionTimeline (US-5.4)
+    getDecisionTimeline: async (dsId: string): Promise<DecisionEpisodeRaw[]> => {
+        const query = `
+PREFIX valor: <https://valor-ecosystem.nl/ontology/>
+PREFIX prov: <https://www.w3.org/ns/prov#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT ?episode ?type ?phase ?startedAt ?startedBy ?vote ?voteType ?castBy ?onTessera WHERE {
+  ?episode a ?type .
+  FILTER(?type IN (valor:DecisionEpisode, valor:PhaseTransition))
+  OPTIONAL { ?episode valor:forPhase ?phase }
+  OPTIONAL { ?episode prov:startedAtTime ?startedAt }
+  OPTIONAL { ?episode prov:wasStartedBy ?startedBy }
+  OPTIONAL {
+    ?episode valor:hasVote ?vote .
+    ?vote valor:voteType ?voteType ;
+          valor:castBy ?castBy .
+    OPTIONAL { ?vote valor:onTessera ?onTessera }
+  }
+}
+ORDER BY DESC(?startedAt)`.trim();
+        const response = await apiClient.get<DecisionTimelineRaw>(
+            `/designspace/${dsId}/sparql`,
+            { params: { query } }
+        );
+        return parseDecisionTimeline(response.data);
+    },
+
     // Argue-relatietypes uit de ontologie — US-5.1
     getArgueTypes: async (): Promise<ArgueType[]> => {
         const response = await apiClient.get<ArgueType[]>('/tessera/argue-types');
@@ -824,6 +852,79 @@ function parseArgumentationNetwork(raw: ArgumentationNetworkRaw, argueTypes: Arg
     }
 
     return { nodes: Array.from(nodesMap.values()), edges };
+}
+
+// DecisionTimeline types (US-5.4)
+export interface DecisionVote {
+    voteUri: string;
+    voteType: string;
+    castBy: string;
+    onTessera: string | null;
+}
+
+export interface DecisionEpisodeRaw {
+    episodeUri: string;
+    type: 'DecisionEpisode' | 'PhaseTransition';
+    phase: string | null;
+    startedAt: string | null;
+    startedBy: string | null;
+    votes: DecisionVote[];
+}
+
+interface DecisionTimelineSparqlBinding {
+    episode: SparqlBinding;
+    type: SparqlBinding;
+    phase?: SparqlBinding;
+    startedAt?: SparqlBinding;
+    startedBy?: SparqlBinding;
+    vote?: SparqlBinding;
+    voteType?: SparqlBinding;
+    castBy?: SparqlBinding;
+    onTessera?: SparqlBinding;
+}
+
+interface DecisionTimelineRaw {
+    results: {
+        bindings: DecisionTimelineSparqlBinding[];
+    };
+}
+
+function parseDecisionTimeline(raw: DecisionTimelineRaw): DecisionEpisodeRaw[] {
+    const episodesMap = new Map<string, DecisionEpisodeRaw>();
+
+    for (const b of raw.results.bindings) {
+        const episodeUri = b.episode.value;
+        const typeFragment = b.type.value.split('/').pop()?.split('#').pop() ?? 'DecisionEpisode';
+        const episodeType: 'DecisionEpisode' | 'PhaseTransition' =
+            typeFragment === 'PhaseTransition' ? 'PhaseTransition' : 'DecisionEpisode';
+
+        if (!episodesMap.has(episodeUri)) {
+            episodesMap.set(episodeUri, {
+                episodeUri,
+                type: episodeType,
+                phase: b.phase ? (b.phase.value.split('/').pop() ?? b.phase.value) : null,
+                startedAt: b.startedAt?.value ?? null,
+                startedBy: b.startedBy?.value ?? null,
+                votes: [],
+            });
+        }
+
+        const episode = episodesMap.get(episodeUri)!;
+        if (b.vote && b.voteType && b.castBy) {
+            const voteUri = b.vote.value;
+            const alreadyAdded = episode.votes.some(v => v.voteUri === voteUri);
+            if (!alreadyAdded) {
+                episode.votes.push({
+                    voteUri,
+                    voteType: b.voteType.value.split('/').pop() ?? b.voteType.value,
+                    castBy: b.castBy.value,
+                    onTessera: b.onTessera?.value ?? null,
+                });
+            }
+        }
+    }
+
+    return Array.from(episodesMap.values());
 }
 
 export type LifecycleStatus = 'draft' | 'proposed' | 'accepted' | 'rejected' | 'deprecated';

--- a/frontend/src/services/sessions.ts
+++ b/frontend/src/services/sessions.ts
@@ -48,7 +48,7 @@ export const sessionService: SessionService = {
     async submitFeedback(sessionId: string, claimVersionId: string, color: string, motivation?: string): Promise<void> {
         await apiClient.post('/deliberation/feedback', {
             session_id: sessionId,
-            claim_version_id: claimVersionId,
+            tessera_base_id: claimVersionId,
             color,
             motivation
         });
@@ -66,7 +66,7 @@ export const sessionService: SessionService = {
     async submitRanking(sessionId: string, claimVersionId: string, category: string): Promise<void> {
         await apiClient.post('/deliberation/rank', {
             session_id: sessionId,
-            claim_version_id: claimVersionId,
+            tessera_base_id: claimVersionId,
             category
         });
     },

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -40,6 +40,7 @@ export interface Ranking {
 export interface Participation {
     user_id: string;
     user_name: string;
+    name?: string;
     has_completed_refinement?: boolean;
     has_completed_ranking?: boolean;
     has_completed_consent?: boolean;

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -24,7 +24,7 @@ export interface SessionContext {
 export interface Feedback {
     id: string;
     session_id: string;
-    claim_version_id: string;
+    tessera_base_id: string;
     user_id: string;
     color: 'green' | 'amber' | 'red';
     motivation?: string;
@@ -32,7 +32,7 @@ export interface Feedback {
 }
 
 export interface Ranking {
-    claim_version_id: string;
+    tessera_base_id: string;
     category: 'high' | 'medium' | 'backlog' | 'discard';
     count: number;
 }


### PR DESCRIPTION
## Samenvatting

- **US-5.0** — Deliberation gemigreerd van `ClaimVersion` (Neo4j) naar `tessera_base_id` (Fuseki)
- **US-5.1** — Argumentatiediagram: Factor-Tesserae als nodes, CausalClaim-Tesserae als edges via `fromFactor`/`toFactor`/`polarity` (conform VALOR-O 00h-causa.trig)
- **US-5.2** — Consent votes dual-written naar Fuseki als `valor:Vote`
- **US-5.3** — PhaseTransition geschreven naar Fuseki als `valor:PhaseTransition` bij `finalize_deliberation`
- **US-5.4** — DecisionTimeline leest DecisionEpisodes via SPARQL uit Fuseki
- **VersionLayout refactor** — sidebar + topbalk (agent-tabs, PhaseSelector, focusmodus) gedeeld over alle `/designspace/:dsId` views; ValorWorkspace is pure canvas

## Geblokkeerde stories (wachten op andere Epics)
US-5.5 t/m US-5.8 (gate-checks) — afhankelijk van Epic 4, 9, 12

## Testplan
- [ ] Argumentatiediagram toont factors als nodes en claims als gekleurde edges
- [ ] Fase-switcher werkt voor alle views (werkruimte, argumentatie, tijdlijn)
- [ ] Deliberatieronden (refine/ranking/consent) werken ongewijzigd
- [ ] PhaseTransition zichtbaar in Fuseki na afronden consent-ronde
- [ ] DecisionTimeline toont episodes chronologisch

Closes #272