### PR TITLE
feat(tessera-engine): PROV-O logging per Tessera-operatie (US-T.4)

### DIFF
--- a/backend/app/routers/designspace.py
+++ b/backend/app/routers/designspace.py
@@ -1,6 +1,7 @@
 import logging
 import uuid
 from datetime import datetime, timezone
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
@@ -531,6 +532,77 @@ INSERT DATA {{
         has_voting_right=rol["voting_right"],
         added_at=added_at,
     )
+
+
+class DesignSpaceProvenanceActivity(BaseModel):
+    activity_uri: str
+    operation_type: str
+    attributed_to: str
+    started_at: str
+    generated: Optional[str] = None
+    used: list[str] = []
+
+
+@router.get("/{design_space_id}/provenance", response_model=list[DesignSpaceProvenanceActivity])
+async def get_design_space_provenance(
+    design_space_id: str,
+    user: dict = Depends(get_current_user),
+) -> list[DesignSpaceProvenanceActivity]:
+    """Geeft de volledige PROV-O activiteitenketen terug voor een DesignSpace."""
+    user_id = user["id"]
+
+    if not await check_permission(user_id, design_space_id, Role.VIEWER):
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten voor deze DesignSpace.")
+
+    prov_graph = f"urn:valor:ds:{design_space_id}/provenance"
+    PROV_NS = "https://www.w3.org/ns/prov#"
+
+    rows = await sparql_select(
+        f"""PREFIX prov: <{PROV_NS}>
+SELECT ?activity ?opType ?agent ?startedAt ?generated WHERE {{
+  GRAPH <{prov_graph}> {{
+    ?activity a prov:Activity ;
+      <urn:valor:operationType> ?opType ;
+      prov:wasAttributedTo ?agent ;
+      prov:startedAtTime ?startedAt .
+    OPTIONAL {{ ?activity prov:generated ?generated . }}
+  }}
+}}
+ORDER BY ?startedAt""",
+        f"{design_space_id}/provenance",
+    )
+
+    used_rows = await sparql_select(
+        f"""PREFIX prov: <{PROV_NS}>
+SELECT ?activity ?used WHERE {{
+  GRAPH <{prov_graph}> {{
+    ?activity a prov:Activity ;
+      prov:used ?used .
+  }}
+}}""",
+        f"{design_space_id}/provenance",
+    )
+
+    used_by_activity: dict[str, list[str]] = {}
+    for r in used_rows:
+        used_by_activity.setdefault(r["activity"], []).append(r["used"])
+
+    results = []
+    for row in rows:
+        activity_uri = row["activity"]
+        op_uri = row["opType"]
+        op_label = op_uri.rsplit(":", 1)[-1]
+        agent = row["agent"].rsplit(":", 1)[-1]
+        results.append(DesignSpaceProvenanceActivity(
+            activity_uri=activity_uri,
+            operation_type=op_label,
+            attributed_to=agent,
+            started_at=row["startedAt"],
+            generated=row.get("generated"),
+            used=used_by_activity.get(activity_uri, []),
+        ))
+
+    return results
 
 
 @router.get("/{design_space_id}/participants", response_model=list[ParticipantResponse])

--- a/backend/app/routers/tessera.py
+++ b/backend/app/routers/tessera.py
@@ -1,3 +1,4 @@
+import asyncio
 import uuid
 import logging
 from datetime import datetime, timezone
@@ -204,12 +205,12 @@ INSERT DATA {{
 
     await sparql_update(sparql, request.design_space_id)
 
-    await record_provenance_activity(
+    asyncio.create_task(record_provenance_activity(
         request.design_space_id,
         "TesseraCreated",
         user_uri,
         generated=tessera_uri,
-    )
+    ))
 
     logger.info("Tessera aangemaakt: %s in DesignSpace %s door %s", tessera_uri, request.design_space_id, user_id)
 
@@ -409,13 +410,13 @@ WHERE {{
 
     await sparql_update(update, request.design_space_id)
 
-    await record_provenance_activity(
+    asyncio.create_task(record_provenance_activity(
         request.design_space_id,
         "RealisedByLinked",
         f"urn:valor:user:{user_id}",
         used=[tessera_uri],
         extra_props=[(f"{CAUSA_NS}realisedBy", request.transaction_type_uri)],
-    )
+    ))
 
     logger.info(
         "Tessera %s gekoppeld aan TransactionType %s door %s",
@@ -521,7 +522,7 @@ WHERE {{
 
     status_label_to_uri_map = get_status_label_to_uri()
     old_status_uri = status_label_to_uri_map.get(current_status, current_raw)
-    await record_provenance_activity(
+    asyncio.create_task(record_provenance_activity(
         request.design_space_id,
         "StatusChanged",
         f"urn:valor:user:{user_id}",
@@ -530,7 +531,7 @@ WHERE {{
             (f"{VALOR_NS}previousStatus", old_status_uri),
             (f"{VALOR_NS}newStatus", new_status_uri),
         ],
-    )
+    ))
 
     logger.info(
         "Tessera %s status: %s → %s (door %s)",
@@ -746,13 +747,13 @@ WHERE {{
                     contested_triggered = True
                     logger.info("Tessera %s naar Contested door undermines van %s", target_uri, source_uri)
 
-    await record_provenance_activity(
+    asyncio.create_task(record_provenance_activity(
         request.design_space_id,
         "ArgumentAdded",
         f"urn:valor:user:{user_id}",
         used=[source_uri, target_uri],
         extra_props=[(relation_uri, target_uri)],
-    )
+    ))
 
     logger.info(
         "Argumentatierelatie: %s -[%s]-> %s (door %s)",

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -591,6 +591,11 @@ export const api = {
         return response.data;
     },
 
+    getProvenance: async (dsId: string): Promise<{ activity_uri: string; operation_type: string; attributed_to: string; started_at: string; generated?: string; used: string[] }[]> => {
+        const response = await apiClient.get(`/designspace/${dsId}/provenance`);
+        return response.data;
+    },
+
     getDesignSpacesByProject: async (projectId: string, themeId?: string): Promise<{ id: string; name: string; status: string; current_phase: string }[]> => {
         const response = await apiClient.get(`/designspace/by-project/${projectId}`, {
             params: themeId ? { theme_id: themeId } : undefined,


### PR DESCRIPTION
## Summary

- Tessera schrijfoperaties (aanmaak, statusovergang, argue, realise) loggen nu een `prov:Activity` via `asyncio.create_task` — Fuseki-fouten blokkeren de response niet
- Nieuw endpoint `GET /designspace/{id}/provenance` retourneert de volledige activiteitenketen van een DesignSpace
- `getProvenance(dsId)` toegevoegd aan `frontend/src/services/api.ts`

## Wijzigingen

**`backend/app/routers/tessera.py`**
- `import asyncio` toegevoegd
- Alle vier `await record_provenance_activity(...)` aanroepen omgezet naar `asyncio.create_task(...)` (fire-and-forget)

**`backend/app/routers/designspace.py`**
- `from typing import Optional` toegevoegd
- `DesignSpaceProvenanceActivity` Pydantic model toegevoegd
- `GET /{design_space_id}/provenance` endpoint toegevoegd — retourneert alle `prov:Activity` records uit de provenance-graph, gesorteerd op `startedAtTime`

**`frontend/src/services/api.ts`**
- `getProvenance(dsId)` functie toegevoegd

## Test plan

- [ ] `POST /tessera/` aanmaken en daarna `GET /designspace/{id}/provenance` bevragen — activiteit met `TesseraCreated` verschijnt
- [ ] `PATCH /tessera/{id}/status` uitvoeren — activiteit met `StatusChanged` + `previousStatus`/`newStatus` verschijnt
- [ ] `POST /tessera/{id}/argue` uitvoeren — activiteit met `ArgumentAdded` verschijnt
- [ ] Fuseki offline simuleren bij aanmaak — response komt terug, geen 502
- [ ] `GET /designspace/{id}/provenance` op niet-bestaande DS geeft 403 of leeg resultaat

Closes #372