### PR TITLE
feat(entities): CausalVariable Entity Registry (US-AI.8) #489

### DIFF
--- a/backend/app/db/fuseki_entities.py
+++ b/backend/app/db/fuseki_entities.py
@@ -12,6 +12,7 @@ URI-conventies:
   urn:valor:entities:person:{random_uuid}     — externe personen
   urn:valor:entities:org:{random_uuid}        — organisaties
   urn:valor:entities:norm:{slug}              — wetten/regelingen
+  urn:valor:entities:cvar:{slug-of-uuid}      — causale variabelen (Factors)
 """
 import logging
 import uuid
@@ -20,6 +21,7 @@ from typing import Optional
 from app.ontology import UFOC_NS, VALOR_NS
 
 _LEXA_NS = f"{VALOR_NS}lexa-ext#"
+_CAUSA_NS = f"{VALOR_NS}causa#"
 from app.services.fuseki import sparql_select_global, sparql_update
 
 logger = logging.getLogger(__name__)
@@ -27,13 +29,15 @@ logger = logging.getLogger(__name__)
 _ENTITIES_GRAPH = "urn:valor:entities"
 _RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
 _RDFS_LABEL = "http://www.w3.org/2000/01/rdf-schema#label"
+_RDFS_COMMENT = "http://www.w3.org/2000/01/rdf-schema#comment"
 
-# Ondersteunde entity types → UFOC klasse-URI
+# Ondersteunde entity types → klasse-URI
 ENTITY_TYPE_MAP = {
     "PhysicalAgent": f"{UFOC_NS}PhysicalAgent",
     "InstitutionalAgent": f"{UFOC_NS}InstitutionalAgent",
     "NormativeDescription": f"{UFOC_NS}NormativeDescription",
     "SocialObject": f"{UFOC_NS}SocialObject",
+    "CausalVariable": f"{_CAUSA_NS}CausalVariable",
 }
 
 # URI-prefix per entity type
@@ -42,6 +46,7 @@ _URI_PREFIX_MAP = {
     "InstitutionalAgent": "org",
     "NormativeDescription": "norm",
     "SocialObject": "obj",
+    "CausalVariable": "cvar",
 }
 
 
@@ -395,6 +400,130 @@ LIMIT 100
         }
         for row in rows
     ]
+
+
+# ---------------------------------------------------------------------------
+# CausalVariable (US-AI.8)
+# ---------------------------------------------------------------------------
+
+async def create_causal_variable(
+    label: str,
+    identifier: Optional[str] = None,
+    domain: Optional[str] = None,
+    unit: Optional[str] = None,
+    comment: Optional[str] = None,
+) -> str:
+    """Maakt een causa:CausalVariable-instantie aan in urn:valor:entities.
+
+    identifier: optionele slug (bijv. "recidivecijfer"); anders UUID.
+    URI-patroon: urn:valor:entities:cvar:{identifier-or-uuid}
+
+    Geeft de URI terug.
+    """
+    slug = (identifier or str(uuid.uuid4())).lower().replace(" ", "-").replace("/", "-")
+    uri = f"{_ENTITIES_GRAPH}:cvar:{slug}"
+    label_escaped = _escape(label)
+
+    domain_triple = ""
+    if domain:
+        domain_triple = f'    <{VALOR_NS}domain> "{_escape(domain)}" ;\n'
+
+    unit_triple = ""
+    if unit:
+        unit_triple = f'    <{VALOR_NS}unit> "{_escape(unit)}" ;\n'
+
+    comment_triple = ""
+    if comment:
+        comment_triple = f'    <{_RDFS_COMMENT}> "{_escape(comment)}"@nl ;\n'
+
+    update = f"""
+INSERT DATA {{
+  GRAPH <{_ENTITIES_GRAPH}> {{
+    <{uri}> a <{_CAUSA_NS}CausalVariable> ;
+      <{_RDFS_LABEL}> "{label_escaped}"@nl ;
+{domain_triple}{unit_triple}{comment_triple}      <{VALOR_NS}entityCreatedAt> "{_now_iso()}"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+      <{VALOR_NS}entityId> "{slug}" .
+  }}
+}}
+"""
+    await sparql_update(update, "entities")
+    logger.info("Entity Registry: CausalVariable aangemaakt: %s (%s)", label, uri)
+    return uri
+
+
+async def search_cvars(
+    query: str,
+    domain: Optional[str] = None,
+    limit: int = 20,
+) -> list[dict]:
+    """Zoekt causa:CausalVariable-instanties in de Entity Registry op label of entityId.
+
+    Optionele filter op domain (beleidsdomein).
+    """
+    escaped_q = _escape(query.lower())
+    domain_filter = ""
+    if domain:
+        domain_filter = f'?uri <{VALOR_NS}domain> "{_escape(domain)}" .'
+
+    sparql = f"""
+SELECT ?uri ?label ?domain ?unit ?entityId WHERE {{
+  GRAPH <{_ENTITIES_GRAPH}> {{
+    ?uri a <{_CAUSA_NS}CausalVariable> .
+    OPTIONAL {{ ?uri <{_RDFS_LABEL}> ?label }}
+    OPTIONAL {{ ?uri <{VALOR_NS}domain> ?domain }}
+    OPTIONAL {{ ?uri <{VALOR_NS}unit> ?unit }}
+    OPTIONAL {{ ?uri <{VALOR_NS}entityId> ?entityId }}
+    {domain_filter}
+    FILTER (
+      CONTAINS(LCASE(STR(?label)), "{escaped_q}") ||
+      CONTAINS(STR(?uri), "{escaped_q}")
+    )
+  }}
+}}
+LIMIT {limit}
+"""
+    rows = await sparql_select_global(sparql)
+    return [
+        {
+            "uri": row["uri"],
+            "entity_type": "CausalVariable",
+            "label": row.get("label", ""),
+            "domain": row.get("domain", ""),
+            "unit": row.get("unit", ""),
+            "entity_id": row.get("entityId", ""),
+        }
+        for row in rows
+    ]
+
+
+async def get_cvar(uri: str) -> Optional[dict]:
+    """Haalt een CausalVariable op uit de Entity Registry op basis van URI."""
+    rows = await sparql_select_global(f"""
+SELECT ?label ?domain ?unit ?comment ?entityId ?createdAt WHERE {{
+  GRAPH <{_ENTITIES_GRAPH}> {{
+    <{uri}> a <{_CAUSA_NS}CausalVariable> .
+    OPTIONAL {{ <{uri}> <{_RDFS_LABEL}> ?label }}
+    OPTIONAL {{ <{uri}> <{VALOR_NS}domain> ?domain }}
+    OPTIONAL {{ <{uri}> <{VALOR_NS}unit> ?unit }}
+    OPTIONAL {{ <{uri}> <{_RDFS_COMMENT}> ?comment }}
+    OPTIONAL {{ <{uri}> <{VALOR_NS}entityId> ?entityId }}
+    OPTIONAL {{ <{uri}> <{VALOR_NS}entityCreatedAt> ?createdAt }}
+  }}
+}}
+""")
+    if not rows:
+        return None
+    row = rows[0]
+    return {
+        "uri": uri,
+        "entity_type": "CausalVariable",
+        "label": row.get("label"),
+        "domain": row.get("domain"),
+        "unit": row.get("unit"),
+        "comment": row.get("comment"),
+        "entity_id": row.get("entityId"),
+        "created_at": row.get("createdAt"),
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/routers/entities.py
+++ b/backend/app/routers/entities.py
@@ -1,4 +1,4 @@
-"""Entity Registry API endpoints (US-AI.3 / US-AI.7).
+"""Entity Registry API endpoints (US-AI.3 / US-AI.7 / US-AI.8).
 
 Routes:
   POST /entities/                                 — nieuwe entiteit aanmaken
@@ -6,6 +6,9 @@ Routes:
   POST /entities/norms/                           — normatief object aanmaken
   GET  /entities/norms/search?q=&jurisdiction=    — normen zoeken
   GET  /entities/norms/{uri}/cross-perspective    — cross-perspectief verwijzingen
+  POST /entities/cvars/                           — CausalVariable aanmaken
+  GET  /entities/cvars/search?q=&domain=          — CausalVariables zoeken
+  GET  /entities/cvars/{uri:path}                 — CausalVariable ophalen
   GET  /entities/{uri:path}                       — entiteitsdata ophalen
   GET  /entities/{uri:path}/roles?ds_id=          — rollen per DesignSpace
 """
@@ -17,11 +20,14 @@ from app.auth import get_current_user
 from app.db.fuseki_entities import (
     ENTITY_TYPE_MAP,
     assign_role,
+    create_causal_variable,
     create_entity,
     create_norm_entity,
+    get_cvar,
     get_entity,
     get_norm_cross_perspective,
     get_roles_for_entity,
+    search_cvars,
     search_entities,
     search_norms,
 )
@@ -53,6 +59,14 @@ class NormCreateRequest(BaseModel):
     identifier: str
     jurisdiction: Optional[str] = None
     effective_date: Optional[str] = None
+
+
+class CvarCreateRequest(BaseModel):
+    label: str
+    identifier: Optional[str] = None
+    domain: Optional[str] = None
+    unit: Optional[str] = None
+    comment: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -144,6 +158,48 @@ async def get_norm_cross_perspective_endpoint(
         uri = uri.replace("urn:/", "urn:").lstrip("/")
     refs = await get_norm_cross_perspective(uri)
     return {"norm_uri": uri, "references": refs, "count": len(refs)}
+
+
+@router.post("/cvars/", status_code=201)
+async def create_cvar_endpoint(
+    body: CvarCreateRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """Maakt een causa:CausalVariable aan in de Entity Registry."""
+    uri = await create_causal_variable(
+        label=body.label,
+        identifier=body.identifier,
+        domain=body.domain,
+        unit=body.unit,
+        comment=body.comment,
+    )
+    return {"uri": uri, "entity_type": "CausalVariable", "label": body.label}
+
+
+@router.get("/cvars/search")
+async def search_cvars_endpoint(
+    q: str = Query(..., min_length=1),
+    domain: Optional[str] = Query(None),
+    limit: int = Query(20, ge=1, le=100),
+    current_user: dict = Depends(get_current_user),
+):
+    """Zoekt causa:CausalVariable-instanties in de registry op label (substring, case-insensitief)."""
+    results = await search_cvars(query=q, domain=domain, limit=limit)
+    return {"results": results, "count": len(results)}
+
+
+@router.get("/cvars/{uri:path}")
+async def get_cvar_endpoint(
+    uri: str,
+    current_user: dict = Depends(get_current_user),
+):
+    """Haalt een CausalVariable op uit de registry op basis van URI."""
+    if not uri.startswith("urn:"):
+        uri = uri.replace("urn:/", "urn:").lstrip("/")
+    cvar = await get_cvar(uri=uri)
+    if cvar is None:
+        raise HTTPException(status_code=404, detail=f"CausalVariable niet gevonden: {uri}")
+    return cvar
 
 
 @router.get("/{uri:path}/roles")

--- a/backend/tests/integration/test_cvar_entities.py
+++ b/backend/tests/integration/test_cvar_entities.py
@@ -1,0 +1,315 @@
+"""Integratietests voor CausalVariable-functies in app.db.fuseki_entities (US-AI.8).
+
+Test:
+- create_causal_variable: URI-patroon, verplichte en optionele triples
+- search_cvars: zoeken op label, optionele domein-filter
+- get_cvar: ophalen op URI, niet-bestaande URI
+
+Gebruik:
+    cd backend
+    FUSEKI_URL=http://localhost:3030 pytest tests/integration/test_cvar_entities.py -v
+"""
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+pytestmark = pytest.mark.integration
+
+_ENTITIES_GRAPH = "urn:valor:entities"
+_CAUSA_NS = "https://valor-ecosystem.nl/ontology/causa#"
+_VALOR_NS = "https://valor-ecosystem.nl/ontology/"
+_RDFS_LABEL = "http://www.w3.org/2000/01/rdf-schema#label"
+_RDFS_COMMENT = "http://www.w3.org/2000/01/rdf-schema#comment"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _select(sparql: str) -> list[dict]:
+    from app.services.fuseki import sparql_select_global
+    return await sparql_select_global(sparql)
+
+
+async def _ask_triple(graph: str, subject: str, predicate: str, obj: str) -> bool:
+    rows = await _select(f"""
+SELECT (COUNT(*) AS ?c) WHERE {{
+  GRAPH <{graph}> {{
+    <{subject}> <{predicate}> <{obj}> .
+  }}
+}}
+""")
+    return int(rows[0]["c"]) > 0 if rows else False
+
+
+async def _ask_literal(graph: str, subject: str, predicate: str, value: str) -> bool:
+    rows = await _select(f"""
+SELECT ?val WHERE {{
+  GRAPH <{graph}> {{
+    <{subject}> <{predicate}> ?val .
+  }}
+}}
+""")
+    return any(value.lower() in str(r.get("val", "")).lower() for r in rows)
+
+
+async def _delete_cvar(uri: str) -> None:
+    from app.services.fuseki import sparql_update
+    await sparql_update(
+        f"DELETE WHERE {{ GRAPH <{_ENTITIES_GRAPH}> {{ <{uri}> ?p ?o }} }}",
+        "entities",
+    )
+
+
+# ---------------------------------------------------------------------------
+# create_causal_variable
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_create_cvar_geeft_urn_uri_terug():
+    from app.db.fuseki_entities import create_causal_variable
+    uri = await create_causal_variable(label="Test Variabele", identifier="test-var-uri")
+    try:
+        assert uri == f"{_ENTITIES_GRAPH}:cvar:test-var-uri"
+    finally:
+        await _delete_cvar(uri)
+
+
+@pytest.mark.asyncio
+async def test_create_cvar_schrijft_rdf_type():
+    from app.db.fuseki_entities import create_causal_variable
+    uri = await create_causal_variable(label="Recidivecijfer", identifier="recidivecijfer")
+    try:
+        has_type = await _ask_triple(
+            _ENTITIES_GRAPH, uri,
+            "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+            f"{_CAUSA_NS}CausalVariable",
+        )
+        assert has_type, "rdf:type causa:CausalVariable ontbreekt"
+    finally:
+        await _delete_cvar(uri)
+
+
+@pytest.mark.asyncio
+async def test_create_cvar_schrijft_label():
+    from app.db.fuseki_entities import create_causal_variable
+    uri = await create_causal_variable(label="Wachttijd jeugdzorg", identifier="wachttijd-jeugdzorg")
+    try:
+        has_label = await _ask_literal(_ENTITIES_GRAPH, uri, _RDFS_LABEL, "wachttijd jeugdzorg")
+        assert has_label, "rdfs:label ontbreekt"
+    finally:
+        await _delete_cvar(uri)
+
+
+@pytest.mark.asyncio
+async def test_create_cvar_schrijft_optioneel_domain():
+    from app.db.fuseki_entities import create_causal_variable
+    uri = await create_causal_variable(
+        label="Zorgkosten",
+        identifier="zorgkosten-test",
+        domain="gezondheidszorg",
+    )
+    try:
+        has_domain = await _ask_literal(
+            _ENTITIES_GRAPH, uri, f"{_VALOR_NS}domain", "gezondheidszorg"
+        )
+        assert has_domain, "valor:domain ontbreekt"
+    finally:
+        await _delete_cvar(uri)
+
+
+@pytest.mark.asyncio
+async def test_create_cvar_schrijft_optioneel_unit():
+    from app.db.fuseki_entities import create_causal_variable
+    uri = await create_causal_variable(
+        label="Gemiddeld Inkomen",
+        identifier="gemiddeld-inkomen-test",
+        unit="EUR/jaar",
+    )
+    try:
+        has_unit = await _ask_literal(
+            _ENTITIES_GRAPH, uri, f"{_VALOR_NS}unit", "EUR/jaar"
+        )
+        assert has_unit, "valor:unit ontbreekt"
+    finally:
+        await _delete_cvar(uri)
+
+
+@pytest.mark.asyncio
+async def test_create_cvar_schrijft_optioneel_comment():
+    from app.db.fuseki_entities import create_causal_variable
+    uri = await create_causal_variable(
+        label="Schuldendruk",
+        identifier="schuldendruk-test",
+        comment="Gemiddelde schuldenlast als % van inkomen",
+    )
+    try:
+        has_comment = await _ask_literal(
+            _ENTITIES_GRAPH, uri, _RDFS_COMMENT, "schuldenlast"
+        )
+        assert has_comment, "rdfs:comment ontbreekt"
+    finally:
+        await _delete_cvar(uri)
+
+
+@pytest.mark.asyncio
+async def test_create_cvar_zonder_identifier_genereert_uuid():
+    from app.db.fuseki_entities import create_causal_variable
+    uri = await create_causal_variable(label="Armoederisico")
+    try:
+        assert uri.startswith(f"{_ENTITIES_GRAPH}:cvar:")
+        slug = uri.split(":cvar:")[-1]
+        # UUID heeft 32 hex-chars + 4 streepjes = 36 tekens
+        assert len(slug) == 36, f"Verwacht UUID-slug maar kreeg: {slug}"
+    finally:
+        await _delete_cvar(uri)
+
+
+@pytest.mark.asyncio
+async def test_create_cvar_schrijft_entity_id():
+    from app.db.fuseki_entities import create_causal_variable
+    uri = await create_causal_variable(label="Criminaliteitscijfer", identifier="criminaliteit-test")
+    try:
+        has_id = await _ask_literal(
+            _ENTITIES_GRAPH, uri, f"{_VALOR_NS}entityId", "criminaliteit-test"
+        )
+        assert has_id, "valor:entityId ontbreekt"
+    finally:
+        await _delete_cvar(uri)
+
+
+# ---------------------------------------------------------------------------
+# search_cvars
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_search_cvars_vindt_op_label():
+    from app.db.fuseki_entities import create_causal_variable, search_cvars
+    uri = await create_causal_variable(label="Werkloosheidscijfer NL", identifier="werkloosheid-nl-search")
+    try:
+        results = await search_cvars("werkloosheid")
+        uris = [r["uri"] for r in results]
+        assert uri in uris, f"Verwachtte {uri} in zoekresultaten"
+    finally:
+        await _delete_cvar(uri)
+
+
+@pytest.mark.asyncio
+async def test_search_cvars_case_insensitief():
+    from app.db.fuseki_entities import create_causal_variable, search_cvars
+    uri = await create_causal_variable(label="Energieprijzen", identifier="energieprijzen-case-test")
+    try:
+        results = await search_cvars("ENERGIEPRIJZEN")
+        uris = [r["uri"] for r in results]
+        assert uri in uris
+    finally:
+        await _delete_cvar(uri)
+
+
+@pytest.mark.asyncio
+async def test_search_cvars_filtert_op_domain():
+    from app.db.fuseki_entities import create_causal_variable, search_cvars
+    uri_a = await create_causal_variable(
+        label="Luchtkwaliteit", identifier="luchtkwaliteit-dom-test",
+        domain="milieu"
+    )
+    uri_b = await create_causal_variable(
+        label="Zorgwachttijd", identifier="zorgwachttijd-dom-test",
+        domain="gezondheidszorg"
+    )
+    try:
+        results = await search_cvars("a", domain="milieu")
+        uris = [r["uri"] for r in results]
+        assert uri_a in uris, "milieu-variabele niet gevonden"
+        assert uri_b not in uris, "gezondheidszorg-variabele mag niet in milieu-resultaten"
+    finally:
+        await _delete_cvar(uri_a)
+        await _delete_cvar(uri_b)
+
+
+@pytest.mark.asyncio
+async def test_search_cvars_retourneert_entity_type_causalvariable():
+    from app.db.fuseki_entities import create_causal_variable, search_cvars
+    uri = await create_causal_variable(label="Participatiegraad", identifier="participatie-type-test")
+    try:
+        results = await search_cvars("participatiegraad")
+        match = next((r for r in results if r["uri"] == uri), None)
+        assert match is not None
+        assert match["entity_type"] == "CausalVariable"
+    finally:
+        await _delete_cvar(uri)
+
+
+@pytest.mark.asyncio
+async def test_search_cvars_geeft_lege_lijst_bij_geen_match():
+    from app.db.fuseki_entities import search_cvars
+    results = await search_cvars("xyznonexistentcvar12345")
+    assert results == []
+
+
+# ---------------------------------------------------------------------------
+# get_cvar
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_cvar_retourneert_volledige_data():
+    from app.db.fuseki_entities import create_causal_variable, get_cvar
+    uri = await create_causal_variable(
+        label="Belastingdruk",
+        identifier="belastingdruk-get-test",
+        domain="economie",
+        unit="%",
+        comment="Totale belastingdruk als percentage van BBP",
+    )
+    try:
+        result = await get_cvar(uri)
+        assert result is not None
+        assert result["uri"] == uri
+        assert result["entity_type"] == "CausalVariable"
+        assert "belastingdruk" in result["label"].lower()
+        assert result["domain"] == "economie"
+        assert result["unit"] == "%"
+        assert result["entity_id"] == "belastingdruk-get-test"
+    finally:
+        await _delete_cvar(uri)
+
+
+@pytest.mark.asyncio
+async def test_get_cvar_geeft_none_voor_niet_bestaande_uri():
+    from app.db.fuseki_entities import get_cvar
+    result = await get_cvar("urn:valor:entities:cvar:bestaat-niet-xyz")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_cvar_geeft_none_voor_andere_entity_type():
+    """Een PhysicalAgent mag niet als CausalVariable worden opgehaald."""
+    from app.db.fuseki_entities import create_entity, get_cvar
+    uri = await create_entity("PhysicalAgent", "Test Persoon", identifier="test-persoon-cvar-guard")
+    try:
+        result = await get_cvar(uri)
+        assert result is None, "get_cvar mag geen PhysicalAgent teruggeven"
+    finally:
+        from app.services.fuseki import sparql_update
+        await sparql_update(
+            f"DELETE WHERE {{ GRAPH <{_ENTITIES_GRAPH}> {{ <{uri}> ?p ?o }} }}",
+            "entities",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Hergebruik: zelfde slug = zelfde URI (idempotentie via slug)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_create_cvar_slug_is_deterministisch():
+    """Dezelfde identifier geeft altijd dezelfde URI (hergebruik-principe)."""
+    from app.db.fuseki_entities import create_causal_variable
+    uri1 = await create_causal_variable(label="Ongelijkheid", identifier="ongelijkheid-idem")
+    uri2 = await create_causal_variable(label="Ongelijkheid V2", identifier="ongelijkheid-idem")
+    try:
+        assert uri1 == uri2, "Dezelfde identifier moet dezelfde URI opleveren"
+    finally:
+        await _delete_cvar(uri1)


### PR DESCRIPTION
## Samenvatting

Registreert `causa:CausalVariable`-instanties als persistente rigide Kinds in de platformbrede Entity Registry (`urn:valor:entities`), zodat dezelfde causale variabele in meerdere CAUSA-modellen herbruikbaar is via één URI.

## Wijzigingen

### `backend/app/db/fuseki_entities.py`
- `CausalVariable` toegevoegd aan `ENTITY_TYPE_MAP` (klasse: `https://valor-ecosystem.nl/ontology/causa#CausalVariable`)
- URI-patroon: `urn:valor:entities:cvar:{slug-of-uuid}`
- Nieuwe functies:
  - `create_causal_variable(label, identifier, domain, unit, comment)` — maakt cvar aan
  - `search_cvars(query, domain, limit)` — zoekt op label/URI, optioneel gefilterd op beleidsdomein
  - `get_cvar(uri)` — haalt cvar op, type-check: retourneert `None` voor andere entity types

### `backend/app/routers/entities.py`
- `CvarCreateRequest` Pydantic model
- `POST /entities/cvars/` — nieuwe CausalVariable aanmaken
- `GET /entities/cvars/search?q=&domain=` — zoeken op label
- `GET /entities/cvars/{uri:path}` — ophalen op URI

### `backend/tests/integration/test_cvar_entities.py`
- 17 integratietests: aanmaak, URI-patroon, optionele velden, zoeken, filteren, ophalen, type-isolatie, slug-determinisme

## Testplan
- [x] `test_cvar_entities.py` — 17/17 groen
- [x] `test_norm_entities.py` — 22/22 groen (regressie)
- [x] `test_entities.py` — 16/16 groen (regressie)
- [x] Fuseki container draait (`valor-fuseki` healthy)

Sluit US-AI.8 (#489) — laatste story van Epic 18 (#481).

🤖 Generated with [Claude Code](https://claude.com/claude-code)