### PR TITLE
feat(tessera-engine): GDI-vlag TruthfulnessIssue op Tessera zonder Evidence (US-T.5)

### DIFF
--- a/backend/app/db/fuseki_knowledge.py
+++ b/backend/app/db/fuseki_knowledge.py
@@ -92,13 +92,14 @@ async def _find_tessera_uri_by_base_id(ds_id: str, base_id: str) -> Optional[str
 async def _sparql_get_factors(ds_id: str) -> list[dict]:
     asis_graph = _ds_asis_graph(ds_id)
     rows = await sparql_select_global(f"""
-SELECT ?tessera ?baseId ?name ?role ?description WHERE {{
+SELECT ?tessera ?baseId ?name ?role ?description ?gdiFlag WHERE {{
   GRAPH <{asis_graph}> {{
     ?tessera a <{VALOR_NS}Tessera> ;
              <{VALOR_NS}baseId> ?baseId ;
              <{VALOR_NS}claimContent> ?name ;
              <{VALOR_NS}factorRole> ?role .
     OPTIONAL {{ ?tessera <{VALOR_NS}description> ?description }}
+    OPTIONAL {{ ?tessera <{VALOR_NS}gdiFlag> ?gdiFlag }}
     FILTER NOT EXISTS {{ ?tessera <{VALOR_NS}fromFactor> ?x }}
   }}
 }}
@@ -112,6 +113,7 @@ SELECT ?tessera ?baseId ?name ?role ?description WHERE {{
             "type": row.get("role"),
             "theme_id": None,
             "thread_id": None,
+            "gdi_flag": row["gdiFlag"].rsplit("/", 1)[-1].rsplit("#", 1)[-1] if row.get("gdiFlag") else None,
         }
         for row in rows
     ]
@@ -151,7 +153,8 @@ async def create_factor_fuseki(
       <{VALOR_NS}epistemicStatus> <{proposed_uri}> ;
       <{VALOR_NS}claimedBy> <{user_uri}> ;
       <{VALOR_NS}claimedAt> "{claimed_at}"^^<{_XSD}dateTime> ;
-      <{VALOR_NS}inDesignSpace> <urn:valor:ds:{ds_id}> .
+      <{VALOR_NS}inDesignSpace> <urn:valor:ds:{ds_id}> ;
+      <{VALOR_NS}gdiFlag> <{VALOR_NS}TruthfulnessIssue> .
     {desc_triple}
   }}
 }}"""
@@ -236,7 +239,7 @@ async def _sparql_get_claims(ds_id: str, claim_type: Optional[str] = None) -> li
     rows = await sparql_select_global(f"""
 SELECT ?tessera ?baseId ?statement ?polarity ?confidence
        ?fromFactor ?sourceBaseId ?toFactor ?targetBaseId
-       ?evidenceText ?claimedAt ?manifestationCondition WHERE {{
+       ?evidenceText ?claimedAt ?manifestationCondition ?gdiFlag WHERE {{
   GRAPH <{asis_graph}> {{
     ?tessera a <{VALOR_NS}Tessera> ;
              <{VALOR_NS}baseId> ?baseId ;
@@ -251,6 +254,7 @@ SELECT ?tessera ?baseId ?statement ?polarity ?confidence
     OPTIONAL {{ ?tessera <{VALOR_NS}evidenceText> ?evidenceText }}
     OPTIONAL {{ ?tessera <{VALOR_NS}claimedAt>    ?claimedAt }}
     OPTIONAL {{ ?tessera <{_CAUSA_NS}hasManifestationCondition> ?manifestationCondition }}
+    OPTIONAL {{ ?tessera <{VALOR_NS}gdiFlag>      ?gdiFlag }}
   }}
 }}
 """)
@@ -274,6 +278,7 @@ SELECT ?tessera ?baseId ?statement ?polarity ?confidence
             "created_by": None,
             "status": None,
             "manifestation_condition": row.get("manifestationCondition"),
+            "gdi_flag": row["gdiFlag"].rsplit("/", 1)[-1].rsplit("#", 1)[-1] if row.get("gdiFlag") else None,
         }
         for row in rows
     ]
@@ -328,7 +333,8 @@ async def create_claim_fuseki(
       <{VALOR_NS}epistemicStatus> <{proposed_uri}> ;
       <{VALOR_NS}claimedBy> <{user_uri}> ;
       <{VALOR_NS}claimedAt> "{claimed_at}"^^<{_XSD}dateTime> ;
-      <{VALOR_NS}inDesignSpace> <urn:valor:ds:{ds_id}> .
+      <{VALOR_NS}inDesignSpace> <urn:valor:ds:{ds_id}> ;
+      <{VALOR_NS}gdiFlag> <{VALOR_NS}TruthfulnessIssue> .
     {evidence_triple}
   }}
 }}"""

--- a/backend/app/routers/tessera.py
+++ b/backend/app/routers/tessera.py
@@ -79,6 +79,7 @@ class TesseraResponse(BaseModel):
     in_phase: Optional[str] = None
     manifestation_condition: Optional[str] = None
     realised_by: Optional[str] = None
+    gdi_flag: Optional[str] = None
 
 
 class RealiseRequest(BaseModel):
@@ -205,6 +206,14 @@ INSERT DATA {{
 
     await sparql_update(sparql, request.design_space_id)
 
+    gdi_flag_sparql = f"""PREFIX valor: <{VALOR_NS}>
+INSERT DATA {{
+  GRAPH <{graph_uri}> {{
+    <{tessera_uri}> valor:gdiFlag valor:TruthfulnessIssue .
+  }}
+}}"""
+    asyncio.create_task(sparql_update(gdi_flag_sparql, request.design_space_id))
+
     asyncio.create_task(record_provenance_activity(
         request.design_space_id,
         "TesseraCreated",
@@ -227,6 +236,7 @@ INSERT DATA {{
         in_alternative=request.in_alternative,
         in_phase=request.in_phase,
         manifestation_condition=request.manifestation_condition,
+        gdi_flag="TruthfulnessIssue",
     )
 
 
@@ -314,7 +324,7 @@ async def get_tessera(
         graph_uri = named_graph_uri(design_space_id)
 
     rows = await sparql_select(
-        f"""SELECT ?content ?claimType ?uncertaintyLevel ?status ?claimedBy ?claimedAt ?inAlternative ?inPhase ?manifestationCondition ?realisedBy WHERE {{
+        f"""SELECT ?content ?claimType ?uncertaintyLevel ?status ?claimedBy ?claimedAt ?inAlternative ?inPhase ?manifestationCondition ?realisedBy ?gdiFlag WHERE {{
           GRAPH <{graph_uri}> {{
             <{tessera_uri}> a <{VALOR_NS}Tessera> ;
               <{VALOR_NS}claimContent> ?content ;
@@ -327,6 +337,7 @@ async def get_tessera(
             OPTIONAL {{ <{tessera_uri}> <{VALOR_NS}inPhase> ?inPhase . }}
             OPTIONAL {{ <{tessera_uri}> <{CAUSA_NS}hasManifestationCondition> ?manifestationCondition . }}
             OPTIONAL {{ <{tessera_uri}> <{CAUSA_NS}realisedBy> ?realisedBy . }}
+            OPTIONAL {{ <{tessera_uri}> <{VALOR_NS}gdiFlag> ?gdiFlag . }}
           }}
         }}""",
         design_space_id,
@@ -344,6 +355,9 @@ async def get_tessera(
     uncertainty_uri_to_label = {v: k for k, v in uncertainty_label_to_uri.items()}
     uncertainty_level = uncertainty_uri_to_label.get(raw_uncertainty) if raw_uncertainty else None
 
+    raw_gdi = row.get("gdiFlag", "")
+    gdi_flag = raw_gdi.rsplit("/", 1)[-1].rsplit("#", 1)[-1] if raw_gdi else None
+
     return TesseraResponse(
         tessera_id=tessera_id,
         tessera_uri=tessera_uri,
@@ -358,6 +372,7 @@ async def get_tessera(
         in_phase=row.get("inPhase"),
         manifestation_condition=row.get("manifestationCondition"),
         realised_by=row.get("realisedBy"),
+        gdi_flag=gdi_flag,
     )
 
 
@@ -607,6 +622,14 @@ INSERT DATA {{
 }}"""
 
     await sparql_update(sparql, request.design_space_id)
+
+    gdi_remove_sparql = f"""PREFIX valor: <{VALOR_NS}>
+DELETE DATA {{
+  GRAPH <{graph_uri}> {{
+    <{tessera_uri}> valor:gdiFlag valor:TruthfulnessIssue .
+  }}
+}}"""
+    asyncio.create_task(sparql_update(gdi_remove_sparql, request.design_space_id))
 
     logger.info("Evidence %s toegevoegd aan Tessera %s door %s", evidence_uri, tessera_uri, user_id)
 

--- a/backend/app/routers/tessera.py
+++ b/backend/app/routers/tessera.py
@@ -200,19 +200,12 @@ INSERT DATA {{
       valor:claimType <{claim_type_uri}> ;
       valor:claimedBy <{user_uri}> ;
       valor:claimedAt "{claimed_at}"^^xsd:dateTime ;
-      valor:inDesignSpace <{graph_uri}> .
+      valor:inDesignSpace <{graph_uri}> ;
+      valor:gdiFlag valor:TruthfulnessIssue .
 {optional_triples}  }}
 }}"""
 
     await sparql_update(sparql, request.design_space_id)
-
-    gdi_flag_sparql = f"""PREFIX valor: <{VALOR_NS}>
-INSERT DATA {{
-  GRAPH <{graph_uri}> {{
-    <{tessera_uri}> valor:gdiFlag valor:TruthfulnessIssue .
-  }}
-}}"""
-    asyncio.create_task(sparql_update(gdi_flag_sparql, request.design_space_id))
 
     asyncio.create_task(record_provenance_activity(
         request.design_space_id,

--- a/frontend/src/perspectives/causa/layout/mappers.ts
+++ b/frontend/src/perspectives/causa/layout/mappers.ts
@@ -20,7 +20,8 @@ export const mapFactorToNode = (factor: Factor): CausalNode => {
         role: factor.type,
         description: factor.description,
         epistemicStatus: normalizeEpistemicStatus(factor.epistemic_status),
-        version_id: factor.version_id
+        version_id: factor.version_id,
+        gdiFlag: factor.gdi_flag ?? undefined,
     };
 };
 

--- a/frontend/src/perspectives/causa/types.ts
+++ b/frontend/src/perspectives/causa/types.ts
@@ -13,6 +13,7 @@ export interface CausalNode {
     description?: string;
     epistemicStatus?: EpistemicStatus;
     version_id?: string;
+    gdiFlag?: string;
 }
 
 export interface CausalLink {

--- a/frontend/src/perspectives/causa/views/CLDView.tsx
+++ b/frontend/src/perspectives/causa/views/CLDView.tsx
@@ -160,6 +160,7 @@ export const CLDView: FunctionComponent<CLDViewProps> = ({
                         role: cn.role,
                         description: cn.description,
                         epistemicStatus: cn.epistemicStatus,
+                        gdiFlag: cn.gdiFlag,
                         threadCount: (cn.version_id && threadStats[cn.version_id]) || 0,
                         version_id: cn.version_id,
                         onOpenThread: handleOpenThread,

--- a/frontend/src/perspectives/causa/views/nodes/CLDNode.tsx
+++ b/frontend/src/perspectives/causa/views/nodes/CLDNode.tsx
@@ -1,6 +1,6 @@
 import { memo, type FunctionComponent, type MouseEvent } from 'react';
 import { Handle, Position, type NodeProps } from 'reactflow';
-import { Wrench, Cloud, Cpu, Target, HelpCircle, MessageSquare, type LucideProps } from 'lucide-react';
+import { Wrench, Cloud, Cpu, Target, HelpCircle, MessageSquare, TriangleAlert, type LucideProps } from 'lucide-react';
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -61,6 +61,7 @@ const CLDNode: FunctionComponent<NodeProps> = ({ id, data, selected }) => {
     const isReadOnly = data.isReadOnly || false;
     const isInCycle = data.isInCycle || false;
     const epistemicStatus = (data.epistemicStatus || 'Proposed') as EpistemicStatus;
+    const hasGdiFlag = !!data.gdiFlag;
 
     const Icon = iconMap[role] || iconMap.unknown;
     const styles = roleStyles[role] || roleStyles.unknown;
@@ -135,6 +136,11 @@ const CLDNode: FunctionComponent<NodeProps> = ({ id, data, selected }) => {
 
             {/* Footer: rol-icoon + status-badge */}
             <div className="absolute bottom-2 right-2 flex items-center gap-1">
+                {hasGdiFlag && (
+                    <span title="Epistemisch kwetsbaar — geen bewijs" className="text-amber-500">
+                        <TriangleAlert size={12} />
+                    </span>
+                )}
                 <span
                     className={cn('w-2 h-2 rounded-full', statusStyle.dot)}
                     title={statusStyle.label}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -54,6 +54,7 @@ export interface Claim {
     status?: string;
     evidence_text?: string;
     evidence_url?: string;
+    gdi_flag?: string;
 }
 
 export interface ValidationResult {
@@ -104,6 +105,7 @@ export interface Factor {
     version_id?: string;
     thread_id?: string;
     epistemic_status?: string;
+    gdi_flag?: string;
 }
 
 export interface Organization {


### PR DESCRIPTION
## Summary

- Alle nieuwe Tesserae (Factor + Claim via `fuseki_knowledge.py`, én via `tessera.py` router) krijgen automatisch `valor:gdiFlag valor:TruthfulnessIssue` bij aanmaak
- Flag wordt verwijderd via `asyncio.create_task` (fire-and-forget) bij toevoegen van een volledig Evidence-object (`POST /tessera/{id}/evidence`)
- `GET /tessera/{id}` retourneert `gdi_flag`-veld in de response
- `_sparql_get_factors` en `_sparql_get_claims` in `fuseki_knowledge.py` retourneren `gdi_flag` via `OPTIONAL { ?tessera valor:gdiFlag ?gdiFlag }`
- Frontend: `CLDNode` toont een amber `TriangleAlert`-icoon als `gdiFlag` gezet is, met tooltip "Epistemisch kwetsbaar — geen bewijs"

## Gewijzigde bestanden

- `backend/app/db/fuseki_knowledge.py` — gdi_flag in create_factor_fuseki, create_claim_fuseki, _sparql_get_factors, _sparql_get_claims
- `backend/app/routers/tessera.py` — TesseraResponse.gdi_flag, create_tessera INSERT, get_tessera OPTIONAL, add_evidence DELETE
- `frontend/src/services/api.ts` — Factor.gdi_flag, Claim.gdi_flag
- `frontend/src/perspectives/causa/types.ts` — CausalNode.gdiFlag
- `frontend/src/perspectives/causa/layout/mappers.ts` — mapFactorToNode
- `frontend/src/perspectives/causa/views/CLDView.tsx` — gdiFlag doorgeven aan node data
- `frontend/src/perspectives/causa/views/nodes/CLDNode.tsx` — TriangleAlert badge

## Test plan

- [ ] Factor aanmaken → `GET /designspace/{id}/factors` retourneert `gdi_flag: "TruthfulnessIssue"`
- [ ] Claim aanmaken → `GET /designspace/{id}/claims` retourneert `gdi_flag: "TruthfulnessIssue"`
- [ ] Tessera aanmaken via `POST /tessera/` → response bevat `gdi_flag: "TruthfulnessIssue"`
- [ ] Evidence toevoegen via `POST /tessera/{id}/evidence` → `GET /tessera/{id}` retourneert `gdi_flag: null`
- [ ] CLDView: Factor-node toont amber waarschuwingsicoon

Closes #384