### PR TITLE
fix(infra): Fuseki geheugenlimieten + JVM-args voor productie

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -27,11 +27,14 @@ services:
     container_name: valor-fuseki-prod
     restart: always
     # Geen publieke poort — alleen bereikbaar via intern Coolify-netwerk
+    mem_limit: 1536m
+    memswap_limit: 1536m
     volumes:
       - fuseki_data:/fuseki/databases
     environment:
       # ADMIN_PASSWORD wordt ingesteld via Coolify UI
       - ADMIN_PASSWORD=${FUSEKI_ADMIN_PASSWORD}
+      - JVM_ARGS=-Xmx1g -Xms256m
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://localhost:3030/$/ping || exit 1"]
       interval: 30s


### PR DESCRIPTION
## Summary

- `mem_limit: 1536m` en `memswap_limit: 1536m` toegevoegd aan Fuseki-container
- `JVM_ARGS=-Xmx1g -Xms256m` toegevoegd — voorkomt OOM-crashes in productie

Uitsluitend deze infrastructuurwijziging — geen andere development-commits.

## Test plan

- [ ] Fuseki-container start op met nieuwe geheugenlimieten
- [ ] `JVM_ARGS` wordt correct doorgegeven aan het Fuseki-proces

🤖 Generated with [Claude Code](https://claude.com/claude-code)