### PR TITLE
Epic T — Tessera-engine v1.0 (#352)

### DIFF
--- a/backend/app/db/fuseki_knowledge.py
+++ b/backend/app/db/fuseki_knowledge.py
@@ -92,13 +92,14 @@ async def _find_tessera_uri_by_base_id(ds_id: str, base_id: str) -> Optional[str
 async def _sparql_get_factors(ds_id: str) -> list[dict]:
     asis_graph = _ds_asis_graph(ds_id)
     rows = await sparql_select_global(f"""
-SELECT ?tessera ?baseId ?name ?role ?description WHERE {{
+SELECT ?tessera ?baseId ?name ?role ?description ?gdiFlag WHERE {{
   GRAPH <{asis_graph}> {{
     ?tessera a <{VALOR_NS}Tessera> ;
              <{VALOR_NS}baseId> ?baseId ;
              <{VALOR_NS}claimContent> ?name ;
              <{VALOR_NS}factorRole> ?role .
     OPTIONAL {{ ?tessera <{VALOR_NS}description> ?description }}
+    OPTIONAL {{ ?tessera <{VALOR_NS}gdiFlag> ?gdiFlag }}
     FILTER NOT EXISTS {{ ?tessera <{VALOR_NS}fromFactor> ?x }}
   }}
 }}
@@ -112,6 +113,7 @@ SELECT ?tessera ?baseId ?name ?role ?description WHERE {{
             "type": row.get("role"),
             "theme_id": None,
             "thread_id": None,
+            "gdi_flag": row["gdiFlag"].rsplit("/", 1)[-1].rsplit("#", 1)[-1] if row.get("gdiFlag") else None,
         }
         for row in rows
     ]
@@ -151,7 +153,8 @@ async def create_factor_fuseki(
       <{VALOR_NS}epistemicStatus> <{proposed_uri}> ;
       <{VALOR_NS}claimedBy> <{user_uri}> ;
       <{VALOR_NS}claimedAt> "{claimed_at}"^^<{_XSD}dateTime> ;
-      <{VALOR_NS}inDesignSpace> <urn:valor:ds:{ds_id}> .
+      <{VALOR_NS}inDesignSpace> <urn:valor:ds:{ds_id}> ;
+      <{VALOR_NS}gdiFlag> <{VALOR_NS}TruthfulnessIssue> .
     {desc_triple}
   }}
 }}"""
@@ -236,7 +239,7 @@ async def _sparql_get_claims(ds_id: str, claim_type: Optional[str] = None) -> li
     rows = await sparql_select_global(f"""
 SELECT ?tessera ?baseId ?statement ?polarity ?confidence
        ?fromFactor ?sourceBaseId ?toFactor ?targetBaseId
-       ?evidenceText ?claimedAt ?manifestationCondition WHERE {{
+       ?evidenceText ?claimedAt ?manifestationCondition ?gdiFlag WHERE {{
   GRAPH <{asis_graph}> {{
     ?tessera a <{VALOR_NS}Tessera> ;
              <{VALOR_NS}baseId> ?baseId ;
@@ -251,6 +254,7 @@ SELECT ?tessera ?baseId ?statement ?polarity ?confidence
     OPTIONAL {{ ?tessera <{VALOR_NS}evidenceText> ?evidenceText }}
     OPTIONAL {{ ?tessera <{VALOR_NS}claimedAt>    ?claimedAt }}
     OPTIONAL {{ ?tessera <{_CAUSA_NS}hasManifestationCondition> ?manifestationCondition }}
+    OPTIONAL {{ ?tessera <{VALOR_NS}gdiFlag>      ?gdiFlag }}
   }}
 }}
 """)
@@ -274,6 +278,7 @@ SELECT ?tessera ?baseId ?statement ?polarity ?confidence
             "created_by": None,
             "status": None,
             "manifestation_condition": row.get("manifestationCondition"),
+            "gdi_flag": row["gdiFlag"].rsplit("/", 1)[-1].rsplit("#", 1)[-1] if row.get("gdiFlag") else None,
         }
         for row in rows
     ]
@@ -328,7 +333,8 @@ async def create_claim_fuseki(
       <{VALOR_NS}epistemicStatus> <{proposed_uri}> ;
       <{VALOR_NS}claimedBy> <{user_uri}> ;
       <{VALOR_NS}claimedAt> "{claimed_at}"^^<{_XSD}dateTime> ;
-      <{VALOR_NS}inDesignSpace> <urn:valor:ds:{ds_id}> .
+      <{VALOR_NS}inDesignSpace> <urn:valor:ds:{ds_id}> ;
+      <{VALOR_NS}gdiFlag> <{VALOR_NS}TruthfulnessIssue> .
     {evidence_triple}
   }}
 }}"""

--- a/backend/app/routers/designspace.py
+++ b/backend/app/routers/designspace.py
@@ -1,6 +1,7 @@
 import logging
 import uuid
 from datetime import datetime, timezone
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
@@ -531,6 +532,77 @@ INSERT DATA {{
         has_voting_right=rol["voting_right"],
         added_at=added_at,
     )
+
+
+class DesignSpaceProvenanceActivity(BaseModel):
+    activity_uri: str
+    operation_type: str
+    attributed_to: str
+    started_at: str
+    generated: Optional[str] = None
+    used: list[str] = []
+
+
+@router.get("/{design_space_id}/provenance", response_model=list[DesignSpaceProvenanceActivity])
+async def get_design_space_provenance(
+    design_space_id: str,
+    user: dict = Depends(get_current_user),
+) -> list[DesignSpaceProvenanceActivity]:
+    """Geeft de volledige PROV-O activiteitenketen terug voor een DesignSpace."""
+    user_id = user["id"]
+
+    if not await check_permission(user_id, design_space_id, Role.VIEWER):
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten voor deze DesignSpace.")
+
+    prov_graph = f"urn:valor:ds:{design_space_id}/provenance"
+    PROV_NS = "https://www.w3.org/ns/prov#"
+
+    rows = await sparql_select(
+        f"""PREFIX prov: <{PROV_NS}>
+SELECT ?activity ?opType ?agent ?startedAt ?generated WHERE {{
+  GRAPH <{prov_graph}> {{
+    ?activity a prov:Activity ;
+      <urn:valor:operationType> ?opType ;
+      prov:wasAttributedTo ?agent ;
+      prov:startedAtTime ?startedAt .
+    OPTIONAL {{ ?activity prov:generated ?generated . }}
+  }}
+}}
+ORDER BY ?startedAt""",
+        f"{design_space_id}/provenance",
+    )
+
+    used_rows = await sparql_select(
+        f"""PREFIX prov: <{PROV_NS}>
+SELECT ?activity ?used WHERE {{
+  GRAPH <{prov_graph}> {{
+    ?activity a prov:Activity ;
+      prov:used ?used .
+  }}
+}}""",
+        f"{design_space_id}/provenance",
+    )
+
+    used_by_activity: dict[str, list[str]] = {}
+    for r in used_rows:
+        used_by_activity.setdefault(r["activity"], []).append(r["used"])
+
+    results = []
+    for row in rows:
+        activity_uri = row["activity"]
+        op_uri = row["opType"]
+        op_label = op_uri.rsplit(":", 1)[-1]
+        agent = row["agent"].rsplit(":", 1)[-1]
+        results.append(DesignSpaceProvenanceActivity(
+            activity_uri=activity_uri,
+            operation_type=op_label,
+            attributed_to=agent,
+            started_at=row["startedAt"],
+            generated=row.get("generated"),
+            used=used_by_activity.get(activity_uri, []),
+        ))
+
+    return results
 
 
 @router.get("/{design_space_id}/participants", response_model=list[ParticipantResponse])

--- a/backend/app/routers/designspace.py
+++ b/backend/app/routers/designspace.py
@@ -26,7 +26,7 @@ from app.ontology import VALOR_NS
 from app.db.fuseki_knowledge import get_condition_coverage, create_claim_coverage_assessment, get_asis_condition_coverage
 from app.services.fuseki import (
     initialize_design_space_graphs, initialize_alternative_graph,
-    sparql_proxy_query, sparql_select, sparql_update,
+    sparql_proxy_query, sparql_select, sparql_select_global, sparql_update,
 )
 
 logger = logging.getLogger(__name__)
@@ -603,6 +603,40 @@ SELECT ?activity ?used WHERE {{
         ))
 
     return results
+
+
+@router.get("/{design_space_id}/conflicts")
+async def get_conflicts(
+    design_space_id: str,
+    user: dict = Depends(get_current_user),
+) -> list[dict]:
+    """Geeft alle actieve valor:ConflictSignal resources terug voor een DesignSpace."""
+    if not await check_permission(user["id"], design_space_id, Role.VIEWER):
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten voor deze DesignSpace.")
+
+    prov_graph = f"urn:valor:ds:{design_space_id}/provenance"
+    rows = await sparql_select_global(
+        f"""SELECT ?signal ?tessera1 ?tessera2 ?detectedAt WHERE {{
+  GRAPH <{prov_graph}> {{
+    ?signal a <{VALOR_NS}ConflictSignal> ;
+      <{VALOR_NS}conflictingTessera> ?tessera1 ;
+      <{VALOR_NS}conflictingTessera> ?tessera2 ;
+      <{VALOR_NS}detectedAt> ?detectedAt .
+    FILTER(str(?tessera1) < str(?tessera2))
+  }}
+}}
+ORDER BY DESC(?detectedAt)""",
+    )
+
+    return [
+        {
+            "conflict_uri": row["signal"],
+            "tessera_a": row["tessera1"],
+            "tessera_b": row["tessera2"],
+            "detected_at": row["detectedAt"],
+        }
+        for row in rows
+    ]
 
 
 @router.get("/{design_space_id}/participants", response_model=list[ParticipantResponse])

--- a/backend/app/routers/tessera.py
+++ b/backend/app/routers/tessera.py
@@ -8,8 +8,10 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from app.auth import get_current_user
+from app.db import fuseki_knowledge
 from app.db.permissions import check_permission
 from app.models.domain import Role
+from app.services.connection_manager import manager
 from app.services.fuseki import sparql_select, sparql_update, sparql_shacl_validate, named_graph_uri, record_provenance_activity
 from app.services.ontology_cache import (
     get_evidence_label_to_uri,
@@ -213,6 +215,18 @@ INSERT DATA {{
         user_uri,
         generated=tessera_uri,
     ))
+
+    project_id = await fuseki_knowledge.get_project_id_for_designspace(request.design_space_id)
+    if project_id:
+        await manager.broadcast_data(project_id, {
+            "type": "TESSERA_PROPOSED",
+            "payload": {
+                "tessera_uri": tessera_uri,
+                "design_space_id": request.design_space_id,
+                "epistemic_status": "Proposed",
+                "claimed_by": user_id,
+            },
+        })
 
     logger.info("Tessera aangemaakt: %s in DesignSpace %s door %s", tessera_uri, request.design_space_id, user_id)
 
@@ -540,6 +554,18 @@ WHERE {{
             (f"{VALOR_NS}newStatus", new_status_uri),
         ],
     ))
+
+    if request.new_status == "Contested":
+        project_id = await fuseki_knowledge.get_project_id_for_designspace(request.design_space_id)
+        if project_id:
+            await manager.broadcast_data(project_id, {
+                "type": "TESSERA_CONTESTED",
+                "payload": {
+                    "tessera_uri": tessera_uri,
+                    "design_space_id": request.design_space_id,
+                    "previous_status": current_status,
+                },
+            })
 
     logger.info(
         "Tessera %s status: %s → %s (door %s)",

--- a/backend/app/routers/tessera.py
+++ b/backend/app/routers/tessera.py
@@ -453,6 +453,65 @@ WHERE {{
     )
 
 
+async def _detect_conflicts_async(
+    tessera_uri: str,
+    design_space_id: str,
+    accepted_status_uri: str,
+):
+    """
+    Fire-and-forget conflictdetectie na statusovergang naar Accepted.
+    Detecteert valor:undermines conflicten tussen Accepted Tesserae en schrijft
+    een valor:ConflictSignal naar de provenance graph.
+
+    # TODO: semantische conflictdetectie op basis van claimContent (NLP/embeddings) — zie #477
+    """
+    rows = await sparql_select(
+        f"""SELECT DISTINCT ?other WHERE {{
+          {{
+            <{tessera_uri}> <{VALOR_NS}undermines> ?other .
+            ?other <{VALOR_NS}epistemicStatus> <{accepted_status_uri}> .
+          }} UNION {{
+            ?other <{VALOR_NS}undermines> <{tessera_uri}> .
+            ?other <{VALOR_NS}epistemicStatus> <{accepted_status_uri}> .
+          }}
+        }}""",
+        design_space_id,
+    )
+
+    if not rows:
+        return
+
+    prov_graph = f"urn:valor:ds:{design_space_id}/provenance"
+    detected_at = datetime.now(timezone.utc).isoformat()
+
+    for row in rows:
+        other_uri = row["other"]
+        conflict_uri = f"urn:valor:conflict:{uuid.uuid4()}"
+        signal_sparql = f"""PREFIX valor: <{VALOR_NS}>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+INSERT DATA {{
+  GRAPH <{prov_graph}> {{
+    <{conflict_uri}> a valor:ConflictSignal ;
+      valor:conflictingTessera <{tessera_uri}> ;
+      valor:conflictingTessera <{other_uri}> ;
+      valor:detectedAt "{detected_at}"^^xsd:dateTime .
+  }}
+}}"""
+        await sparql_update(signal_sparql, design_space_id)
+        logger.warning("Conflict gesignaleerd: %s ↔ %s in DesignSpace %s", tessera_uri, other_uri, design_space_id)
+
+    project_id = await fuseki_knowledge.get_project_id_for_designspace(design_space_id)
+    if project_id:
+        await manager.broadcast_data(project_id, {
+            "type": "TESSERA_CONFLICT_DETECTED",
+            "payload": {
+                "tessera_uri": tessera_uri,
+                "design_space_id": design_space_id,
+                "conflicting_tesserae": [row["other"] for row in rows],
+            },
+        })
+
+
 @router.patch("/{tessera_id}/status", response_model=PatchTesseraStatusResponse)
 async def patch_tessera_status(
     tessera_id: str,
@@ -554,6 +613,13 @@ WHERE {{
             (f"{VALOR_NS}newStatus", new_status_uri),
         ],
     ))
+
+    if request.new_status == "Accepted":
+        asyncio.create_task(_detect_conflicts_async(
+            tessera_uri,
+            request.design_space_id,
+            new_status_uri,
+        ))
 
     if request.new_status == "Contested":
         project_id = await fuseki_knowledge.get_project_id_for_designspace(request.design_space_id)

--- a/backend/app/routers/tessera.py
+++ b/backend/app/routers/tessera.py
@@ -1,3 +1,4 @@
+import asyncio
 import uuid
 import logging
 from datetime import datetime, timezone
@@ -204,12 +205,12 @@ INSERT DATA {{
 
     await sparql_update(sparql, request.design_space_id)
 
-    await record_provenance_activity(
+    asyncio.create_task(record_provenance_activity(
         request.design_space_id,
         "TesseraCreated",
         user_uri,
         generated=tessera_uri,
-    )
+    ))
 
     logger.info("Tessera aangemaakt: %s in DesignSpace %s door %s", tessera_uri, request.design_space_id, user_id)
 
@@ -409,13 +410,13 @@ WHERE {{
 
     await sparql_update(update, request.design_space_id)
 
-    await record_provenance_activity(
+    asyncio.create_task(record_provenance_activity(
         request.design_space_id,
         "RealisedByLinked",
         f"urn:valor:user:{user_id}",
         used=[tessera_uri],
         extra_props=[(f"{CAUSA_NS}realisedBy", request.transaction_type_uri)],
-    )
+    ))
 
     logger.info(
         "Tessera %s gekoppeld aan TransactionType %s door %s",
@@ -521,7 +522,7 @@ WHERE {{
 
     status_label_to_uri_map = get_status_label_to_uri()
     old_status_uri = status_label_to_uri_map.get(current_status, current_raw)
-    await record_provenance_activity(
+    asyncio.create_task(record_provenance_activity(
         request.design_space_id,
         "StatusChanged",
         f"urn:valor:user:{user_id}",
@@ -530,7 +531,7 @@ WHERE {{
             (f"{VALOR_NS}previousStatus", old_status_uri),
             (f"{VALOR_NS}newStatus", new_status_uri),
         ],
-    )
+    ))
 
     logger.info(
         "Tessera %s status: %s → %s (door %s)",
@@ -746,13 +747,13 @@ WHERE {{
                     contested_triggered = True
                     logger.info("Tessera %s naar Contested door undermines van %s", target_uri, source_uri)
 
-    await record_provenance_activity(
+    asyncio.create_task(record_provenance_activity(
         request.design_space_id,
         "ArgumentAdded",
         f"urn:valor:user:{user_id}",
         used=[source_uri, target_uri],
         extra_props=[(relation_uri, target_uri)],
-    )
+    ))
 
     logger.info(
         "Argumentatierelatie: %s -[%s]-> %s (door %s)",

--- a/backend/app/routers/tessera.py
+++ b/backend/app/routers/tessera.py
@@ -79,6 +79,7 @@ class TesseraResponse(BaseModel):
     in_phase: Optional[str] = None
     manifestation_condition: Optional[str] = None
     realised_by: Optional[str] = None
+    gdi_flag: Optional[str] = None
 
 
 class RealiseRequest(BaseModel):
@@ -199,7 +200,8 @@ INSERT DATA {{
       valor:claimType <{claim_type_uri}> ;
       valor:claimedBy <{user_uri}> ;
       valor:claimedAt "{claimed_at}"^^xsd:dateTime ;
-      valor:inDesignSpace <{graph_uri}> .
+      valor:inDesignSpace <{graph_uri}> ;
+      valor:gdiFlag valor:TruthfulnessIssue .
 {optional_triples}  }}
 }}"""
 
@@ -227,6 +229,7 @@ INSERT DATA {{
         in_alternative=request.in_alternative,
         in_phase=request.in_phase,
         manifestation_condition=request.manifestation_condition,
+        gdi_flag="TruthfulnessIssue",
     )
 
 
@@ -314,7 +317,7 @@ async def get_tessera(
         graph_uri = named_graph_uri(design_space_id)
 
     rows = await sparql_select(
-        f"""SELECT ?content ?claimType ?uncertaintyLevel ?status ?claimedBy ?claimedAt ?inAlternative ?inPhase ?manifestationCondition ?realisedBy WHERE {{
+        f"""SELECT ?content ?claimType ?uncertaintyLevel ?status ?claimedBy ?claimedAt ?inAlternative ?inPhase ?manifestationCondition ?realisedBy ?gdiFlag WHERE {{
           GRAPH <{graph_uri}> {{
             <{tessera_uri}> a <{VALOR_NS}Tessera> ;
               <{VALOR_NS}claimContent> ?content ;
@@ -327,6 +330,7 @@ async def get_tessera(
             OPTIONAL {{ <{tessera_uri}> <{VALOR_NS}inPhase> ?inPhase . }}
             OPTIONAL {{ <{tessera_uri}> <{CAUSA_NS}hasManifestationCondition> ?manifestationCondition . }}
             OPTIONAL {{ <{tessera_uri}> <{CAUSA_NS}realisedBy> ?realisedBy . }}
+            OPTIONAL {{ <{tessera_uri}> <{VALOR_NS}gdiFlag> ?gdiFlag . }}
           }}
         }}""",
         design_space_id,
@@ -344,6 +348,9 @@ async def get_tessera(
     uncertainty_uri_to_label = {v: k for k, v in uncertainty_label_to_uri.items()}
     uncertainty_level = uncertainty_uri_to_label.get(raw_uncertainty) if raw_uncertainty else None
 
+    raw_gdi = row.get("gdiFlag", "")
+    gdi_flag = raw_gdi.rsplit("/", 1)[-1].rsplit("#", 1)[-1] if raw_gdi else None
+
     return TesseraResponse(
         tessera_id=tessera_id,
         tessera_uri=tessera_uri,
@@ -358,6 +365,7 @@ async def get_tessera(
         in_phase=row.get("inPhase"),
         manifestation_condition=row.get("manifestationCondition"),
         realised_by=row.get("realisedBy"),
+        gdi_flag=gdi_flag,
     )
 
 
@@ -607,6 +615,14 @@ INSERT DATA {{
 }}"""
 
     await sparql_update(sparql, request.design_space_id)
+
+    gdi_remove_sparql = f"""PREFIX valor: <{VALOR_NS}>
+DELETE DATA {{
+  GRAPH <{graph_uri}> {{
+    <{tessera_uri}> valor:gdiFlag valor:TruthfulnessIssue .
+  }}
+}}"""
+    asyncio.create_task(sparql_update(gdi_remove_sparql, request.design_space_id))
 
     logger.info("Evidence %s toegevoegd aan Tessera %s door %s", evidence_uri, tessera_uri, user_id)
 

--- a/backend/tests/integration/test_conflict_detection.py
+++ b/backend/tests/integration/test_conflict_detection.py
@@ -1,0 +1,229 @@
+"""Integratietests voor conflictdetectie (US-T.1).
+
+Test:
+- ConflictSignal wordt aangemaakt wanneer twee Accepted Tesserae een valor:undermines relatie hebben
+- ConflictSignal blijft afwezig wanneer er geen undermines relatie is
+- ConflictSignal blijft afwezig wanneer slechts één Tessera Accepted is
+- GET /designspace/{ds_id}/conflicts geeft aanwezige ConflictSignals terug
+"""
+import asyncio
+import uuid
+
+import httpx
+import pytest
+
+from app.ontology import VALOR_NS
+from tests.conftest import FUSEKI_TEST_URL, FUSEKI_TEST_DATASET
+
+pytestmark = pytest.mark.integration
+
+XSD_NS = "http://www.w3.org/2001/XMLSchema#"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _sparql_update(update: str) -> None:
+    from tests.conftest import FUSEKI_ADMIN_PASSWORD
+    endpoint = f"{FUSEKI_TEST_URL}/{FUSEKI_TEST_DATASET}/update"
+    async with httpx.AsyncClient() as client:
+        r = await client.post(
+            endpoint,
+            data={"update": update},
+            auth=("admin", FUSEKI_ADMIN_PASSWORD),
+            timeout=10,
+        )
+    r.raise_for_status()
+
+
+async def _sparql_select(sparql: str) -> list[dict]:
+    endpoint = f"{FUSEKI_TEST_URL}/{FUSEKI_TEST_DATASET}/sparql"
+    async with httpx.AsyncClient() as client:
+        r = await client.post(
+            endpoint,
+            data={"query": sparql},
+            headers={"Accept": "application/sparql-results+json"},
+            timeout=10,
+        )
+    r.raise_for_status()
+    return r.json()["results"]["bindings"]
+
+
+async def _seed_design_space(ds_id: str) -> None:
+    from app.services.fuseki import initialize_design_space_graphs
+    await initialize_design_space_graphs(ds_id, f"urn:valor:issue:{ds_id}")
+
+
+def _accepted_status_uri() -> str:
+    from app.services.ontology_cache import get_status_label_to_uri
+    return get_status_label_to_uri()["Accepted"]
+
+
+def _proposed_status_uri() -> str:
+    from app.services.ontology_cache import get_status_label_to_uri
+    return get_status_label_to_uri()["Proposed"]
+
+
+async def _insert_tessera(ds_id: str, tessera_id: str, status_uri: str) -> str:
+    """Schrijft een minimale Tessera naar de default graph van ds_id.
+
+    sparql_select(query, ds_id) gebruikt urn:valor:ds:{ds_id} als default-graph-uri,
+    dus de data moet in die graph staan zodat _detect_conflicts_async hem vindt.
+    """
+    tessera_uri = f"urn:valor:tessera:{tessera_id}"
+    graph = f"urn:valor:ds:{ds_id}"
+    await _sparql_update(f"""PREFIX valor: <{VALOR_NS}>
+INSERT DATA {{
+  GRAPH <{graph}> {{
+    <{tessera_uri}> a valor:Tessera ;
+      valor:epistemicStatus <{status_uri}> ;
+      valor:claimContent "Testclaim {tessera_id}" .
+  }}
+}}""")
+    return tessera_uri
+
+
+async def _insert_undermines(ds_id: str, tessera_a_uri: str, tessera_b_uri: str) -> None:
+    """Schrijft een valor:undermines triple in de default graph van ds_id."""
+    graph = f"urn:valor:ds:{ds_id}"
+    await _sparql_update(f"""PREFIX valor: <{VALOR_NS}>
+INSERT DATA {{
+  GRAPH <{graph}> {{
+    <{tessera_a_uri}> valor:undermines <{tessera_b_uri}> .
+  }}
+}}""")
+
+
+async def _count_conflict_signals(ds_id: str) -> int:
+    prov_graph = f"urn:valor:ds:{ds_id}/provenance"
+    rows = await _sparql_select(f"""SELECT (COUNT(?s) AS ?c) WHERE {{
+  GRAPH <{prov_graph}> {{
+    ?s a <{VALOR_NS}ConflictSignal> .
+  }}
+}}""")
+    return int(rows[0]["c"]["value"]) if rows else 0
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+async def test_no_conflict_without_undermines(ds_id: str) -> None:
+    """Twee Accepted Tesserae zonder undermines relatie -> geen ConflictSignal."""
+    await _seed_design_space(ds_id)
+    accepted = _accepted_status_uri()
+
+    tessera_a = await _insert_tessera(ds_id, f"a-{uuid.uuid4().hex[:8]}", accepted)
+    tessera_b = await _insert_tessera(ds_id, f"b-{uuid.uuid4().hex[:8]}", accepted)
+
+    from app.routers.tessera import _detect_conflicts_async
+    await _detect_conflicts_async(tessera_a, ds_id, accepted)
+    await _detect_conflicts_async(tessera_b, ds_id, accepted)
+
+    count = await _count_conflict_signals(ds_id)
+    assert count == 0, f"Geen ConflictSignal verwacht, maar {count} gevonden"
+
+
+async def test_conflict_detected_when_both_accepted(ds_id: str) -> None:
+    """Tessera A undermines Tessera B; beide Accepted -> ConflictSignal aangemaakt."""
+    await _seed_design_space(ds_id)
+    accepted = _accepted_status_uri()
+
+    tessera_a = await _insert_tessera(ds_id, f"a-{uuid.uuid4().hex[:8]}", accepted)
+    tessera_b = await _insert_tessera(ds_id, f"b-{uuid.uuid4().hex[:8]}", accepted)
+    await _insert_undermines(ds_id, tessera_a, tessera_b)
+
+    from app.routers.tessera import _detect_conflicts_async
+
+    # Simuleer: eerst A Accepted (B nog niet Accepted, dus geen conflict).
+    # Dan B Accepted (A is al Accepted, dus conflict).
+    await _detect_conflicts_async(tessera_b, ds_id, accepted)
+
+    count = await _count_conflict_signals(ds_id)
+    assert count == 1, f"Precies 1 ConflictSignal verwacht, maar {count} gevonden"
+
+    # Verifieer inhoud van het ConflictSignal
+    prov_graph = f"urn:valor:ds:{ds_id}/provenance"
+    rows = await _sparql_select(f"""SELECT ?signal ?ta ?tb ?det WHERE {{
+  GRAPH <{prov_graph}> {{
+    ?signal a <{VALOR_NS}ConflictSignal> ;
+      <{VALOR_NS}conflictingTessera> ?ta ;
+      <{VALOR_NS}conflictingTessera> ?tb ;
+      <{VALOR_NS}detectedAt> ?det .
+    FILTER(?ta != ?tb)
+  }}
+}}""")
+    assert rows, "ConflictSignal triples niet volledig aanwezig in provenance graph"
+    tessera_uris = {rows[0]["ta"]["value"], rows[0]["tb"]["value"]}
+    assert tessera_a in tessera_uris, f"{tessera_a} niet in conflictingTessera triples"
+    assert tessera_b in tessera_uris, f"{tessera_b} niet in conflictingTessera triples"
+    assert rows[0]["det"]["value"], "valor:detectedAt is leeg"
+
+
+async def test_no_conflict_when_only_one_accepted(ds_id: str) -> None:
+    """Tessera A undermines Tessera B; alleen A is Accepted -> geen ConflictSignal."""
+    await _seed_design_space(ds_id)
+    accepted = _accepted_status_uri()
+    proposed = _proposed_status_uri()
+
+    tessera_a = await _insert_tessera(ds_id, f"a-{uuid.uuid4().hex[:8]}", accepted)
+    tessera_b = await _insert_tessera(ds_id, f"b-{uuid.uuid4().hex[:8]}", proposed)
+    await _insert_undermines(ds_id, tessera_a, tessera_b)
+
+    from app.routers.tessera import _detect_conflicts_async
+    await _detect_conflicts_async(tessera_a, ds_id, accepted)
+
+    count = await _count_conflict_signals(ds_id)
+    assert count == 0, f"Geen ConflictSignal verwacht (B is Proposed), maar {count} gevonden"
+
+
+async def test_get_conflicts_endpoint_returns_signals(ds_id: str) -> None:
+    """GET /designspace/{ds_id}/conflicts geeft ConflictSignal data terug.
+
+    Schrijft een ConflictSignal direct naar de provenance graph en verifieert
+    dat het endpoint dit correct teruggeeft.
+    """
+
+    tessera_a_uri = f"urn:valor:tessera:conflict-a-{uuid.uuid4().hex[:8]}"
+    tessera_b_uri = f"urn:valor:tessera:conflict-b-{uuid.uuid4().hex[:8]}"
+    conflict_uri = f"urn:valor:conflict:{uuid.uuid4()}"
+    prov_graph = f"urn:valor:ds:{ds_id}/provenance"
+    detected_at = "2026-01-01T12:00:00+00:00"
+
+    await _sparql_update(f"""PREFIX valor: <{VALOR_NS}>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+INSERT DATA {{
+  GRAPH <{prov_graph}> {{
+    <{conflict_uri}> a valor:ConflictSignal ;
+      valor:conflictingTessera <{tessera_a_uri}> ;
+      valor:conflictingTessera <{tessera_b_uri}> ;
+      valor:detectedAt "{detected_at}"^^xsd:dateTime .
+  }}
+}}""")
+
+    import app.routers.designspace as ds_router
+    original_check = ds_router.check_permission
+
+    async def _allow_all(*args, **kwargs):
+        return True
+
+    ds_router.check_permission = _allow_all
+    try:
+        from app.routers.designspace import get_conflicts
+        result = await get_conflicts(
+            design_space_id=ds_id,
+            user={"id": "test-user-001"},
+        )
+    finally:
+        ds_router.check_permission = original_check
+
+    assert isinstance(result, list), "Verwacht een lijst"
+    assert len(result) == 1, f"Verwacht 1 conflict, maar {len(result)} gevonden"
+
+    conflict = result[0]
+    assert conflict["conflict_uri"] == conflict_uri
+    tessera_uris = {conflict["tessera_a"], conflict["tessera_b"]}
+    assert tessera_a_uri in tessera_uris
+    assert tessera_b_uri in tessera_uris
+    assert conflict["detected_at"] == detected_at

--- a/frontend/src/perspectives/causa/layout/mappers.ts
+++ b/frontend/src/perspectives/causa/layout/mappers.ts
@@ -20,7 +20,8 @@ export const mapFactorToNode = (factor: Factor): CausalNode => {
         role: factor.type,
         description: factor.description,
         epistemicStatus: normalizeEpistemicStatus(factor.epistemic_status),
-        version_id: factor.version_id
+        version_id: factor.version_id,
+        gdiFlag: factor.gdi_flag ?? undefined,
     };
 };
 

--- a/frontend/src/perspectives/causa/types.ts
+++ b/frontend/src/perspectives/causa/types.ts
@@ -13,6 +13,7 @@ export interface CausalNode {
     description?: string;
     epistemicStatus?: EpistemicStatus;
     version_id?: string;
+    gdiFlag?: string;
 }
 
 export interface CausalLink {

--- a/frontend/src/perspectives/causa/views/CLDView.tsx
+++ b/frontend/src/perspectives/causa/views/CLDView.tsx
@@ -160,6 +160,7 @@ export const CLDView: FunctionComponent<CLDViewProps> = ({
                         role: cn.role,
                         description: cn.description,
                         epistemicStatus: cn.epistemicStatus,
+                        gdiFlag: cn.gdiFlag,
                         threadCount: (cn.version_id && threadStats[cn.version_id]) || 0,
                         version_id: cn.version_id,
                         onOpenThread: handleOpenThread,

--- a/frontend/src/perspectives/causa/views/nodes/CLDNode.tsx
+++ b/frontend/src/perspectives/causa/views/nodes/CLDNode.tsx
@@ -1,6 +1,6 @@
 import { memo, type FunctionComponent, type MouseEvent } from 'react';
 import { Handle, Position, type NodeProps } from 'reactflow';
-import { Wrench, Cloud, Cpu, Target, HelpCircle, MessageSquare, type LucideProps } from 'lucide-react';
+import { Wrench, Cloud, Cpu, Target, HelpCircle, MessageSquare, TriangleAlert, type LucideProps } from 'lucide-react';
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -61,6 +61,7 @@ const CLDNode: FunctionComponent<NodeProps> = ({ id, data, selected }) => {
     const isReadOnly = data.isReadOnly || false;
     const isInCycle = data.isInCycle || false;
     const epistemicStatus = (data.epistemicStatus || 'Proposed') as EpistemicStatus;
+    const hasGdiFlag = !!data.gdiFlag;
 
     const Icon = iconMap[role] || iconMap.unknown;
     const styles = roleStyles[role] || roleStyles.unknown;
@@ -135,6 +136,11 @@ const CLDNode: FunctionComponent<NodeProps> = ({ id, data, selected }) => {
 
             {/* Footer: rol-icoon + status-badge */}
             <div className="absolute bottom-2 right-2 flex items-center gap-1">
+                {hasGdiFlag && (
+                    <span title="Epistemisch kwetsbaar — geen bewijs" className="text-amber-500">
+                        <TriangleAlert size={12} />
+                    </span>
+                )}
                 <span
                     className={cn('w-2 h-2 rounded-full', statusStyle.dot)}
                     title={statusStyle.label}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -54,6 +54,7 @@ export interface Claim {
     status?: string;
     evidence_text?: string;
     evidence_url?: string;
+    gdi_flag?: string;
 }
 
 export interface ValidationResult {
@@ -104,6 +105,7 @@ export interface Factor {
     version_id?: string;
     thread_id?: string;
     epistemic_status?: string;
+    gdi_flag?: string;
 }
 
 export interface Organization {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -591,6 +591,11 @@ export const api = {
         return response.data;
     },
 
+    getProvenance: async (dsId: string): Promise<{ activity_uri: string; operation_type: string; attributed_to: string; started_at: string; generated?: string; used: string[] }[]> => {
+        const response = await apiClient.get(`/designspace/${dsId}/provenance`);
+        return response.data;
+    },
+
     getDesignSpacesByProject: async (projectId: string, themeId?: string): Promise<{ id: string; name: string; status: string; current_phase: string }[]> => {
         const response = await apiClient.get(`/designspace/by-project/${projectId}`, {
             params: themeId ? { theme_id: themeId } : undefined,


### PR DESCRIPTION
## Scope

Uitbreiding van de Tessera-engine naar v1.0 conform VALOR-O v2.4 §8.3.

## Geïmplementeerde User Stories

- ✅ US-T.4 (#372) — PROV-O logging per Tessera-operatie
- ✅ US-T.5 (#384) — valor:gdiFlag TruthfulnessIssue automatisch zetten
- ✅ US-T.3 (#371) — WebSocket-notificaties TESSERA_PROPOSED / TESSERA_CONTESTED
- ✅ US-T.1 (#369) — Conflictdetectie via valor:undermines + GET /designspace/{id}/conflicts

## Uitgesteld

- ⏳ US-T.2 (#370) — Auto-CapabilityGap: geblokkeerd op Epic 9 US-9.4 (CAPAX-engine). Wordt opgepakt na Epic 9.

## Test plan

- [ ] `pytest tests/integration/ -v` — alle integratietests groen

Closes #352