### PR TITLE
feat(socia): cross-perspectief rolpatroon socia:playsRole in datalaag (US-AI.5) #486

### DIFF
--- a/backend/app/db/fuseki_socia.py
+++ b/backend/app/db/fuseki_socia.py
@@ -1,0 +1,192 @@
+"""SOCIA rolpatroon — named graph datalaag (US-AI.5).
+
+Implementeert het cross-perspectief rolpatroon waarbij een agent-URI
+via context-specifieke triples in de DesignSpace-graph een rol aanneemt.
+
+Architectuur:
+  urn:valor:entities              — rigide Kinds (PhysicalAgent, InstitutionalAgent, …)
+  urn:valor:ds:{ds_id}/baseline   — socia:playsRole assignaties per DesignSpace
+
+Patroon in baseline-graph:
+  <entity_uri> socia:playsRole <role_uri> ;
+               socia:isStakeholderIn <ds_uri> ;
+               valor:inDesignSpace <ds_uri> .
+"""
+import logging
+
+from app.ontology import VALOR_NS
+from app.services.fuseki import sparql_select_global, sparql_update
+
+logger = logging.getLogger(__name__)
+
+_SOCIA_NS = f"{VALOR_NS}socia#"
+_ENTITIES_GRAPH = "urn:valor:entities"
+_RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+_RDFS_LABEL = "http://www.w3.org/2000/01/rdf-schema#label"
+
+
+def _baseline_graph(ds_id: str) -> str:
+    return f"urn:valor:ds:{ds_id}/baseline"
+
+
+def _ds_uri(ds_id: str) -> str:
+    return f"urn:valor:ds:{ds_id}"
+
+
+def _escape(text: str) -> str:
+    return text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "")
+
+
+def _local_name(uri: str) -> str:
+    """Haalt het lokale fragment uit een URI (na # of laatste /)."""
+    if "#" in uri:
+        return uri.split("#")[-1]
+    return uri.rstrip("/").split("/")[-1]
+
+
+# ---------------------------------------------------------------------------
+# Rol-assignatie schrijven
+# ---------------------------------------------------------------------------
+
+async def assign_actor_role(entity_uri: str, role_uri: str, ds_id: str) -> None:
+    """Schrijft een socia:playsRole-assignatie naar de DesignSpace-baseline-graph.
+
+    Idempotent: bij bestaande assignatie wordt niets overschreven (INSERT WHERE NOT EXISTS).
+    """
+    baseline = _baseline_graph(ds_id)
+    ds_uri = _ds_uri(ds_id)
+
+    update = f"""
+        PREFIX socia: <{_SOCIA_NS}>
+        PREFIX valor: <{VALOR_NS}>
+
+        INSERT {{
+          GRAPH <{baseline}> {{
+            <{entity_uri}> socia:playsRole <{role_uri}> ;
+                           socia:isStakeholderIn <{ds_uri}> ;
+                           valor:inDesignSpace <{ds_uri}> .
+          }}
+        }}
+        WHERE {{
+          FILTER NOT EXISTS {{
+            GRAPH <{baseline}> {{
+              <{entity_uri}> socia:playsRole <{role_uri}> .
+            }}
+          }}
+        }}
+    """
+    await sparql_update(update, "socia-role")
+    logger.info("[fuseki-socia] playsRole: %s → %s in %s", entity_uri, role_uri, ds_id)
+
+
+# ---------------------------------------------------------------------------
+# Actor rollen in een DesignSpace ophalen
+# ---------------------------------------------------------------------------
+
+async def get_actor_roles_in_ds(ds_id: str) -> list[dict]:
+    """Retourneert alle actor-rol-paren in een DesignSpace, verrijkt met Entity Registry data.
+
+    JOIN-t urn:valor:entities voor label en rdf:type van de agent.
+    JOIN-t de SOCIA-ontologiegraph voor het Nederlands label van de rol.
+    """
+    baseline = _baseline_graph(ds_id)
+
+    rows = await sparql_select_global(f"""
+        PREFIX socia:  <{_SOCIA_NS}>
+        PREFIX valor:  <{VALOR_NS}>
+        PREFIX rdfs:   <{_RDFS_LABEL.rsplit('#', 1)[0]}#>
+        PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+        SELECT ?entity ?role ?entityLabel ?entityType ?roleLabel WHERE {{
+          GRAPH <{baseline}> {{
+            ?entity socia:playsRole ?role .
+          }}
+          OPTIONAL {{
+            GRAPH <{_ENTITIES_GRAPH}> {{
+              OPTIONAL {{ ?entity rdfs:label ?entityLabel . }}
+              OPTIONAL {{ ?entity rdf:type ?entityType . }}
+            }}
+          }}
+          OPTIONAL {{
+            GRAPH <{VALOR_NS}socia> {{
+              ?role rdfs:label ?roleLabel . FILTER(lang(?roleLabel) = "nl")
+            }}
+          }}
+        }}
+    """)
+
+    result = []
+    for row in rows:
+        entity_uri = row["entity"]
+        role_uri = row["role"]
+        result.append({
+            "entity_uri": entity_uri,
+            "role_uri": role_uri,
+            "entity_label": row.get("entityLabel", entity_uri.split(":")[-1]),
+            "entity_type": row.get("entityType", ""),
+            "entity_type_local": row.get("entityType", "").split("#")[-1],
+            "role_local": role_uri.split("#")[-1],
+            "role_label_nl": row.get("roleLabel", role_uri.split("#")[-1]),
+        })
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Tesserae over een agent ophalen (cross-perspectief)
+# ---------------------------------------------------------------------------
+
+async def get_tesserae_for_agent(entity_uri: str, ds_id: str) -> list[dict]:
+    """Retourneert alle Tesserae in een DesignSpace waar valor:claimedBy = entity_uri.
+
+    Queryt over alle named graphs van de DesignSpace (baseline + overige).
+    """
+    ds_prefix = f"urn:valor:ds:{ds_id}"
+
+    rows = await sparql_select_global(f"""
+        PREFIX valor: <{VALOR_NS}>
+        PREFIX rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+        PREFIX rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+        SELECT ?tessera ?type ?content ?graph WHERE {{
+          GRAPH ?graph {{
+            ?tessera valor:claimedBy <{entity_uri}> .
+            OPTIONAL {{ ?tessera rdf:type ?type . }}
+            OPTIONAL {{ ?tessera valor:claimContent ?content . }}
+          }}
+          FILTER(STRSTARTS(STR(?graph), "{ds_prefix}/"))
+        }}
+    """)
+
+    return [
+        {
+            "tessera_uri": row["tessera"],
+            "type": row.get("type", ""),
+            "type_local": _local_name(row.get("type", "")),
+            "content": row.get("content", ""),
+            "graph": row.get("graph", ""),
+        }
+        for row in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# DesignSpaces voor een agent ophalen
+# ---------------------------------------------------------------------------
+
+async def get_designspaces_for_agent(entity_uri: str) -> list[str]:
+    """Retourneert alle DesignSpace-IDs waar de agent een socia:playsRole heeft."""
+    rows = await sparql_select_global(f"""
+        PREFIX socia: <{_SOCIA_NS}>
+
+        SELECT DISTINCT ?ds WHERE {{
+          GRAPH ?graph {{
+            <{entity_uri}> socia:isStakeholderIn ?ds .
+          }}
+          FILTER(STRSTARTS(STR(?graph), "urn:valor:ds:"))
+        }}
+    """)
+
+    return [
+        row["ds"].replace("urn:valor:ds:", "")
+        for row in rows
+    ]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,6 +17,7 @@ from app.routers import factors, claims, organizations, hierarchy
 from app.routers import tessera
 from app.routers import designspace
 from app.routers import entities
+from app.routers import socia
 
 load_dotenv()
 
@@ -97,6 +98,7 @@ app.include_router(claims.router)
 app.include_router(tessera.router)
 app.include_router(designspace.router)
 app.include_router(entities.router)
+app.include_router(socia.router)
 
 
 @app.get("/")

--- a/backend/app/routers/socia.py
+++ b/backend/app/routers/socia.py
@@ -1,0 +1,57 @@
+"""SOCIA API-endpoints voor het cross-perspectief rolpatroon (US-AI.5)."""
+from fastapi import APIRouter, Depends, Query
+
+from app.auth import get_current_user
+from app.db.fuseki_socia import (
+    assign_actor_role,
+    get_actor_roles_in_ds,
+    get_designspaces_for_agent,
+    get_tesserae_for_agent,
+)
+
+router = APIRouter(tags=["socia"])
+
+
+@router.post("/designspace/{ds_id}/socia/roles")
+async def assign_role_endpoint(
+    ds_id: str,
+    entity_uri: str,
+    role_uri: str,
+    _user=Depends(get_current_user),
+):
+    """Wijst een socia:playsRole toe aan een agent in een DesignSpace."""
+    await assign_actor_role(entity_uri, role_uri, ds_id)
+    return {"status": "ok", "entity_uri": entity_uri, "role_uri": role_uri, "ds_id": ds_id}
+
+
+@router.get("/designspace/{ds_id}/socia/roles")
+async def get_roles_endpoint(
+    ds_id: str,
+    _user=Depends(get_current_user),
+):
+    """Retourneert alle actor-rol-paren in een DesignSpace."""
+    return await get_actor_roles_in_ds(ds_id)
+
+
+@router.get("/designspace/{ds_id}/socia/actors/{actor_uri:path}/tesserae")
+async def get_actor_tesserae_endpoint(
+    ds_id: str,
+    actor_uri: str,
+    _user=Depends(get_current_user),
+):
+    """Retourneert alle Tesserae in een DesignSpace waarop de agent is geclaimed (cross-perspectief)."""
+    if not actor_uri.startswith("urn:"):
+        actor_uri = actor_uri.replace("urn:/", "urn:").lstrip("/")
+    return await get_tesserae_for_agent(actor_uri, ds_id)
+
+
+@router.get("/agents/{agent_uri:path}/designspaces")
+async def get_agent_designspaces_endpoint(
+    agent_uri: str,
+    _user=Depends(get_current_user),
+):
+    """Retourneert alle DesignSpace-IDs waar de agent een socia:playsRole heeft."""
+    if not agent_uri.startswith("urn:"):
+        agent_uri = agent_uri.replace("urn:/", "urn:").lstrip("/")
+    ds_ids = await get_designspaces_for_agent(agent_uri)
+    return {"agent_uri": agent_uri, "designspaces": ds_ids}

--- a/backend/tests/integration/test_socia.py
+++ b/backend/tests/integration/test_socia.py
@@ -1,0 +1,313 @@
+"""Integratietests voor app.db.fuseki_socia (US-AI.5).
+
+Test:
+- assign_actor_role: schrijft socia:playsRole naar baseline-graph; idempotent
+- get_actor_roles_in_ds: retourneert juiste actor-rol-paren
+- get_tesserae_for_agent: vindt Tesserae waar valor:claimedBy = entity_uri
+- get_designspaces_for_agent: vindt alle DSes waar agent een playsRole heeft
+
+Gebruik:
+    cd backend
+    FUSEKI_URL=http://localhost:3030 pytest tests/integration/test_socia.py -v
+"""
+import sys
+import os
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+pytestmark = pytest.mark.integration
+
+_SOCIA_NS = "https://valor-ecosystem.nl/ontology/socia#"
+_VALOR_NS = "https://valor-ecosystem.nl/ontology/"
+_ENTITIES_GRAPH = "urn:valor:entities"
+
+TEST_DS_ID = "test-ds-socia"
+TEST_DS_ID_2 = "test-ds-socia-2"
+TEST_ENTITY_URI = "urn:valor:entities:person:socia-test-001"
+TEST_ROLE_URI = f"{_SOCIA_NS}Implementer"
+TEST_ROLE_URI_2 = f"{_SOCIA_NS}Supervisor"
+
+
+def _baseline_graph(ds_id: str) -> str:
+    return f"urn:valor:ds:{ds_id}/baseline"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _insert_triple(graph_uri: str, s: str, p: str, o: str, literal: bool = False) -> None:
+    """Voegt een triple in via sparql_update. Gebruik literal=True voor string-literals als object."""
+    from app.services.fuseki import sparql_update
+
+    o_str = f'"{o}"' if literal else f"<{o}>"
+    update = f"""
+        INSERT DATA {{
+          GRAPH <{graph_uri}> {{
+            <{s}> <{p}> {o_str} .
+          }}
+        }}
+    """
+    await sparql_update(update, "test-helper")
+
+
+async def _count_triples_in_graph(graph_uri: str, s: str, p: str, o: str) -> int:
+    """Telt triples die overeenkomen met het patroon in de opgegeven graph."""
+    from app.services.fuseki import sparql_select_global
+
+    rows = await sparql_select_global(f"""
+        SELECT (COUNT(*) AS ?c) WHERE {{
+          GRAPH <{graph_uri}> {{
+            <{s}> <{p}> <{o}> .
+          }}
+        }}
+    """)
+    return int(rows[0]["c"]) if rows else 0
+
+
+# ---------------------------------------------------------------------------
+# assign_actor_role
+# ---------------------------------------------------------------------------
+
+async def test_assign_actor_role_schrijft_plays_role_triple():
+    from app.db.fuseki_socia import assign_actor_role
+
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI, TEST_DS_ID)
+
+    count = await _count_triples_in_graph(
+        _baseline_graph(TEST_DS_ID),
+        TEST_ENTITY_URI,
+        f"{_SOCIA_NS}playsRole",
+        TEST_ROLE_URI,
+    )
+    assert count == 1
+
+
+async def test_assign_actor_role_schrijft_is_stakeholder_in():
+    from app.db.fuseki_socia import assign_actor_role
+
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI, TEST_DS_ID)
+
+    count = await _count_triples_in_graph(
+        _baseline_graph(TEST_DS_ID),
+        TEST_ENTITY_URI,
+        f"{_SOCIA_NS}isStakeholderIn",
+        f"urn:valor:ds:{TEST_DS_ID}",
+    )
+    assert count == 1
+
+
+async def test_assign_actor_role_idempotent():
+    from app.db.fuseki_socia import assign_actor_role
+
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI, TEST_DS_ID)
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI, TEST_DS_ID)
+
+    count = await _count_triples_in_graph(
+        _baseline_graph(TEST_DS_ID),
+        TEST_ENTITY_URI,
+        f"{_SOCIA_NS}playsRole",
+        TEST_ROLE_URI,
+    )
+    assert count == 1
+
+
+async def test_assign_actor_role_meerdere_rollen_mogelijk():
+    from app.db.fuseki_socia import assign_actor_role
+
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI, TEST_DS_ID)
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI_2, TEST_DS_ID)
+
+    count1 = await _count_triples_in_graph(
+        _baseline_graph(TEST_DS_ID),
+        TEST_ENTITY_URI,
+        f"{_SOCIA_NS}playsRole",
+        TEST_ROLE_URI,
+    )
+    count2 = await _count_triples_in_graph(
+        _baseline_graph(TEST_DS_ID),
+        TEST_ENTITY_URI,
+        f"{_SOCIA_NS}playsRole",
+        TEST_ROLE_URI_2,
+    )
+    assert count1 == 1
+    assert count2 == 1
+
+
+# ---------------------------------------------------------------------------
+# get_actor_roles_in_ds
+# ---------------------------------------------------------------------------
+
+async def test_get_actor_roles_in_ds_retourneert_rol_paar():
+    from app.db.fuseki_socia import assign_actor_role, get_actor_roles_in_ds
+
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI, TEST_DS_ID)
+
+    roles = await get_actor_roles_in_ds(TEST_DS_ID)
+
+    assert len(roles) == 1
+    assert roles[0]["entity_uri"] == TEST_ENTITY_URI
+    assert roles[0]["role_uri"] == TEST_ROLE_URI
+
+
+async def test_get_actor_roles_in_ds_bevat_role_local():
+    from app.db.fuseki_socia import assign_actor_role, get_actor_roles_in_ds
+
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI, TEST_DS_ID)
+
+    roles = await get_actor_roles_in_ds(TEST_DS_ID)
+
+    assert roles[0]["role_local"] == "Implementer"
+
+
+async def test_get_actor_roles_in_ds_join_entity_registry():
+    from app.db.fuseki_socia import assign_actor_role, get_actor_roles_in_ds
+    from app.ontology import UFOC_NS
+
+    # Entiteit aanmaken in Entity Registry
+    type_uri = f"{UFOC_NS}PhysicalAgent"
+    await _insert_triple(_ENTITIES_GRAPH, TEST_ENTITY_URI, "http://www.w3.org/1999/02/22-rdf-syntax-ns#type", type_uri)
+    await _insert_triple(_ENTITIES_GRAPH, TEST_ENTITY_URI, "http://www.w3.org/2000/01/rdf-schema#label", "Test Persoon", literal=True)
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI, TEST_DS_ID)
+
+    roles = await get_actor_roles_in_ds(TEST_DS_ID)
+
+    match = next((r for r in roles if r["entity_uri"] == TEST_ENTITY_URI), None)
+    assert match is not None
+    assert match["entity_type"] == type_uri
+    assert match["entity_type_local"] == "PhysicalAgent"
+
+
+async def test_get_actor_roles_in_ds_leeg_resultaat():
+    from app.db.fuseki_socia import get_actor_roles_in_ds
+
+    roles = await get_actor_roles_in_ds("ds-zonder-rollen")
+
+    assert roles == []
+
+
+async def test_get_actor_roles_in_ds_isoleert_per_ds():
+    from app.db.fuseki_socia import assign_actor_role, get_actor_roles_in_ds
+
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI, TEST_DS_ID)
+
+    roles_andere_ds = await get_actor_roles_in_ds(TEST_DS_ID_2)
+
+    assert roles_andere_ds == []
+
+
+# ---------------------------------------------------------------------------
+# get_tesserae_for_agent
+# ---------------------------------------------------------------------------
+
+async def test_get_tesserae_for_agent_vindt_tessera():
+    from app.db.fuseki_socia import get_tesserae_for_agent
+
+    tessera_uri = "urn:valor:tessera:socia-test-factor-001"
+    graph = _baseline_graph(TEST_DS_ID)
+
+    await _insert_triple(graph, tessera_uri, f"{_VALOR_NS}claimedBy", TEST_ENTITY_URI)
+
+    results = await get_tesserae_for_agent(TEST_ENTITY_URI, TEST_DS_ID)
+
+    assert len(results) == 1
+    assert results[0]["tessera_uri"] == tessera_uri
+    assert results[0]["graph"] == graph
+
+
+async def test_get_tesserae_for_agent_bevat_type_en_content():
+    from app.db.fuseki_socia import get_tesserae_for_agent
+    from app.services.fuseki import sparql_update
+
+    tessera_uri = "urn:valor:tessera:socia-test-factor-002"
+    type_uri = f"{_VALOR_NS}Factor"
+    graph = _baseline_graph(TEST_DS_ID)
+
+    update = f"""
+        INSERT DATA {{
+          GRAPH <{graph}> {{
+            <{tessera_uri}> <{_VALOR_NS}claimedBy> <{TEST_ENTITY_URI}> ;
+                            <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <{type_uri}> ;
+                            <{_VALOR_NS}claimContent> "Testinhoud" .
+          }}
+        }}
+    """
+    await sparql_update(update, "test-helper")
+
+    results = await get_tesserae_for_agent(TEST_ENTITY_URI, TEST_DS_ID)
+
+    match = next((r for r in results if r["tessera_uri"] == tessera_uri), None)
+    assert match is not None
+    assert match["type"] == type_uri
+    assert match["type_local"] == "Factor"
+    assert match["content"] == "Testinhoud"
+
+
+async def test_get_tesserae_for_agent_leeg_resultaat():
+    from app.db.fuseki_socia import get_tesserae_for_agent
+
+    results = await get_tesserae_for_agent("urn:valor:entities:person:bestaat-niet", TEST_DS_ID)
+
+    assert results == []
+
+
+async def test_get_tesserae_for_agent_isoleert_per_ds():
+    from app.db.fuseki_socia import get_tesserae_for_agent
+
+    tessera_uri = "urn:valor:tessera:socia-test-factor-003"
+    graph_andere_ds = _baseline_graph(TEST_DS_ID_2)
+
+    await _insert_triple(graph_andere_ds, tessera_uri, f"{_VALOR_NS}claimedBy", TEST_ENTITY_URI)
+
+    # DS2-tessera mag NIET zichtbaar zijn via DS1-query
+    results = await get_tesserae_for_agent(TEST_ENTITY_URI, TEST_DS_ID)
+    uris = [r["tessera_uri"] for r in results]
+    assert tessera_uri not in uris
+
+
+# ---------------------------------------------------------------------------
+# get_designspaces_for_agent
+# ---------------------------------------------------------------------------
+
+async def test_get_designspaces_for_agent_retourneert_ds_id():
+    from app.db.fuseki_socia import assign_actor_role, get_designspaces_for_agent
+
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI, TEST_DS_ID)
+
+    ds_ids = await get_designspaces_for_agent(TEST_ENTITY_URI)
+
+    assert TEST_DS_ID in ds_ids
+
+
+async def test_get_designspaces_for_agent_meerdere_ds():
+    from app.db.fuseki_socia import assign_actor_role, get_designspaces_for_agent
+
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI, TEST_DS_ID)
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI_2, TEST_DS_ID_2)
+
+    ds_ids = await get_designspaces_for_agent(TEST_ENTITY_URI)
+
+    assert TEST_DS_ID in ds_ids
+    assert TEST_DS_ID_2 in ds_ids
+
+
+async def test_get_designspaces_for_agent_leeg_resultaat():
+    from app.db.fuseki_socia import get_designspaces_for_agent
+
+    ds_ids = await get_designspaces_for_agent("urn:valor:entities:person:bestaat-niet")
+
+    assert ds_ids == []
+
+
+async def test_get_designspaces_for_agent_geen_duplicaten():
+    from app.db.fuseki_socia import assign_actor_role, get_designspaces_for_agent
+
+    # Twee rollen in dezelfde DS — DISTINCT moet zorgen voor één DS-ID
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI, TEST_DS_ID)
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI_2, TEST_DS_ID)
+
+    ds_ids = await get_designspaces_for_agent(TEST_ENTITY_URI)
+
+    assert ds_ids.count(TEST_DS_ID) == 1


### PR DESCRIPTION
## Summary

- Implementeert het ontologisch correcte rolpatroon: een agent-URI uit `urn:valor:entities` krijgt via `socia:playsRole` context-specifieke triples in de DesignSpace baseline-graph
- Cross-perspectief SPARQL: alle Tesserae over één agent ophalen over alle DesignSpace-graphs
- API voor "in welke DesignSpaces heeft agent X een rol?"

## Wijzigingen

- `backend/app/db/fuseki_socia.py` — `assign_actor_role`, `get_actor_roles_in_ds`, `get_tesserae_for_agent`, `get_designspaces_for_agent`
- `backend/app/routers/socia.py` — 4 endpoints: POST/GET roles, GET tesserae, GET designspaces
- `backend/app/main.py` — socia router geregistreerd
- `backend/tests/integration/test_socia.py` — 17 integratietests

## Patroon in baseline-graph

```turtle
# In urn:valor:ds:{ds_id}/baseline:
<urn:valor:entities:person:uuid> socia:playsRole socia:Implementer ;
    socia:isStakeholderIn <urn:valor:ds:{ds_id}> ;
    valor:inDesignSpace <urn:valor:ds:{ds_id}> .
```

## Test plan

- [ ] `pytest tests/integration/test_socia.py -v` — 17/17 groen ✅
- [ ] `POST /designspace/{ds_id}/socia/roles` — rol-assignatie aanmaken
- [ ] `GET /designspace/{ds_id}/socia/roles` — lijst met entity + rol + labels
- [ ] `GET /agents/{entity_uri}/designspaces` — welke DSes heeft deze agent?
- [ ] Frontend build geslaagd ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)