### PR TITLE
feat(entities): Entity Registry backend + JIT Supabase-bridge (US-AI.3) #484

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -103,5 +103,12 @@ async def get_current_user(payload: dict = Depends(verify_token)):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Database synchronization failed for user"
         )
-        
+
+    # JIT Sync: Ensure PhysicalAgent entity exists in urn:valor:entities
+    try:
+        from app.db.fuseki_entities import ensure_person_entity
+        await ensure_person_entity(user_id, name)
+    except Exception as exc:
+        logger.warning("Entity Registry JIT-sync mislukt voor %s: %s", user_id, exc)
+
     return db_user

--- a/backend/app/db/fuseki_entities.py
+++ b/backend/app/db/fuseki_entities.py
@@ -1,0 +1,303 @@
+"""Entity Registry — named graph urn:valor:entities.
+
+Implementeert de platformbrede Entity Registry als single source of truth
+voor alle rigide Kinds in VALOR (US-AI.3).
+
+Architectuur:
+  urn:valor:entities              — alle rigide Kinds (platform-breed, persistent)
+  urn:valor:ds:{ds_id}/baseline   — rol-assignaties per perspectief/DesignSpace
+
+URI-conventies:
+  urn:valor:entities:person:{supabase_uuid}   — interne gebruikers
+  urn:valor:entities:person:{random_uuid}     — externe personen
+  urn:valor:entities:org:{random_uuid}        — organisaties
+  urn:valor:entities:norm:{slug}              — wetten/regelingen
+"""
+import logging
+import uuid
+from typing import Optional
+
+from app.ontology import UFOC_NS, VALOR_NS
+from app.services.fuseki import sparql_select_global, sparql_update
+
+logger = logging.getLogger(__name__)
+
+_ENTITIES_GRAPH = "urn:valor:entities"
+_RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+_RDFS_LABEL = "http://www.w3.org/2000/01/rdf-schema#label"
+
+# Ondersteunde entity types → UFOC klasse-URI
+ENTITY_TYPE_MAP = {
+    "PhysicalAgent": f"{UFOC_NS}PhysicalAgent",
+    "InstitutionalAgent": f"{UFOC_NS}InstitutionalAgent",
+    "NormativeDescription": f"{UFOC_NS}NormativeDescription",
+    "SocialObject": f"{UFOC_NS}SocialObject",
+}
+
+# URI-prefix per entity type
+_URI_PREFIX_MAP = {
+    "PhysicalAgent": "person",
+    "InstitutionalAgent": "org",
+    "NormativeDescription": "norm",
+    "SocialObject": "obj",
+}
+
+
+def _escape(text: str) -> str:
+    return text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "")
+
+
+def _entity_uri(entity_type: str, identifier: str) -> str:
+    prefix = _URI_PREFIX_MAP.get(entity_type, "entity")
+    return f"{_ENTITIES_GRAPH}:{prefix}:{identifier}"
+
+
+# ---------------------------------------------------------------------------
+# JIT-bridge: Supabase → Fuseki
+# ---------------------------------------------------------------------------
+
+async def ensure_person_entity(supabase_id: str, name: Optional[str] = None) -> str:
+    """Garandeert dat een ufoc:PhysicalAgent-resource bestaat voor de Supabase-gebruiker.
+
+    Geeft de URI terug. Maakt JIT aan als nog niet aanwezig.
+    URI-patroon: urn:valor:entities:person:{supabase_uuid}
+    """
+    uri = _entity_uri("PhysicalAgent", supabase_id)
+
+    # Check of entity al bestaat
+    rows = await sparql_select_global(
+        f"SELECT ?uri WHERE {{ GRAPH <{_ENTITIES_GRAPH}> {{ <{uri}> a <{UFOC_NS}PhysicalAgent> }} }}"
+    )
+    if rows:
+        return uri
+
+    # JIT aanmaken
+    label = _escape(name or supabase_id)
+    update = f"""
+INSERT DATA {{
+  GRAPH <{_ENTITIES_GRAPH}> {{
+    <{uri}> a <{UFOC_NS}PhysicalAgent> ;
+      <{_RDFS_LABEL}> "{label}"@nl ;
+      <{VALOR_NS}supabaseId> "{_escape(supabase_id)}" ;
+      <{VALOR_NS}entityCreatedAt> "{_now_iso()}"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+  }}
+}}
+"""
+    await sparql_update(update, "entities")
+    logger.info("Entity Registry: PhysicalAgent aangemaakt voor Supabase-gebruiker %s", supabase_id)
+    return uri
+
+
+# ---------------------------------------------------------------------------
+# CRUD
+# ---------------------------------------------------------------------------
+
+async def create_entity(
+    entity_type: str,
+    label: str,
+    properties: Optional[dict] = None,
+    identifier: Optional[str] = None,
+) -> str:
+    """Maakt een nieuwe entiteit aan in urn:valor:entities.
+
+    Geeft de URI terug.
+    """
+    if entity_type not in ENTITY_TYPE_MAP:
+        raise ValueError(f"Onbekend entity type: {entity_type}. Kies uit: {list(ENTITY_TYPE_MAP)}")
+
+    ident = identifier or str(uuid.uuid4())
+    uri = _entity_uri(entity_type, ident)
+    class_uri = ENTITY_TYPE_MAP[entity_type]
+    label_escaped = _escape(label)
+
+    extra_triples = ""
+    if properties:
+        for key, value in properties.items():
+            if value is not None:
+                escaped_val = _escape(str(value))
+                extra_triples += f'    <{VALOR_NS}{key}> "{escaped_val}" ;\n'
+
+    update = f"""
+INSERT DATA {{
+  GRAPH <{_ENTITIES_GRAPH}> {{
+    <{uri}> a <{class_uri}> ;
+      <{_RDFS_LABEL}> "{label_escaped}"@nl ;
+      <{VALOR_NS}entityCreatedAt> "{_now_iso()}"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+{extra_triples}      <{VALOR_NS}entityId> "{_escape(ident)}" .
+  }}
+}}
+"""
+    await sparql_update(update, "entities")
+    logger.info("Entity Registry: %s aangemaakt met URI %s", entity_type, uri)
+    return uri
+
+
+async def get_entity(uri: str) -> Optional[dict]:
+    """Haalt een entiteit op uit de Entity Registry op basis van URI.
+
+    Geeft None terug als de entiteit niet bestaat.
+    """
+    rows = await sparql_select_global(f"""
+SELECT ?type ?label ?supabaseId ?entityId ?createdAt WHERE {{
+  GRAPH <{_ENTITIES_GRAPH}> {{
+    <{uri}> a ?type ;
+      OPTIONAL {{ <{uri}> <{_RDFS_LABEL}> ?label }}
+      OPTIONAL {{ <{uri}> <{VALOR_NS}supabaseId> ?supabaseId }}
+      OPTIONAL {{ <{uri}> <{VALOR_NS}entityId> ?entityId }}
+      OPTIONAL {{ <{uri}> <{VALOR_NS}entityCreatedAt> ?createdAt }}
+  }}
+}}
+""")
+    if not rows:
+        return None
+
+    row = rows[0]
+    # Bepaal entity_type label vanuit URI
+    type_uri = row.get("type", "")
+    entity_type = next(
+        (k for k, v in ENTITY_TYPE_MAP.items() if v == type_uri),
+        type_uri,
+    )
+    return {
+        "uri": uri,
+        "entity_type": entity_type,
+        "label": row.get("label"),
+        "supabase_id": row.get("supabaseId"),
+        "entity_id": row.get("entityId"),
+        "created_at": row.get("createdAt"),
+    }
+
+
+async def search_entities(
+    query: str,
+    entity_type: Optional[str] = None,
+    limit: int = 20,
+) -> list[dict]:
+    """Zoekt entiteiten in de Entity Registry op basis van label (case-insensitive substring).
+
+    Optionele filter op entity_type.
+    """
+    type_filter = ""
+    if entity_type and entity_type in ENTITY_TYPE_MAP:
+        class_uri = ENTITY_TYPE_MAP[entity_type]
+        type_filter = f"?uri a <{class_uri}> ."
+    else:
+        type_filter = f"?uri a ?type ."
+
+    escaped_q = _escape(query.lower())
+
+    sparql = f"""
+SELECT ?uri ?type ?label WHERE {{
+  GRAPH <{_ENTITIES_GRAPH}> {{
+    {type_filter}
+    ?uri a ?type .
+    OPTIONAL {{ ?uri <{_RDFS_LABEL}> ?label }}
+    FILTER (CONTAINS(LCASE(STR(?label)), "{escaped_q}") || CONTAINS(STR(?uri), "{escaped_q}"))
+  }}
+}}
+LIMIT {limit}
+"""
+    rows = await sparql_select_global(sparql)
+    results = []
+    for row in rows:
+        type_uri = row.get("type", "")
+        entity_type_label = next(
+            (k for k, v in ENTITY_TYPE_MAP.items() if v == type_uri),
+            type_uri,
+        )
+        results.append({
+            "uri": row["uri"],
+            "entity_type": entity_type_label,
+            "label": row.get("label"),
+        })
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Rol-assignatie
+# ---------------------------------------------------------------------------
+
+async def assign_role(
+    entity_uri: str,
+    role_uri: str,
+    ds_id: str,
+    context: Optional[str] = None,
+) -> None:
+    """Wijst een rol toe aan een entiteit in de baseline-graph van een DesignSpace.
+
+    Triple: entity_uri valor:playsRole role_uri  (in urn:valor:ds:{ds_id}/baseline)
+    """
+    baseline_graph = f"urn:valor:ds:{ds_id}/baseline"
+    context_triple = ""
+    if context:
+        escaped_ctx = _escape(context)
+        context_triple = f'    <{VALOR_NS}roleContext> "{escaped_ctx}" ;\n'
+
+    update = f"""
+INSERT DATA {{
+  GRAPH <{baseline_graph}> {{
+    <{entity_uri}> <{VALOR_NS}playsRole> <{role_uri}> ;
+{context_triple}      <{VALOR_NS}roleAssignedAt> "{_now_iso()}"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+  }}
+}}
+"""
+    await sparql_update(update, ds_id)
+    logger.info(
+        "Entity Registry: rol %s toegewezen aan %s in DesignSpace %s",
+        role_uri, entity_uri, ds_id,
+    )
+
+
+async def get_roles_for_entity(entity_uri: str, ds_id: str) -> list[dict]:
+    """Haalt alle rollen op voor een entiteit in een specifieke DesignSpace.
+
+    Leest uit urn:valor:ds:{ds_id}/baseline.
+    """
+    baseline_graph = f"urn:valor:ds:{ds_id}/baseline"
+    rows = await sparql_select_global(f"""
+SELECT ?role ?context ?assignedAt WHERE {{
+  GRAPH <{baseline_graph}> {{
+    <{entity_uri}> <{VALOR_NS}playsRole> ?role .
+    OPTIONAL {{ <{entity_uri}> <{VALOR_NS}roleContext> ?context }}
+    OPTIONAL {{ <{entity_uri}> <{VALOR_NS}roleAssignedAt> ?assignedAt }}
+  }}
+}}
+""")
+    return [
+        {
+            "role_uri": row["role"],
+            "context": row.get("context"),
+            "assigned_at": row.get("assignedAt"),
+        }
+        for row in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Backfill helpers
+# ---------------------------------------------------------------------------
+
+async def backfill_existing_users(users: list[dict]) -> int:
+    """Maakt PhysicalAgent-entities aan voor bestaande gebruikers die nog geen entity hebben.
+
+    Verwacht een lijst van dicts met 'id' (Supabase UUID) en optioneel 'name'.
+    Geeft het aantal nieuw aangemaakte entities terug.
+    """
+    created = 0
+    for user in users:
+        user_id = user.get("id")
+        if not user_id:
+            continue
+        uri = await ensure_person_entity(user_id, user.get("name"))
+        if uri:
+            created += 1
+    return created
+
+
+# ---------------------------------------------------------------------------
+# Intern
+# ---------------------------------------------------------------------------
+
+def _now_iso() -> str:
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,6 +16,7 @@ from app.routers import proposals, dashboard, threads, sessions, deliberation
 from app.routers import factors, claims, organizations, hierarchy
 from app.routers import tessera
 from app.routers import designspace
+from app.routers import entities
 
 load_dotenv()
 
@@ -95,6 +96,7 @@ app.include_router(factors.router)
 app.include_router(claims.router)
 app.include_router(tessera.router)
 app.include_router(designspace.router)
+app.include_router(entities.router)
 
 
 @app.get("/")

--- a/backend/app/routers/entities.py
+++ b/backend/app/routers/entities.py
@@ -1,0 +1,120 @@
+"""Entity Registry API endpoints (US-AI.3).
+
+Routes:
+  POST /entities/                           — nieuwe entiteit aanmaken
+  GET  /entities/search?q=&type=            — zoeken in registry
+  GET  /entities/{uri:path}                 — entiteitsdata ophalen
+  GET  /entities/{uri:path}/roles?ds_id=    — rollen per DesignSpace
+"""
+from typing import Optional
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from app.auth import get_current_user
+from app.db.fuseki_entities import (
+    ENTITY_TYPE_MAP,
+    assign_role,
+    create_entity,
+    get_entity,
+    get_roles_for_entity,
+    search_entities,
+)
+
+router = APIRouter(prefix="/entities", tags=["entities"])
+
+
+# ---------------------------------------------------------------------------
+# Request / Response modellen
+# ---------------------------------------------------------------------------
+
+class EntityCreateRequest(BaseModel):
+    entity_type: str
+    label: str
+    properties: Optional[dict] = None
+    identifier: Optional[str] = None
+
+
+class RoleAssignRequest(BaseModel):
+    entity_uri: str
+    role_uri: str
+    ds_id: str
+    context: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+@router.post("/", status_code=201)
+async def create_entity_endpoint(
+    body: EntityCreateRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """Maakt een nieuwe entiteit aan in de Entity Registry."""
+    if body.entity_type not in ENTITY_TYPE_MAP:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Onbekend entity_type '{body.entity_type}'. Kies uit: {list(ENTITY_TYPE_MAP)}",
+        )
+    uri = await create_entity(
+        entity_type=body.entity_type,
+        label=body.label,
+        properties=body.properties,
+        identifier=body.identifier,
+    )
+    return {"uri": uri, "entity_type": body.entity_type, "label": body.label}
+
+
+@router.get("/search")
+async def search_entities_endpoint(
+    q: str = Query(..., min_length=1),
+    type: Optional[str] = Query(None),
+    limit: int = Query(20, ge=1, le=100),
+    current_user: dict = Depends(get_current_user),
+):
+    """Zoekt entiteiten in de registry op basis van label (substring, case-insensitief)."""
+    results = await search_entities(query=q, entity_type=type, limit=limit)
+    return {"results": results, "count": len(results)}
+
+
+@router.post("/roles", status_code=201)
+async def assign_role_endpoint(
+    body: RoleAssignRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """Wijst een rol toe aan een entiteit in een DesignSpace."""
+    await assign_role(
+        entity_uri=body.entity_uri,
+        role_uri=body.role_uri,
+        ds_id=body.ds_id,
+        context=body.context,
+    )
+    return {"status": "ok", "entity_uri": body.entity_uri, "role_uri": body.role_uri, "ds_id": body.ds_id}
+
+
+@router.get("/{uri:path}/roles")
+async def get_entity_roles_endpoint(
+    uri: str,
+    ds_id: str = Query(...),
+    current_user: dict = Depends(get_current_user),
+):
+    """Haalt alle rollen op voor een entiteit in een specifieke DesignSpace."""
+    # uri komt binnen als URL-pad zonder leading slash — herstel urn: prefix
+    if not uri.startswith("urn:"):
+        uri = uri.replace("urn:/", "urn:").lstrip("/")
+    roles = await get_roles_for_entity(entity_uri=uri, ds_id=ds_id)
+    return {"entity_uri": uri, "ds_id": ds_id, "roles": roles}
+
+
+@router.get("/{uri:path}")
+async def get_entity_endpoint(
+    uri: str,
+    current_user: dict = Depends(get_current_user),
+):
+    """Haalt een entiteit op uit de registry op basis van URI."""
+    if not uri.startswith("urn:"):
+        uri = uri.replace("urn:/", "urn:").lstrip("/")
+    entity = await get_entity(uri=uri)
+    if entity is None:
+        raise HTTPException(status_code=404, detail=f"Entiteit niet gevonden: {uri}")
+    return entity

--- a/backend/tests/integration/test_entities.py
+++ b/backend/tests/integration/test_entities.py
@@ -1,0 +1,233 @@
+"""Integratietests voor app.db.fuseki_entities (US-AI.3).
+
+Test de Entity Registry: named graph urn:valor:entities, JIT-bridge,
+CRUD-operaties en rol-assignaties.
+
+Gebruik:
+    cd backend
+    FUSEKI_URL=http://localhost:3030 pytest tests/integration/test_entities.py -v
+"""
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+pytestmark = pytest.mark.integration
+
+_ENTITIES_GRAPH = "urn:valor:entities"
+TEST_SUPABASE_ID = "test-supabase-uuid-0001"
+TEST_DS_ID = "test-ds-entities"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _count_entities(entity_type_uri: str) -> int:
+    from app.services.fuseki import sparql_select_global
+    rows = await sparql_select_global(
+        f"SELECT (COUNT(?e) AS ?c) WHERE {{ GRAPH <{_ENTITIES_GRAPH}> {{ ?e a <{entity_type_uri}> }} }}"
+    )
+    return int(rows[0]["c"]) if rows else 0
+
+
+# ---------------------------------------------------------------------------
+# JIT-bridge: ensure_person_entity
+# ---------------------------------------------------------------------------
+
+async def test_ensure_person_entity_maakt_physical_agent_aan():
+    from app.db.fuseki_entities import ensure_person_entity
+    from app.ontology import UFOC_NS
+
+    uri = await ensure_person_entity(TEST_SUPABASE_ID, "Test Gebruiker")
+
+    assert uri == f"{_ENTITIES_GRAPH}:person:{TEST_SUPABASE_ID}"
+    count = await _count_entities(f"{UFOC_NS}PhysicalAgent")
+    assert count == 1
+
+
+async def test_ensure_person_entity_idempotent():
+    from app.db.fuseki_entities import ensure_person_entity
+    from app.ontology import UFOC_NS
+
+    uri1 = await ensure_person_entity(TEST_SUPABASE_ID, "Test Gebruiker")
+    uri2 = await ensure_person_entity(TEST_SUPABASE_ID, "Test Gebruiker")
+
+    assert uri1 == uri2
+    count = await _count_entities(f"{UFOC_NS}PhysicalAgent")
+    assert count == 1  # geen duplicaat
+
+
+async def test_ensure_person_entity_zonder_naam():
+    from app.db.fuseki_entities import ensure_person_entity
+    from app.ontology import UFOC_NS
+
+    uri = await ensure_person_entity(TEST_SUPABASE_ID)
+
+    assert uri is not None
+    count = await _count_entities(f"{UFOC_NS}PhysicalAgent")
+    assert count == 1
+
+
+# ---------------------------------------------------------------------------
+# create_entity
+# ---------------------------------------------------------------------------
+
+async def test_create_entity_physical_agent():
+    from app.db.fuseki_entities import create_entity
+    from app.ontology import UFOC_NS
+
+    uri = await create_entity("PhysicalAgent", "Jan de Vries")
+
+    assert "urn:valor:entities:person:" in uri
+    count = await _count_entities(f"{UFOC_NS}PhysicalAgent")
+    assert count == 1
+
+
+async def test_create_entity_institutional_agent():
+    from app.db.fuseki_entities import create_entity
+    from app.ontology import UFOC_NS
+
+    uri = await create_entity("InstitutionalAgent", "Gemeente Amsterdam")
+
+    assert "urn:valor:entities:org:" in uri
+    count = await _count_entities(f"{UFOC_NS}InstitutionalAgent")
+    assert count == 1
+
+
+async def test_create_entity_normative_description():
+    from app.db.fuseki_entities import create_entity
+    from app.ontology import UFOC_NS
+
+    uri = await create_entity(
+        "NormativeDescription",
+        "Wet op de schuldsanering",
+        identifier="wsnp-2024",
+    )
+
+    assert uri == "urn:valor:entities:norm:wsnp-2024"
+    count = await _count_entities(f"{UFOC_NS}NormativeDescription")
+    assert count == 1
+
+
+async def test_create_entity_onbekend_type_geeft_error():
+    from app.db.fuseki_entities import create_entity
+
+    with pytest.raises(ValueError, match="Onbekend entity type"):
+        await create_entity("OnbestaandType", "Test")
+
+
+async def test_create_entity_met_properties():
+    from app.db.fuseki_entities import create_entity, get_entity
+
+    uri = await create_entity(
+        "InstitutionalAgent",
+        "Ministerie van SZW",
+        properties={"kvkNumber": "12345678"},
+    )
+    entity = await get_entity(uri)
+    assert entity is not None
+    assert entity["label"] == "Ministerie van SZW"
+
+
+# ---------------------------------------------------------------------------
+# get_entity
+# ---------------------------------------------------------------------------
+
+async def test_get_entity_retourneert_data():
+    from app.db.fuseki_entities import create_entity, get_entity
+
+    uri = await create_entity("PhysicalAgent", "Piet Jansen")
+    entity = await get_entity(uri)
+
+    assert entity is not None
+    assert entity["uri"] == uri
+    assert entity["entity_type"] == "PhysicalAgent"
+    assert entity["label"] == "Piet Jansen"
+
+
+async def test_get_entity_niet_bestaand_geeft_none():
+    from app.db.fuseki_entities import get_entity
+
+    result = await get_entity("urn:valor:entities:person:bestaat-niet")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# search_entities
+# ---------------------------------------------------------------------------
+
+async def test_search_entities_vindt_op_label():
+    from app.db.fuseki_entities import create_entity, search_entities
+
+    await create_entity("PhysicalAgent", "Maria van Dijk")
+    await create_entity("PhysicalAgent", "Johan van Dijk")
+    await create_entity("InstitutionalAgent", "Gemeente Rotterdam")
+
+    results = await search_entities("van dijk")
+    assert len(results) == 2
+    labels = [r["label"] for r in results]
+    assert "Maria van Dijk" in labels
+    assert "Johan van Dijk" in labels
+
+
+async def test_search_entities_filter_op_type():
+    from app.db.fuseki_entities import create_entity, search_entities
+
+    await create_entity("PhysicalAgent", "Maria Gemeente")
+    await create_entity("InstitutionalAgent", "Gemeente Alkmaar")
+
+    results = await search_entities("gemeente", entity_type="InstitutionalAgent")
+    assert len(results) == 1
+    assert results[0]["entity_type"] == "InstitutionalAgent"
+
+
+async def test_search_entities_leeg_resultaat():
+    from app.db.fuseki_entities import search_entities
+
+    results = await search_entities("xyzOnbestaandeNaam")
+    assert results == []
+
+
+# ---------------------------------------------------------------------------
+# assign_role + get_roles_for_entity
+# ---------------------------------------------------------------------------
+
+async def test_assign_role_en_ophalen():
+    from app.db.fuseki_entities import assign_role, create_entity, get_roles_for_entity
+
+    uri = await create_entity("InstitutionalAgent", "Gemeente Utrecht")
+    role_uri = "https://valor-ecosystem.nl/ontology/socia#Implementer"
+
+    await assign_role(uri, role_uri, TEST_DS_ID, context="Schuldhulpverlening")
+    roles = await get_roles_for_entity(uri, TEST_DS_ID)
+
+    assert len(roles) == 1
+    assert roles[0]["role_uri"] == role_uri
+    assert roles[0]["context"] == "Schuldhulpverlening"
+
+
+async def test_get_roles_voor_entity_zonder_rollen():
+    from app.db.fuseki_entities import create_entity, get_roles_for_entity
+
+    uri = await create_entity("PhysicalAgent", "Anonieme Gebruiker")
+    roles = await get_roles_for_entity(uri, TEST_DS_ID)
+
+    assert roles == []
+
+
+async def test_meerdere_rollen_per_entiteit():
+    from app.db.fuseki_entities import assign_role, create_entity, get_roles_for_entity
+
+    uri = await create_entity("InstitutionalAgent", "Belastingdienst")
+    role1 = "https://valor-ecosystem.nl/ontology/socia#Supervisor"
+    role2 = "https://valor-ecosystem.nl/ontology/socia#ChainPartner"
+
+    await assign_role(uri, role1, TEST_DS_ID)
+    await assign_role(uri, role2, TEST_DS_ID)
+
+    roles = await get_roles_for_entity(uri, TEST_DS_ID)
+    role_uris = [r["role_uri"] for r in roles]
+    assert role1 in role_uris
+    assert role2 in role_uris


### PR DESCRIPTION
## Summary

- Implementeert `urn:valor:entities` named graph als platform-brede Entity Registry voor rigide Kinds (US-AI.3)
- JIT-bridge: bij elke login wordt automatisch een `ufoc:PhysicalAgent` aangemaakt in de registry via `ensure_person_entity`
- 5 REST-endpoints: aanmaken, zoeken, ophalen, rol-toewijzen, rollen ophalen per entiteit

## Wijzigingen

- `backend/app/db/fuseki_entities.py` — DB-laag: `create_entity`, `get_entity`, `search_entities`, `assign_role`, `get_roles_for_entity`, `ensure_person_entity`, `backfill_existing_users`
- `backend/app/routers/entities.py` — Router met prefix `/entities` (5 endpoints)
- `backend/app/auth.py` — JIT-sync aanroep na `ensure_user_sync`
- `backend/app/main.py` — `entities.router` geregistreerd
- `backend/tests/integration/test_entities.py` — 14 integratietests

## Test plan

- [ ] `pytest tests/integration/test_entities.py -v` (vereist Fuseki op poort 3030)
- [ ] JIT-bridge: inloggen → controleer of PhysicalAgent aangemaakt is in `urn:valor:entities`
- [ ] `POST /entities/` met elk type (PhysicalAgent, InstitutionalAgent, NormativeDescription, SocialObject)
- [ ] `GET /entities/search?q=naam` — case-insensitive substring match
- [ ] `GET /entities/{uri}/roles?ds_id=xxx` — rollen per DesignSpace

🤖 Generated with [Claude Code](https://claude.com/claude-code)