### PR TITLE
feat(tessera-engine): conflictdetectie via valor:undermines + WebSocket-broadcasts (US-T.1 + US-T.3)

### DIFF
--- a/backend/app/routers/designspace.py
+++ b/backend/app/routers/designspace.py
@@ -26,7 +26,7 @@ from app.ontology import VALOR_NS
 from app.db.fuseki_knowledge import get_condition_coverage, create_claim_coverage_assessment, get_asis_condition_coverage
 from app.services.fuseki import (
     initialize_design_space_graphs, initialize_alternative_graph,
-    sparql_proxy_query, sparql_select, sparql_update,
+    sparql_proxy_query, sparql_select, sparql_select_global, sparql_update,
 )
 
 logger = logging.getLogger(__name__)
@@ -603,6 +603,40 @@ SELECT ?activity ?used WHERE {{
         ))
 
     return results
+
+
+@router.get("/{design_space_id}/conflicts")
+async def get_conflicts(
+    design_space_id: str,
+    user: dict = Depends(get_current_user),
+) -> list[dict]:
+    """Geeft alle actieve valor:ConflictSignal resources terug voor een DesignSpace."""
+    if not await check_permission(user["id"], design_space_id, Role.VIEWER):
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten voor deze DesignSpace.")
+
+    prov_graph = f"urn:valor:ds:{design_space_id}/provenance"
+    rows = await sparql_select_global(
+        f"""SELECT ?signal ?tessera1 ?tessera2 ?detectedAt WHERE {{
+  GRAPH <{prov_graph}> {{
+    ?signal a <{VALOR_NS}ConflictSignal> ;
+      <{VALOR_NS}conflictingTessera> ?tessera1 ;
+      <{VALOR_NS}conflictingTessera> ?tessera2 ;
+      <{VALOR_NS}detectedAt> ?detectedAt .
+    FILTER(str(?tessera1) < str(?tessera2))
+  }}
+}}
+ORDER BY DESC(?detectedAt)""",
+    )
+
+    return [
+        {
+            "conflict_uri": row["signal"],
+            "tessera_a": row["tessera1"],
+            "tessera_b": row["tessera2"],
+            "detected_at": row["detectedAt"],
+        }
+        for row in rows
+    ]
 
 
 @router.get("/{design_space_id}/participants", response_model=list[ParticipantResponse])

--- a/backend/app/routers/tessera.py
+++ b/backend/app/routers/tessera.py
@@ -453,6 +453,65 @@ WHERE {{
     )
 
 
+async def _detect_conflicts_async(
+    tessera_uri: str,
+    design_space_id: str,
+    accepted_status_uri: str,
+):
+    """
+    Fire-and-forget conflictdetectie na statusovergang naar Accepted.
+    Detecteert valor:undermines conflicten tussen Accepted Tesserae en schrijft
+    een valor:ConflictSignal naar de provenance graph.
+
+    # TODO: semantische conflictdetectie op basis van claimContent (NLP/embeddings) — zie #477
+    """
+    rows = await sparql_select(
+        f"""SELECT DISTINCT ?other WHERE {{
+          {{
+            <{tessera_uri}> <{VALOR_NS}undermines> ?other .
+            ?other <{VALOR_NS}epistemicStatus> <{accepted_status_uri}> .
+          }} UNION {{
+            ?other <{VALOR_NS}undermines> <{tessera_uri}> .
+            ?other <{VALOR_NS}epistemicStatus> <{accepted_status_uri}> .
+          }}
+        }}""",
+        design_space_id,
+    )
+
+    if not rows:
+        return
+
+    prov_graph = f"urn:valor:ds:{design_space_id}/provenance"
+    detected_at = datetime.now(timezone.utc).isoformat()
+
+    for row in rows:
+        other_uri = row["other"]
+        conflict_uri = f"urn:valor:conflict:{uuid.uuid4()}"
+        signal_sparql = f"""PREFIX valor: <{VALOR_NS}>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+INSERT DATA {{
+  GRAPH <{prov_graph}> {{
+    <{conflict_uri}> a valor:ConflictSignal ;
+      valor:conflictingTessera <{tessera_uri}> ;
+      valor:conflictingTessera <{other_uri}> ;
+      valor:detectedAt "{detected_at}"^^xsd:dateTime .
+  }}
+}}"""
+        await sparql_update(signal_sparql, design_space_id)
+        logger.warning("Conflict gesignaleerd: %s ↔ %s in DesignSpace %s", tessera_uri, other_uri, design_space_id)
+
+    project_id = await fuseki_knowledge.get_project_id_for_designspace(design_space_id)
+    if project_id:
+        await manager.broadcast_data(project_id, {
+            "type": "TESSERA_CONFLICT_DETECTED",
+            "payload": {
+                "tessera_uri": tessera_uri,
+                "design_space_id": design_space_id,
+                "conflicting_tesserae": [row["other"] for row in rows],
+            },
+        })
+
+
 @router.patch("/{tessera_id}/status", response_model=PatchTesseraStatusResponse)
 async def patch_tessera_status(
     tessera_id: str,
@@ -554,6 +613,13 @@ WHERE {{
             (f"{VALOR_NS}newStatus", new_status_uri),
         ],
     ))
+
+    if request.new_status == "Accepted":
+        asyncio.create_task(_detect_conflicts_async(
+            tessera_uri,
+            request.design_space_id,
+            new_status_uri,
+        ))
 
     if request.new_status == "Contested":
         project_id = await fuseki_knowledge.get_project_id_for_designspace(request.design_space_id)

--- a/backend/tests/integration/test_conflict_detection.py
+++ b/backend/tests/integration/test_conflict_detection.py
@@ -1,0 +1,229 @@
+"""Integratietests voor conflictdetectie (US-T.1).
+
+Test:
+- ConflictSignal wordt aangemaakt wanneer twee Accepted Tesserae een valor:undermines relatie hebben
+- ConflictSignal blijft afwezig wanneer er geen undermines relatie is
+- ConflictSignal blijft afwezig wanneer slechts één Tessera Accepted is
+- GET /designspace/{ds_id}/conflicts geeft aanwezige ConflictSignals terug
+"""
+import asyncio
+import uuid
+
+import httpx
+import pytest
+
+from app.ontology import VALOR_NS
+from tests.conftest import FUSEKI_TEST_URL, FUSEKI_TEST_DATASET
+
+pytestmark = pytest.mark.integration
+
+XSD_NS = "http://www.w3.org/2001/XMLSchema#"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _sparql_update(update: str) -> None:
+    from tests.conftest import FUSEKI_ADMIN_PASSWORD
+    endpoint = f"{FUSEKI_TEST_URL}/{FUSEKI_TEST_DATASET}/update"
+    async with httpx.AsyncClient() as client:
+        r = await client.post(
+            endpoint,
+            data={"update": update},
+            auth=("admin", FUSEKI_ADMIN_PASSWORD),
+            timeout=10,
+        )
+    r.raise_for_status()
+
+
+async def _sparql_select(sparql: str) -> list[dict]:
+    endpoint = f"{FUSEKI_TEST_URL}/{FUSEKI_TEST_DATASET}/sparql"
+    async with httpx.AsyncClient() as client:
+        r = await client.post(
+            endpoint,
+            data={"query": sparql},
+            headers={"Accept": "application/sparql-results+json"},
+            timeout=10,
+        )
+    r.raise_for_status()
+    return r.json()["results"]["bindings"]
+
+
+async def _seed_design_space(ds_id: str) -> None:
+    from app.services.fuseki import initialize_design_space_graphs
+    await initialize_design_space_graphs(ds_id, f"urn:valor:issue:{ds_id}")
+
+
+def _accepted_status_uri() -> str:
+    from app.services.ontology_cache import get_status_label_to_uri
+    return get_status_label_to_uri()["Accepted"]
+
+
+def _proposed_status_uri() -> str:
+    from app.services.ontology_cache import get_status_label_to_uri
+    return get_status_label_to_uri()["Proposed"]
+
+
+async def _insert_tessera(ds_id: str, tessera_id: str, status_uri: str) -> str:
+    """Schrijft een minimale Tessera naar de default graph van ds_id.
+
+    sparql_select(query, ds_id) gebruikt urn:valor:ds:{ds_id} als default-graph-uri,
+    dus de data moet in die graph staan zodat _detect_conflicts_async hem vindt.
+    """
+    tessera_uri = f"urn:valor:tessera:{tessera_id}"
+    graph = f"urn:valor:ds:{ds_id}"
+    await _sparql_update(f"""PREFIX valor: <{VALOR_NS}>
+INSERT DATA {{
+  GRAPH <{graph}> {{
+    <{tessera_uri}> a valor:Tessera ;
+      valor:epistemicStatus <{status_uri}> ;
+      valor:claimContent "Testclaim {tessera_id}" .
+  }}
+}}""")
+    return tessera_uri
+
+
+async def _insert_undermines(ds_id: str, tessera_a_uri: str, tessera_b_uri: str) -> None:
+    """Schrijft een valor:undermines triple in de default graph van ds_id."""
+    graph = f"urn:valor:ds:{ds_id}"
+    await _sparql_update(f"""PREFIX valor: <{VALOR_NS}>
+INSERT DATA {{
+  GRAPH <{graph}> {{
+    <{tessera_a_uri}> valor:undermines <{tessera_b_uri}> .
+  }}
+}}""")
+
+
+async def _count_conflict_signals(ds_id: str) -> int:
+    prov_graph = f"urn:valor:ds:{ds_id}/provenance"
+    rows = await _sparql_select(f"""SELECT (COUNT(?s) AS ?c) WHERE {{
+  GRAPH <{prov_graph}> {{
+    ?s a <{VALOR_NS}ConflictSignal> .
+  }}
+}}""")
+    return int(rows[0]["c"]["value"]) if rows else 0
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+async def test_no_conflict_without_undermines(ds_id: str) -> None:
+    """Twee Accepted Tesserae zonder undermines relatie -> geen ConflictSignal."""
+    await _seed_design_space(ds_id)
+    accepted = _accepted_status_uri()
+
+    tessera_a = await _insert_tessera(ds_id, f"a-{uuid.uuid4().hex[:8]}", accepted)
+    tessera_b = await _insert_tessera(ds_id, f"b-{uuid.uuid4().hex[:8]}", accepted)
+
+    from app.routers.tessera import _detect_conflicts_async
+    await _detect_conflicts_async(tessera_a, ds_id, accepted)
+    await _detect_conflicts_async(tessera_b, ds_id, accepted)
+
+    count = await _count_conflict_signals(ds_id)
+    assert count == 0, f"Geen ConflictSignal verwacht, maar {count} gevonden"
+
+
+async def test_conflict_detected_when_both_accepted(ds_id: str) -> None:
+    """Tessera A undermines Tessera B; beide Accepted -> ConflictSignal aangemaakt."""
+    await _seed_design_space(ds_id)
+    accepted = _accepted_status_uri()
+
+    tessera_a = await _insert_tessera(ds_id, f"a-{uuid.uuid4().hex[:8]}", accepted)
+    tessera_b = await _insert_tessera(ds_id, f"b-{uuid.uuid4().hex[:8]}", accepted)
+    await _insert_undermines(ds_id, tessera_a, tessera_b)
+
+    from app.routers.tessera import _detect_conflicts_async
+
+    # Simuleer: eerst A Accepted (B nog niet Accepted, dus geen conflict).
+    # Dan B Accepted (A is al Accepted, dus conflict).
+    await _detect_conflicts_async(tessera_b, ds_id, accepted)
+
+    count = await _count_conflict_signals(ds_id)
+    assert count == 1, f"Precies 1 ConflictSignal verwacht, maar {count} gevonden"
+
+    # Verifieer inhoud van het ConflictSignal
+    prov_graph = f"urn:valor:ds:{ds_id}/provenance"
+    rows = await _sparql_select(f"""SELECT ?signal ?ta ?tb ?det WHERE {{
+  GRAPH <{prov_graph}> {{
+    ?signal a <{VALOR_NS}ConflictSignal> ;
+      <{VALOR_NS}conflictingTessera> ?ta ;
+      <{VALOR_NS}conflictingTessera> ?tb ;
+      <{VALOR_NS}detectedAt> ?det .
+    FILTER(?ta != ?tb)
+  }}
+}}""")
+    assert rows, "ConflictSignal triples niet volledig aanwezig in provenance graph"
+    tessera_uris = {rows[0]["ta"]["value"], rows[0]["tb"]["value"]}
+    assert tessera_a in tessera_uris, f"{tessera_a} niet in conflictingTessera triples"
+    assert tessera_b in tessera_uris, f"{tessera_b} niet in conflictingTessera triples"
+    assert rows[0]["det"]["value"], "valor:detectedAt is leeg"
+
+
+async def test_no_conflict_when_only_one_accepted(ds_id: str) -> None:
+    """Tessera A undermines Tessera B; alleen A is Accepted -> geen ConflictSignal."""
+    await _seed_design_space(ds_id)
+    accepted = _accepted_status_uri()
+    proposed = _proposed_status_uri()
+
+    tessera_a = await _insert_tessera(ds_id, f"a-{uuid.uuid4().hex[:8]}", accepted)
+    tessera_b = await _insert_tessera(ds_id, f"b-{uuid.uuid4().hex[:8]}", proposed)
+    await _insert_undermines(ds_id, tessera_a, tessera_b)
+
+    from app.routers.tessera import _detect_conflicts_async
+    await _detect_conflicts_async(tessera_a, ds_id, accepted)
+
+    count = await _count_conflict_signals(ds_id)
+    assert count == 0, f"Geen ConflictSignal verwacht (B is Proposed), maar {count} gevonden"
+
+
+async def test_get_conflicts_endpoint_returns_signals(ds_id: str) -> None:
+    """GET /designspace/{ds_id}/conflicts geeft ConflictSignal data terug.
+
+    Schrijft een ConflictSignal direct naar de provenance graph en verifieert
+    dat het endpoint dit correct teruggeeft.
+    """
+
+    tessera_a_uri = f"urn:valor:tessera:conflict-a-{uuid.uuid4().hex[:8]}"
+    tessera_b_uri = f"urn:valor:tessera:conflict-b-{uuid.uuid4().hex[:8]}"
+    conflict_uri = f"urn:valor:conflict:{uuid.uuid4()}"
+    prov_graph = f"urn:valor:ds:{ds_id}/provenance"
+    detected_at = "2026-01-01T12:00:00+00:00"
+
+    await _sparql_update(f"""PREFIX valor: <{VALOR_NS}>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+INSERT DATA {{
+  GRAPH <{prov_graph}> {{
+    <{conflict_uri}> a valor:ConflictSignal ;
+      valor:conflictingTessera <{tessera_a_uri}> ;
+      valor:conflictingTessera <{tessera_b_uri}> ;
+      valor:detectedAt "{detected_at}"^^xsd:dateTime .
+  }}
+}}""")
+
+    import app.routers.designspace as ds_router
+    original_check = ds_router.check_permission
+
+    async def _allow_all(*args, **kwargs):
+        return True
+
+    ds_router.check_permission = _allow_all
+    try:
+        from app.routers.designspace import get_conflicts
+        result = await get_conflicts(
+            design_space_id=ds_id,
+            user={"id": "test-user-001"},
+        )
+    finally:
+        ds_router.check_permission = original_check
+
+    assert isinstance(result, list), "Verwacht een lijst"
+    assert len(result) == 1, f"Verwacht 1 conflict, maar {len(result)} gevonden"
+
+    conflict = result[0]
+    assert conflict["conflict_uri"] == conflict_uri
+    tessera_uris = {conflict["tessera_a"], conflict["tessera_b"]}
+    assert tessera_a_uri in tessera_uris
+    assert tessera_b_uri in tessera_uris
+    assert conflict["detected_at"] == detected_at


### PR DESCRIPTION
## Summary

- **US-T.1 (#369)**: Conflictdetectie via `valor:undermines` predicate
  - `_detect_conflicts_async` wordt fire-and-forget aangeroepen na elke Accepted-statusovergang
  - Schrijft `valor:ConflictSignal` naar de provenance graph van de DesignSpace
  - Broadcast `TESSERA_CONFLICT_DETECTED` via WebSocket naar alle clients in het project
  - `GET /designspace/{id}/conflicts` endpoint geeft alle actieve ConflictSignals terug
- **US-T.3 (#371)**: WebSocket-notificaties `TESSERA_PROPOSED` en `TESSERA_CONTESTED`
- **Integratietests**: 4/4 groen (conflictdetectie scenario's)

## Technische details

- `FILTER(str(?tessera1) < str(?tessera2))` gebruikt `str()` voor IRI-deduplicatie — directe IRI-vergelijking met `<` geeft type error in SPARQL 1.1
- Semantische conflictdetectie op basis van `claimContent` (NLP/embeddings) is uitgesteld naar US-T.1b (#477)

## Test plan

- [ ] `pytest tests/integration/test_conflict_detection.py` — 4/4 groen
- [ ] Handmatig: Tessera aanmaken → TESSERA_PROPOSED in WebSocket client
- [ ] Handmatig: Tessera status → Contested → TESSERA_CONTESTED in WebSocket client
- [ ] Handmatig: Twee Tesserae met `valor:undermines` + Accepted → ConflictSignal in provenance graph + TESSERA_CONFLICT_DETECTED event

Closes #369
Closes #371