### PR TITLE
feat(socia): ontologie-gedreven actor types, rollen en dependency types (US-AI.4) #485

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -111,6 +111,17 @@ async def list_epistemic_statuses():
     return get_epistemic_statuses()
 
 
+@app.get("/ontology/socia")
+async def list_socia_ontology():
+    """Retourneert SOCIA actor types, StakeholderRole instanties en DependencyType instanties (uit VALOR-O ontologie)."""
+    from app.services.ontology_cache import get_socia_actor_types, get_socia_dependency_types, get_socia_roles
+    return {
+        "actor_types": get_socia_actor_types(),
+        "roles": get_socia_roles(),
+        "dependency_types": get_socia_dependency_types(),
+    }
+
+
 @app.get("/health")
 async def health_check():
     is_connected = await verify_connectivity()

--- a/backend/app/services/ontology_cache.py
+++ b/backend/app/services/ontology_cache.py
@@ -8,10 +8,11 @@ Queryt de VALOR-O ontologie-graphs in Fuseki voor:
   - Statussen die een DecisionEpisode vereisen (valor:requiresDecisionEpisode)
   - UncertaintyLevel instanties (PAMS-taxonomie, English label -> URI)
   - disc:ContributionType instanties (Dutch label -> URI)
+  - SOCIA: actor types, StakeholderRole instanties, DependencyType instanties
 """
 import logging
 
-from app.ontology import VALOR_NS, VALOR_SITE_BASE
+from app.ontology import UFOC_NS, VALOR_NS, VALOR_SITE_BASE
 from app.services.fuseki import sparql_select_global
 
 logger = logging.getLogger(__name__)
@@ -35,6 +36,14 @@ _disc_contribution_type_label_to_uri: dict[str, str] = {}  # "Vraag" → URI
 _status_uri_to_nl_label: dict[str, str] = {}  # URI → "Betwist" etc.
 _system_situation_uris: set[str] = set()
 
+# SOCIA ontologie-data
+_SOCIA_GRAPH = f"{VALOR_NS}socia"
+_SOCIA_NS = f"{VALOR_NS}socia#"
+# [{uri, local_name, label_en, label_nl}]
+_socia_actor_types: list[dict] = []
+_socia_roles: list[dict] = []
+_socia_dependency_types: list[dict] = []
+
 
 _DISC_GRAPH = f"{VALOR_NS}disc"
 
@@ -45,6 +54,7 @@ async def load_ontology_cache() -> None:
     global _uncertainty_label_to_uri, _participant_role_data, _rbac_role_weights
     global _disc_contribution_type_label_to_uri, _status_uri_to_nl_label
     global _system_situation_uris
+    global _socia_actor_types, _socia_roles, _socia_dependency_types
 
     logger.info("[ontology-cache] Ontologie-data laden van Fuseki...")
 
@@ -216,6 +226,75 @@ async def load_ontology_cache() -> None:
     _system_situation_uris = {row["uri"] for row in sysont_rows}
     logger.info("[ontology-cache] SystemSituation URIs: %d geladen", len(_system_situation_uris))
 
+    # SOCIA: actor types (subklassen van ufoc:Agent)
+    actor_type_rows = await sparql_select_global(f"""
+        PREFIX ufoc: <{UFOC_NS}>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        SELECT ?uri ?labelEn ?labelNl WHERE {{
+          GRAPH <{_SOCIA_GRAPH}> {{
+            ?uri rdfs:subClassOf+ <{UFOC_NS}Agent> .
+            OPTIONAL {{ ?uri rdfs:label ?labelEn . FILTER(lang(?labelEn) = "en") }}
+            OPTIONAL {{ ?uri rdfs:label ?labelNl . FILTER(lang(?labelNl) = "nl") }}
+          }}
+        }}
+    """)
+    _socia_actor_types = [
+        {
+            "uri": row["uri"],
+            "local_name": row["uri"].split("#")[-1],
+            "label_en": row.get("labelEn", row["uri"].split("#")[-1]),
+            "label_nl": row.get("labelNl", row.get("labelEn", row["uri"].split("#")[-1])),
+        }
+        for row in actor_type_rows
+    ]
+    logger.info("[ontology-cache] SOCIA actor types: %s", [t["local_name"] for t in _socia_actor_types])
+
+    # SOCIA: StakeholderRole instanties
+    role_inst_rows = await sparql_select_global(f"""
+        PREFIX socia: <{_SOCIA_NS}>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        SELECT ?uri ?labelEn ?labelNl WHERE {{
+          GRAPH <{_SOCIA_GRAPH}> {{
+            ?uri a socia:StakeholderRole .
+            OPTIONAL {{ ?uri rdfs:label ?labelEn . FILTER(lang(?labelEn) = "en") }}
+            OPTIONAL {{ ?uri rdfs:label ?labelNl . FILTER(lang(?labelNl) = "nl") }}
+          }}
+        }}
+    """)
+    _socia_roles = [
+        {
+            "uri": row["uri"],
+            "local_name": row["uri"].split("#")[-1],
+            "label_en": row.get("labelEn", row["uri"].split("#")[-1]),
+            "label_nl": row.get("labelNl", row.get("labelEn", row["uri"].split("#")[-1])),
+        }
+        for row in role_inst_rows
+    ]
+    logger.info("[ontology-cache] SOCIA rollen: %s", [r["local_name"] for r in _socia_roles])
+
+    # SOCIA: DependencyType instanties
+    dep_type_rows = await sparql_select_global(f"""
+        PREFIX socia: <{_SOCIA_NS}>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        SELECT ?uri ?labelEn ?labelNl WHERE {{
+          GRAPH <{_SOCIA_GRAPH}> {{
+            ?uri a socia:DependencyType .
+            OPTIONAL {{ ?uri rdfs:label ?labelEn . FILTER(lang(?labelEn) = "en") }}
+            OPTIONAL {{ ?uri rdfs:label ?labelNl . FILTER(lang(?labelNl) = "nl") }}
+          }}
+        }}
+    """)
+    _socia_dependency_types = [
+        {
+            "uri": row["uri"],
+            "local_name": row["uri"].split("#")[-1],
+            "label_en": row.get("labelEn", row["uri"].split("#")[-1]),
+            "label_nl": row.get("labelNl", row.get("labelEn", row["uri"].split("#")[-1])),
+        }
+        for row in dep_type_rows
+    ]
+    logger.info("[ontology-cache] SOCIA dependency types: %s", [d["local_name"] for d in _socia_dependency_types])
+
     if not _evidence_label_to_uri or not _status_label_to_uri or not _valid_transitions:
         logger.warning(
             "[ontology-cache] Ontologie-cache onvolledig. "
@@ -300,3 +379,18 @@ def rbac_to_valor_role(rbac_role: str) -> str:
 
 def get_system_situation_uris() -> set[str]:
     return _system_situation_uris
+
+
+def get_socia_actor_types() -> list[dict]:
+    """Retourneert SOCIA actor types (subklassen van ufoc:Agent) met URI, local_name, label_en, label_nl."""
+    return _socia_actor_types
+
+
+def get_socia_roles() -> list[dict]:
+    """Retourneert socia:StakeholderRole instanties met URI, local_name, label_en, label_nl."""
+    return _socia_roles
+
+
+def get_socia_dependency_types() -> list[dict]:
+    """Retourneert socia:DependencyType instanties met URI, local_name, label_en, label_nl."""
+    return _socia_dependency_types

--- a/frontend/src/perspectives/socia/hooks/useSociaOntology.ts
+++ b/frontend/src/perspectives/socia/hooks/useSociaOntology.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect, useRef } from 'react';
+import { api, type SociaOntology } from '../../../services/api';
+
+const _cache: { data: SociaOntology | null } = { data: null };
+
+interface UseSociaOntologyResult {
+    ontology: SociaOntology | null;
+    loading: boolean;
+    error: Error | null;
+}
+
+export function useSociaOntology(): UseSociaOntologyResult {
+    const [ontology, setOntology] = useState<SociaOntology | null>(_cache.data);
+    const [loading, setLoading] = useState(_cache.data === null);
+    const [error, setError] = useState<Error | null>(null);
+    const fetchedRef = useRef(_cache.data !== null);
+
+    useEffect(() => {
+        if (fetchedRef.current) return;
+        fetchedRef.current = true;
+
+        api.getSociaOntology()
+            .then((data) => {
+                _cache.data = data;
+                setOntology(data);
+            })
+            .catch((err) => setError(err instanceof Error ? err : new Error(String(err))))
+            .finally(() => setLoading(false));
+    }, []);
+
+    return { ontology, loading, error };
+}

--- a/frontend/src/perspectives/socia/views/edges/DependencyEdge.tsx
+++ b/frontend/src/perspectives/socia/views/edges/DependencyEdge.tsx
@@ -1,0 +1,18 @@
+import { useSociaOntology } from '../../hooks/useSociaOntology';
+
+interface DependencyEdgeProps {
+    dependency_type_uri: string;
+}
+
+export function DependencyEdge({ dependency_type_uri }: DependencyEdgeProps) {
+    const { ontology } = useSociaOntology();
+
+    const depType = ontology?.dependency_types.find((d) => d.uri === dependency_type_uri);
+    const label = depType?.label_nl ?? dependency_type_uri.split('#').pop() ?? '';
+
+    return (
+        <span className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
+            {label}
+        </span>
+    );
+}

--- a/frontend/src/perspectives/socia/views/modals/CreateActorModal.tsx
+++ b/frontend/src/perspectives/socia/views/modals/CreateActorModal.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useSociaOntology } from '../../hooks/useSociaOntology';
+
+interface CreateActorModalProps {
+    open: boolean;
+    onClose: () => void;
+    onSubmit: (data: { label: string; actor_type_uri: string; role_uri?: string }) => void;
+}
+
+export function CreateActorModal({ open, onClose, onSubmit }: CreateActorModalProps) {
+    const { ontology, loading } = useSociaOntology();
+    const [label, setLabel] = useState('');
+    const [actorTypeUri, setActorTypeUri] = useState('');
+    const [roleUri, setRoleUri] = useState('');
+
+    function handleSubmit() {
+        if (!label.trim() || !actorTypeUri) return;
+        onSubmit({ label: label.trim(), actor_type_uri: actorTypeUri, role_uri: roleUri || undefined });
+        setLabel('');
+        setActorTypeUri('');
+        setRoleUri('');
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Actor toevoegen</DialogTitle>
+                </DialogHeader>
+
+                <div className="space-y-4 py-2">
+                    <div className="space-y-1">
+                        <Label htmlFor="actor-label">Naam</Label>
+                        <Input
+                            id="actor-label"
+                            value={label}
+                            onChange={(e) => setLabel(e.target.value)}
+                            placeholder="Naam van de actor"
+                        />
+                    </div>
+
+                    <div className="space-y-1">
+                        <Label htmlFor="actor-type">Type</Label>
+                        <Select value={actorTypeUri} onValueChange={setActorTypeUri} disabled={loading}>
+                            <SelectTrigger id="actor-type">
+                                <SelectValue placeholder={loading ? 'Laden...' : 'Kies een type'} />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {ontology?.actor_types.map((t) => (
+                                    <SelectItem key={t.uri} value={t.uri}>
+                                        {t.label_nl}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+
+                    <div className="space-y-1">
+                        <Label htmlFor="actor-role">Rol (optioneel)</Label>
+                        <Select value={roleUri} onValueChange={setRoleUri} disabled={loading}>
+                            <SelectTrigger id="actor-role">
+                                <SelectValue placeholder={loading ? 'Laden...' : 'Kies een rol'} />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="">— geen rol —</SelectItem>
+                                {ontology?.roles.map((r) => (
+                                    <SelectItem key={r.uri} value={r.uri}>
+                                        {r.label_nl}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                </div>
+
+                <DialogFooter>
+                    <Button variant="outline" onClick={onClose}>Annuleren</Button>
+                    <Button onClick={handleSubmit} disabled={!label.trim() || !actorTypeUri}>
+                        Toevoegen
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/frontend/src/perspectives/socia/views/modals/EditActorModal.tsx
+++ b/frontend/src/perspectives/socia/views/modals/EditActorModal.tsx
@@ -1,0 +1,102 @@
+import { useState, useEffect } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useSociaOntology } from '../../hooks/useSociaOntology';
+
+interface Actor {
+    uri: string;
+    label: string;
+    actor_type_uri: string;
+    role_uri?: string;
+}
+
+interface EditActorModalProps {
+    open: boolean;
+    actor: Actor | null;
+    onClose: () => void;
+    onSubmit: (data: { label: string; actor_type_uri: string; role_uri?: string }) => void;
+}
+
+export function EditActorModal({ open, actor, onClose, onSubmit }: EditActorModalProps) {
+    const { ontology, loading } = useSociaOntology();
+    const [label, setLabel] = useState('');
+    const [actorTypeUri, setActorTypeUri] = useState('');
+    const [roleUri, setRoleUri] = useState('');
+
+    useEffect(() => {
+        if (actor) {
+            setLabel(actor.label);
+            setActorTypeUri(actor.actor_type_uri);
+            setRoleUri(actor.role_uri ?? '');
+        }
+    }, [actor]);
+
+    function handleSubmit() {
+        if (!label.trim() || !actorTypeUri) return;
+        onSubmit({ label: label.trim(), actor_type_uri: actorTypeUri, role_uri: roleUri || undefined });
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Actor bewerken</DialogTitle>
+                </DialogHeader>
+
+                <div className="space-y-4 py-2">
+                    <div className="space-y-1">
+                        <Label htmlFor="edit-actor-label">Naam</Label>
+                        <Input
+                            id="edit-actor-label"
+                            value={label}
+                            onChange={(e) => setLabel(e.target.value)}
+                        />
+                    </div>
+
+                    <div className="space-y-1">
+                        <Label htmlFor="edit-actor-type">Type</Label>
+                        <Select value={actorTypeUri} onValueChange={setActorTypeUri} disabled={loading}>
+                            <SelectTrigger id="edit-actor-type">
+                                <SelectValue placeholder={loading ? 'Laden...' : 'Kies een type'} />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {ontology?.actor_types.map((t) => (
+                                    <SelectItem key={t.uri} value={t.uri}>
+                                        {t.label_nl}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+
+                    <div className="space-y-1">
+                        <Label htmlFor="edit-actor-role">Rol (optioneel)</Label>
+                        <Select value={roleUri} onValueChange={setRoleUri} disabled={loading}>
+                            <SelectTrigger id="edit-actor-role">
+                                <SelectValue placeholder={loading ? 'Laden...' : 'Kies een rol'} />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="">— geen rol —</SelectItem>
+                                {ontology?.roles.map((r) => (
+                                    <SelectItem key={r.uri} value={r.uri}>
+                                        {r.label_nl}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                </div>
+
+                <DialogFooter>
+                    <Button variant="outline" onClick={onClose}>Annuleren</Button>
+                    <Button onClick={handleSubmit} disabled={!label.trim() || !actorTypeUri}>
+                        Opslaan
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/frontend/src/perspectives/socia/views/nodes/ActorNode.tsx
+++ b/frontend/src/perspectives/socia/views/nodes/ActorNode.tsx
@@ -1,0 +1,30 @@
+import { useSociaOntology } from '../../hooks/useSociaOntology';
+
+interface ActorNodeProps {
+    label: string;
+    actor_type_uri: string;
+    role_uri?: string;
+}
+
+export function ActorNode({ label, actor_type_uri, role_uri }: ActorNodeProps) {
+    const { ontology } = useSociaOntology();
+
+    const actorType = ontology?.actor_types.find((t) => t.uri === actor_type_uri);
+    const role = role_uri ? ontology?.roles.find((r) => r.uri === role_uri) : null;
+
+    return (
+        <div className="flex flex-col items-center gap-1 px-3 py-2 rounded-lg border border-border bg-card text-card-foreground shadow-sm min-w-[120px]">
+            <span className="text-sm font-medium truncate max-w-[160px]">{label}</span>
+            {actorType && (
+                <span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+                    {actorType.label_nl}
+                </span>
+            )}
+            {role && (
+                <span className="text-xs px-2 py-0.5 rounded-full bg-primary/10 text-primary">
+                    {role.label_nl}
+                </span>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -63,6 +63,19 @@ export interface ValidationResult {
     message: string;
 }
 
+export interface SociaOntologyEntry {
+    uri: string;
+    local_name: string;
+    label_en: string;
+    label_nl: string;
+}
+
+export interface SociaOntology {
+    actor_types: SociaOntologyEntry[];
+    roles: SociaOntologyEntry[];
+    dependency_types: SociaOntologyEntry[];
+}
+
 export interface AgentResponse {
     agent_name: string;
     perspective: string;
@@ -616,6 +629,11 @@ export const api = {
     // Ontologie endpoints
     getEpistemicStatuses: async (): Promise<{ uri: string; label_en: string; label_nl: string }[]> => {
         const response = await apiClient.get('/ontology/epistemic-statuses');
+        return response.data;
+    },
+
+    getSociaOntology: async (): Promise<SociaOntology> => {
+        const response = await apiClient.get<SociaOntology>('/ontology/socia');
         return response.data;
     },
 


### PR DESCRIPTION
## Summary

- Geen hardcoded actor types, rollen of dependency types meer — alles dynamisch uit SOCIA-ontologie
- Bij startup laadt `ontology_cache.py` 3 nieuwe SPARQL-queries: actor types (subklassen ufoc:Agent), StakeholderRole instanties, DependencyType instanties
- Nieuw endpoint `GET /ontology/socia` geeft alle drie terug
- Frontend `useSociaOntology` hook met module-level cache; modals en nodes gebruiken ontologie-gedreven dropdowns/badges

## Wijzigingen

- `backend/app/services/ontology_cache.py` — 3 SPARQL-queries + `get_socia_actor_types/roles/dependency_types()`
- `backend/app/main.py` — `GET /ontology/socia` endpoint
- `frontend/src/services/api.ts` — `SociaOntologyEntry`, `SociaOntology` interfaces + `getSociaOntology()`
- `frontend/src/perspectives/socia/hooks/useSociaOntology.ts` — hook met cache
- `frontend/src/perspectives/socia/views/modals/CreateActorModal.tsx` — type/rol uit ontologie
- `frontend/src/perspectives/socia/views/modals/EditActorModal.tsx` — type/rol uit ontologie
- `frontend/src/perspectives/socia/views/nodes/ActorNode.tsx` — badge uit ontologie
- `frontend/src/perspectives/socia/views/edges/DependencyEdge.tsx` — label uit ontologie

## Test plan

- [ ] Backend opstart: logs tonen "SOCIA actor types: ['Stakeholder', 'HumanStakeholder', 'OrganisationalActor']"
- [ ] `GET /ontology/socia` retourneert 3 actor types, 6 rollen, 4 dependency types
- [ ] Frontend build slaagt zonder fouten
- [ ] CreateActorModal toont dropdowns gevuld vanuit ontologie (geen hardcoded waarden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)