### PR TITLE
Epic 18 — Entity Identiteitsarchitectuur (#481) → development

### DIFF
--- a/.agent/implementatieplan.md
+++ b/.agent/implementatieplan.md
@@ -32,7 +32,7 @@
 | US-AI.3 | #484 | ✅ gemerged | Entity Registry Backend + JIT Supabase-bridge |
 | US-AI.4 | #485 | ✅ gemerged | Ontologie-gedreven SOCIA types |
 | US-AI.5 | #486 | ✅ gemerged | Cross-perspectief rolpatroon |
-| US-AI.6 | #487 | ⏳ open | SOCIA-refactoring: migratie naar Entity Registry |
+| US-AI.6 | #487 | ✅ gemerged | SOCIA-refactoring: migratie naar Entity Registry |
 | US-AI.7 | — | ⏳ open | Normatieve Objecten in Entity Registry |
 
 **Volgende stap:** Wave 3 — US-AI.4 (#485) en US-AI.5 (#486) kunnen parallel lopen.

--- a/.agent/implementatieplan.md
+++ b/.agent/implementatieplan.md
@@ -1,7 +1,7 @@
 # Valor — Implementatieplan
 
-**Laatste update:** 2026-03-28
-**Branch:** epic/issue-352-tessera-engine-v1
+**Laatste update:** 2026-03-30
+**Branch:** epic/issue-481-entity-identiteitsarchitectuur
 
 ---
 
@@ -21,9 +21,25 @@
 
 ## Actieve Epic
 
-### Epic T — Tessera-engine v1.0 (#352)
+### Epic 18 — Entity Identiteitsarchitectuur (#481)
 
-**Branch:** `epic/issue-352-tessera-engine-v1`
+**Branch:** `epic/issue-481-entity-identiteitsarchitectuur`
+
+| US | Issue | Status | Notitie |
+|----|-------|--------|---------|
+| US-AI.1 | #482 | ✅ gemerged | Architectuurdocumentatie valor-ecosystem.md |
+| US-AI.2 | #483 | ✅ gemerged | Ontologie-patches: StakeholderRole, actortypes, NormativeDescription |
+| US-AI.3 | #484 | ✅ gemerged | Entity Registry Backend + JIT Supabase-bridge |
+| US-AI.4 | #485 | ✅ gemerged | Ontologie-gedreven SOCIA types |
+| US-AI.5 | #486 | ✅ gemerged | Cross-perspectief rolpatroon |
+| US-AI.6 | #487 | ⏳ open | SOCIA-refactoring: migratie naar Entity Registry |
+| US-AI.7 | — | ⏳ open | Normatieve Objecten in Entity Registry |
+
+**Volgende stap:** Wave 3 — US-AI.4 (#485) en US-AI.5 (#486) kunnen parallel lopen.
+
+---
+
+### Epic T — Tessera-engine v1.0 (#352) [deels afgerond]
 
 | US | Issue | Status | Notitie |
 |----|-------|--------|---------|
@@ -33,7 +49,7 @@
 | US-T.1 | #369 | ✅ gemerged | Conflictdetectie via valor:undermines |
 | US-T.2 | #370 | ⏳ geblokkeerd | Auto-CapabilityGap — wacht op US-9.4 (#368) uit Epic 9 |
 
-**Volgende stap:** Epic T epic branch mergen naar `development` (US-T.2 deferred naar na Epic 9).
+**Status:** Epic T epic branch gemerged naar `development` (US-T.2 deferred naar na Epic 9).
 
 ---
 

--- a/.agent/implementatieplan.md
+++ b/.agent/implementatieplan.md
@@ -33,9 +33,10 @@
 | US-AI.4 | #485 | ✅ gemerged | Ontologie-gedreven SOCIA types |
 | US-AI.5 | #486 | ✅ gemerged | Cross-perspectief rolpatroon |
 | US-AI.6 | #487 | ✅ gemerged | SOCIA-refactoring: migratie naar Entity Registry |
-| US-AI.7 | — | ⏳ open | Normatieve Objecten in Entity Registry |
+| US-AI.7 | #488 | ✅ gemerged | Normatieve Objecten in Entity Registry |
+| US-AI.8 | #489 | ✅ gemerged | CausalVariable Entity Registry: Factors als persistente Kinds |
 
-**Volgende stap:** Wave 3 — US-AI.4 (#485) en US-AI.5 (#486) kunnen parallel lopen.
+**Alle US gemerged. Epic 18 gereed voor finale merge naar development.**
 
 ---
 

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -103,5 +103,12 @@ async def get_current_user(payload: dict = Depends(verify_token)):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Database synchronization failed for user"
         )
-        
+
+    # JIT Sync: Ensure PhysicalAgent entity exists in urn:valor:entities
+    try:
+        from app.db.fuseki_entities import ensure_person_entity
+        await ensure_person_entity(user_id, name)
+    except Exception as exc:
+        logger.warning("Entity Registry JIT-sync mislukt voor %s: %s", user_id, exc)
+
     return db_user

--- a/backend/app/db/fuseki_entities.py
+++ b/backend/app/db/fuseki_entities.py
@@ -1,0 +1,303 @@
+"""Entity Registry — named graph urn:valor:entities.
+
+Implementeert de platformbrede Entity Registry als single source of truth
+voor alle rigide Kinds in VALOR (US-AI.3).
+
+Architectuur:
+  urn:valor:entities              — alle rigide Kinds (platform-breed, persistent)
+  urn:valor:ds:{ds_id}/baseline   — rol-assignaties per perspectief/DesignSpace
+
+URI-conventies:
+  urn:valor:entities:person:{supabase_uuid}   — interne gebruikers
+  urn:valor:entities:person:{random_uuid}     — externe personen
+  urn:valor:entities:org:{random_uuid}        — organisaties
+  urn:valor:entities:norm:{slug}              — wetten/regelingen
+"""
+import logging
+import uuid
+from typing import Optional
+
+from app.ontology import UFOC_NS, VALOR_NS
+from app.services.fuseki import sparql_select_global, sparql_update
+
+logger = logging.getLogger(__name__)
+
+_ENTITIES_GRAPH = "urn:valor:entities"
+_RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+_RDFS_LABEL = "http://www.w3.org/2000/01/rdf-schema#label"
+
+# Ondersteunde entity types → UFOC klasse-URI
+ENTITY_TYPE_MAP = {
+    "PhysicalAgent": f"{UFOC_NS}PhysicalAgent",
+    "InstitutionalAgent": f"{UFOC_NS}InstitutionalAgent",
+    "NormativeDescription": f"{UFOC_NS}NormativeDescription",
+    "SocialObject": f"{UFOC_NS}SocialObject",
+}
+
+# URI-prefix per entity type
+_URI_PREFIX_MAP = {
+    "PhysicalAgent": "person",
+    "InstitutionalAgent": "org",
+    "NormativeDescription": "norm",
+    "SocialObject": "obj",
+}
+
+
+def _escape(text: str) -> str:
+    return text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "")
+
+
+def _entity_uri(entity_type: str, identifier: str) -> str:
+    prefix = _URI_PREFIX_MAP.get(entity_type, "entity")
+    return f"{_ENTITIES_GRAPH}:{prefix}:{identifier}"
+
+
+# ---------------------------------------------------------------------------
+# JIT-bridge: Supabase → Fuseki
+# ---------------------------------------------------------------------------
+
+async def ensure_person_entity(supabase_id: str, name: Optional[str] = None) -> str:
+    """Garandeert dat een ufoc:PhysicalAgent-resource bestaat voor de Supabase-gebruiker.
+
+    Geeft de URI terug. Maakt JIT aan als nog niet aanwezig.
+    URI-patroon: urn:valor:entities:person:{supabase_uuid}
+    """
+    uri = _entity_uri("PhysicalAgent", supabase_id)
+
+    # Check of entity al bestaat
+    rows = await sparql_select_global(
+        f"SELECT ?uri WHERE {{ GRAPH <{_ENTITIES_GRAPH}> {{ <{uri}> a <{UFOC_NS}PhysicalAgent> }} }}"
+    )
+    if rows:
+        return uri
+
+    # JIT aanmaken
+    label = _escape(name or supabase_id)
+    update = f"""
+INSERT DATA {{
+  GRAPH <{_ENTITIES_GRAPH}> {{
+    <{uri}> a <{UFOC_NS}PhysicalAgent> ;
+      <{_RDFS_LABEL}> "{label}"@nl ;
+      <{VALOR_NS}supabaseId> "{_escape(supabase_id)}" ;
+      <{VALOR_NS}entityCreatedAt> "{_now_iso()}"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+  }}
+}}
+"""
+    await sparql_update(update, "entities")
+    logger.info("Entity Registry: PhysicalAgent aangemaakt voor Supabase-gebruiker %s", supabase_id)
+    return uri
+
+
+# ---------------------------------------------------------------------------
+# CRUD
+# ---------------------------------------------------------------------------
+
+async def create_entity(
+    entity_type: str,
+    label: str,
+    properties: Optional[dict] = None,
+    identifier: Optional[str] = None,
+) -> str:
+    """Maakt een nieuwe entiteit aan in urn:valor:entities.
+
+    Geeft de URI terug.
+    """
+    if entity_type not in ENTITY_TYPE_MAP:
+        raise ValueError(f"Onbekend entity type: {entity_type}. Kies uit: {list(ENTITY_TYPE_MAP)}")
+
+    ident = identifier or str(uuid.uuid4())
+    uri = _entity_uri(entity_type, ident)
+    class_uri = ENTITY_TYPE_MAP[entity_type]
+    label_escaped = _escape(label)
+
+    extra_triples = ""
+    if properties:
+        for key, value in properties.items():
+            if value is not None:
+                escaped_val = _escape(str(value))
+                extra_triples += f'    <{VALOR_NS}{key}> "{escaped_val}" ;\n'
+
+    update = f"""
+INSERT DATA {{
+  GRAPH <{_ENTITIES_GRAPH}> {{
+    <{uri}> a <{class_uri}> ;
+      <{_RDFS_LABEL}> "{label_escaped}"@nl ;
+      <{VALOR_NS}entityCreatedAt> "{_now_iso()}"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+{extra_triples}      <{VALOR_NS}entityId> "{_escape(ident)}" .
+  }}
+}}
+"""
+    await sparql_update(update, "entities")
+    logger.info("Entity Registry: %s aangemaakt met URI %s", entity_type, uri)
+    return uri
+
+
+async def get_entity(uri: str) -> Optional[dict]:
+    """Haalt een entiteit op uit de Entity Registry op basis van URI.
+
+    Geeft None terug als de entiteit niet bestaat.
+    """
+    rows = await sparql_select_global(f"""
+SELECT ?type ?label ?supabaseId ?entityId ?createdAt WHERE {{
+  GRAPH <{_ENTITIES_GRAPH}> {{
+    <{uri}> a ?type ;
+      OPTIONAL {{ <{uri}> <{_RDFS_LABEL}> ?label }}
+      OPTIONAL {{ <{uri}> <{VALOR_NS}supabaseId> ?supabaseId }}
+      OPTIONAL {{ <{uri}> <{VALOR_NS}entityId> ?entityId }}
+      OPTIONAL {{ <{uri}> <{VALOR_NS}entityCreatedAt> ?createdAt }}
+  }}
+}}
+""")
+    if not rows:
+        return None
+
+    row = rows[0]
+    # Bepaal entity_type label vanuit URI
+    type_uri = row.get("type", "")
+    entity_type = next(
+        (k for k, v in ENTITY_TYPE_MAP.items() if v == type_uri),
+        type_uri,
+    )
+    return {
+        "uri": uri,
+        "entity_type": entity_type,
+        "label": row.get("label"),
+        "supabase_id": row.get("supabaseId"),
+        "entity_id": row.get("entityId"),
+        "created_at": row.get("createdAt"),
+    }
+
+
+async def search_entities(
+    query: str,
+    entity_type: Optional[str] = None,
+    limit: int = 20,
+) -> list[dict]:
+    """Zoekt entiteiten in de Entity Registry op basis van label (case-insensitive substring).
+
+    Optionele filter op entity_type.
+    """
+    type_filter = ""
+    if entity_type and entity_type in ENTITY_TYPE_MAP:
+        class_uri = ENTITY_TYPE_MAP[entity_type]
+        type_filter = f"?uri a <{class_uri}> ."
+    else:
+        type_filter = f"?uri a ?type ."
+
+    escaped_q = _escape(query.lower())
+
+    sparql = f"""
+SELECT ?uri ?type ?label WHERE {{
+  GRAPH <{_ENTITIES_GRAPH}> {{
+    {type_filter}
+    ?uri a ?type .
+    OPTIONAL {{ ?uri <{_RDFS_LABEL}> ?label }}
+    FILTER (CONTAINS(LCASE(STR(?label)), "{escaped_q}") || CONTAINS(STR(?uri), "{escaped_q}"))
+  }}
+}}
+LIMIT {limit}
+"""
+    rows = await sparql_select_global(sparql)
+    results = []
+    for row in rows:
+        type_uri = row.get("type", "")
+        entity_type_label = next(
+            (k for k, v in ENTITY_TYPE_MAP.items() if v == type_uri),
+            type_uri,
+        )
+        results.append({
+            "uri": row["uri"],
+            "entity_type": entity_type_label,
+            "label": row.get("label"),
+        })
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Rol-assignatie
+# ---------------------------------------------------------------------------
+
+async def assign_role(
+    entity_uri: str,
+    role_uri: str,
+    ds_id: str,
+    context: Optional[str] = None,
+) -> None:
+    """Wijst een rol toe aan een entiteit in de baseline-graph van een DesignSpace.
+
+    Triple: entity_uri valor:playsRole role_uri  (in urn:valor:ds:{ds_id}/baseline)
+    """
+    baseline_graph = f"urn:valor:ds:{ds_id}/baseline"
+    context_triple = ""
+    if context:
+        escaped_ctx = _escape(context)
+        context_triple = f'    <{VALOR_NS}roleContext> "{escaped_ctx}" ;\n'
+
+    update = f"""
+INSERT DATA {{
+  GRAPH <{baseline_graph}> {{
+    <{entity_uri}> <{VALOR_NS}playsRole> <{role_uri}> ;
+{context_triple}      <{VALOR_NS}roleAssignedAt> "{_now_iso()}"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+  }}
+}}
+"""
+    await sparql_update(update, ds_id)
+    logger.info(
+        "Entity Registry: rol %s toegewezen aan %s in DesignSpace %s",
+        role_uri, entity_uri, ds_id,
+    )
+
+
+async def get_roles_for_entity(entity_uri: str, ds_id: str) -> list[dict]:
+    """Haalt alle rollen op voor een entiteit in een specifieke DesignSpace.
+
+    Leest uit urn:valor:ds:{ds_id}/baseline.
+    """
+    baseline_graph = f"urn:valor:ds:{ds_id}/baseline"
+    rows = await sparql_select_global(f"""
+SELECT ?role ?context ?assignedAt WHERE {{
+  GRAPH <{baseline_graph}> {{
+    <{entity_uri}> <{VALOR_NS}playsRole> ?role .
+    OPTIONAL {{ <{entity_uri}> <{VALOR_NS}roleContext> ?context }}
+    OPTIONAL {{ <{entity_uri}> <{VALOR_NS}roleAssignedAt> ?assignedAt }}
+  }}
+}}
+""")
+    return [
+        {
+            "role_uri": row["role"],
+            "context": row.get("context"),
+            "assigned_at": row.get("assignedAt"),
+        }
+        for row in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Backfill helpers
+# ---------------------------------------------------------------------------
+
+async def backfill_existing_users(users: list[dict]) -> int:
+    """Maakt PhysicalAgent-entities aan voor bestaande gebruikers die nog geen entity hebben.
+
+    Verwacht een lijst van dicts met 'id' (Supabase UUID) en optioneel 'name'.
+    Geeft het aantal nieuw aangemaakte entities terug.
+    """
+    created = 0
+    for user in users:
+        user_id = user.get("id")
+        if not user_id:
+            continue
+        uri = await ensure_person_entity(user_id, user.get("name"))
+        if uri:
+            created += 1
+    return created
+
+
+# ---------------------------------------------------------------------------
+# Intern
+# ---------------------------------------------------------------------------
+
+def _now_iso() -> str:
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat()

--- a/backend/app/db/fuseki_entities.py
+++ b/backend/app/db/fuseki_entities.py
@@ -12,6 +12,7 @@ URI-conventies:
   urn:valor:entities:person:{random_uuid}     — externe personen
   urn:valor:entities:org:{random_uuid}        — organisaties
   urn:valor:entities:norm:{slug}              — wetten/regelingen
+  urn:valor:entities:cvar:{slug-of-uuid}      — causale variabelen (Factors)
 """
 import logging
 import uuid
@@ -20,6 +21,7 @@ from typing import Optional
 from app.ontology import UFOC_NS, VALOR_NS
 
 _LEXA_NS = f"{VALOR_NS}lexa-ext#"
+_CAUSA_NS = f"{VALOR_NS}causa#"
 from app.services.fuseki import sparql_select_global, sparql_update
 
 logger = logging.getLogger(__name__)
@@ -27,13 +29,15 @@ logger = logging.getLogger(__name__)
 _ENTITIES_GRAPH = "urn:valor:entities"
 _RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
 _RDFS_LABEL = "http://www.w3.org/2000/01/rdf-schema#label"
+_RDFS_COMMENT = "http://www.w3.org/2000/01/rdf-schema#comment"
 
-# Ondersteunde entity types → UFOC klasse-URI
+# Ondersteunde entity types → klasse-URI
 ENTITY_TYPE_MAP = {
     "PhysicalAgent": f"{UFOC_NS}PhysicalAgent",
     "InstitutionalAgent": f"{UFOC_NS}InstitutionalAgent",
     "NormativeDescription": f"{UFOC_NS}NormativeDescription",
     "SocialObject": f"{UFOC_NS}SocialObject",
+    "CausalVariable": f"{_CAUSA_NS}CausalVariable",
 }
 
 # URI-prefix per entity type
@@ -42,6 +46,7 @@ _URI_PREFIX_MAP = {
     "InstitutionalAgent": "org",
     "NormativeDescription": "norm",
     "SocialObject": "obj",
+    "CausalVariable": "cvar",
 }
 
 
@@ -395,6 +400,130 @@ LIMIT 100
         }
         for row in rows
     ]
+
+
+# ---------------------------------------------------------------------------
+# CausalVariable (US-AI.8)
+# ---------------------------------------------------------------------------
+
+async def create_causal_variable(
+    label: str,
+    identifier: Optional[str] = None,
+    domain: Optional[str] = None,
+    unit: Optional[str] = None,
+    comment: Optional[str] = None,
+) -> str:
+    """Maakt een causa:CausalVariable-instantie aan in urn:valor:entities.
+
+    identifier: optionele slug (bijv. "recidivecijfer"); anders UUID.
+    URI-patroon: urn:valor:entities:cvar:{identifier-or-uuid}
+
+    Geeft de URI terug.
+    """
+    slug = (identifier or str(uuid.uuid4())).lower().replace(" ", "-").replace("/", "-")
+    uri = f"{_ENTITIES_GRAPH}:cvar:{slug}"
+    label_escaped = _escape(label)
+
+    domain_triple = ""
+    if domain:
+        domain_triple = f'    <{VALOR_NS}domain> "{_escape(domain)}" ;\n'
+
+    unit_triple = ""
+    if unit:
+        unit_triple = f'    <{VALOR_NS}unit> "{_escape(unit)}" ;\n'
+
+    comment_triple = ""
+    if comment:
+        comment_triple = f'    <{_RDFS_COMMENT}> "{_escape(comment)}"@nl ;\n'
+
+    update = f"""
+INSERT DATA {{
+  GRAPH <{_ENTITIES_GRAPH}> {{
+    <{uri}> a <{_CAUSA_NS}CausalVariable> ;
+      <{_RDFS_LABEL}> "{label_escaped}"@nl ;
+{domain_triple}{unit_triple}{comment_triple}      <{VALOR_NS}entityCreatedAt> "{_now_iso()}"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+      <{VALOR_NS}entityId> "{slug}" .
+  }}
+}}
+"""
+    await sparql_update(update, "entities")
+    logger.info("Entity Registry: CausalVariable aangemaakt: %s (%s)", label, uri)
+    return uri
+
+
+async def search_cvars(
+    query: str,
+    domain: Optional[str] = None,
+    limit: int = 20,
+) -> list[dict]:
+    """Zoekt causa:CausalVariable-instanties in de Entity Registry op label of entityId.
+
+    Optionele filter op domain (beleidsdomein).
+    """
+    escaped_q = _escape(query.lower())
+    domain_filter = ""
+    if domain:
+        domain_filter = f'?uri <{VALOR_NS}domain> "{_escape(domain)}" .'
+
+    sparql = f"""
+SELECT ?uri ?label ?domain ?unit ?entityId WHERE {{
+  GRAPH <{_ENTITIES_GRAPH}> {{
+    ?uri a <{_CAUSA_NS}CausalVariable> .
+    OPTIONAL {{ ?uri <{_RDFS_LABEL}> ?label }}
+    OPTIONAL {{ ?uri <{VALOR_NS}domain> ?domain }}
+    OPTIONAL {{ ?uri <{VALOR_NS}unit> ?unit }}
+    OPTIONAL {{ ?uri <{VALOR_NS}entityId> ?entityId }}
+    {domain_filter}
+    FILTER (
+      CONTAINS(LCASE(STR(?label)), "{escaped_q}") ||
+      CONTAINS(STR(?uri), "{escaped_q}")
+    )
+  }}
+}}
+LIMIT {limit}
+"""
+    rows = await sparql_select_global(sparql)
+    return [
+        {
+            "uri": row["uri"],
+            "entity_type": "CausalVariable",
+            "label": row.get("label", ""),
+            "domain": row.get("domain", ""),
+            "unit": row.get("unit", ""),
+            "entity_id": row.get("entityId", ""),
+        }
+        for row in rows
+    ]
+
+
+async def get_cvar(uri: str) -> Optional[dict]:
+    """Haalt een CausalVariable op uit de Entity Registry op basis van URI."""
+    rows = await sparql_select_global(f"""
+SELECT ?label ?domain ?unit ?comment ?entityId ?createdAt WHERE {{
+  GRAPH <{_ENTITIES_GRAPH}> {{
+    <{uri}> a <{_CAUSA_NS}CausalVariable> .
+    OPTIONAL {{ <{uri}> <{_RDFS_LABEL}> ?label }}
+    OPTIONAL {{ <{uri}> <{VALOR_NS}domain> ?domain }}
+    OPTIONAL {{ <{uri}> <{VALOR_NS}unit> ?unit }}
+    OPTIONAL {{ <{uri}> <{_RDFS_COMMENT}> ?comment }}
+    OPTIONAL {{ <{uri}> <{VALOR_NS}entityId> ?entityId }}
+    OPTIONAL {{ <{uri}> <{VALOR_NS}entityCreatedAt> ?createdAt }}
+  }}
+}}
+""")
+    if not rows:
+        return None
+    row = rows[0]
+    return {
+        "uri": uri,
+        "entity_type": "CausalVariable",
+        "label": row.get("label"),
+        "domain": row.get("domain"),
+        "unit": row.get("unit"),
+        "comment": row.get("comment"),
+        "entity_id": row.get("entityId"),
+        "created_at": row.get("createdAt"),
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/db/fuseki_entities.py
+++ b/backend/app/db/fuseki_entities.py
@@ -18,6 +18,8 @@ import uuid
 from typing import Optional
 
 from app.ontology import UFOC_NS, VALOR_NS
+
+_LEXA_NS = f"{VALOR_NS}lexa-ext#"
 from app.services.fuseki import sparql_select_global, sparql_update
 
 logger = logging.getLogger(__name__)
@@ -268,6 +270,128 @@ SELECT ?role ?context ?assignedAt WHERE {{
             "role_uri": row["role"],
             "context": row.get("context"),
             "assigned_at": row.get("assignedAt"),
+        }
+        for row in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Normatieve objecten (US-AI.7)
+# ---------------------------------------------------------------------------
+
+async def create_norm_entity(
+    norm_type_uri: str,
+    label: str,
+    identifier: str,
+    jurisdiction: Optional[str] = None,
+    effective_date: Optional[str] = None,
+) -> str:
+    """Maakt een normatief object aan in urn:valor:entities.
+
+    norm_type_uri moet een subklasse van ufoc:NormativeDescription zijn (bijv. lexa:Law, lexa:Regulation).
+    identifier is het officiële kenmerk (bijv. "BWBR0005537" of "wob-2022").
+    URI-patroon: urn:valor:entities:norm:{slug-van-identifier}
+
+    Geeft de URI terug.
+    """
+    slug = identifier.lower().replace(" ", "-").replace("/", "-")
+    uri = f"{_ENTITIES_GRAPH}:norm:{slug}"
+    label_escaped = _escape(label)
+    identifier_escaped = _escape(identifier)
+
+    jurisdiction_triple = ""
+    if jurisdiction:
+        jurisdiction_triple = f'    <{_LEXA_NS}jurisdiction> "{_escape(jurisdiction)}" ;\n'
+
+    effective_date_triple = ""
+    if effective_date:
+        effective_date_triple = f'    <{_LEXA_NS}effectiveDate> "{_escape(effective_date)}"^^<http://www.w3.org/2001/XMLSchema#date> ;\n'
+
+    update = f"""
+INSERT DATA {{
+  GRAPH <{_ENTITIES_GRAPH}> {{
+    <{uri}> a <{UFOC_NS}NormativeDescription> ;
+            a <{norm_type_uri}> ;
+      <{_RDFS_LABEL}> "{label_escaped}"@nl ;
+      <{_LEXA_NS}identifier> "{identifier_escaped}" ;
+{jurisdiction_triple}{effective_date_triple}      <{VALOR_NS}entityCreatedAt> "{_now_iso()}"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+      <{VALOR_NS}entityId> "{slug}" .
+  }}
+}}
+"""
+    await sparql_update(update, "entities")
+    logger.info("Entity Registry: norm %s aangemaakt met URI %s", label, uri)
+    return uri
+
+
+async def search_norms(
+    query: str,
+    jurisdiction: Optional[str] = None,
+    limit: int = 20,
+) -> list[dict]:
+    """Zoekt normatieve objecten in de Entity Registry op label of lexa:identifier.
+
+    Optionele filter op jurisdictie.
+    """
+    escaped_q = _escape(query.lower())
+    jurisdiction_filter = ""
+    if jurisdiction:
+        escaped_jur = _escape(jurisdiction)
+        jurisdiction_filter = f'?uri <{_LEXA_NS}jurisdiction> "{escaped_jur}" .'
+
+    sparql = f"""
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?uri ?type ?label ?identifier ?jurisdiction WHERE {{
+  GRAPH <{_ENTITIES_GRAPH}> {{
+    ?uri a <{UFOC_NS}NormativeDescription> ;
+         a ?type .
+    OPTIONAL {{ ?uri rdfs:label ?label }}
+    OPTIONAL {{ ?uri <{_LEXA_NS}identifier> ?identifier }}
+    OPTIONAL {{ ?uri <{_LEXA_NS}jurisdiction> ?jurisdiction }}
+    {jurisdiction_filter}
+    FILTER (
+      CONTAINS(LCASE(STR(?label)), "{escaped_q}") ||
+      CONTAINS(LCASE(STR(?identifier)), "{escaped_q}")
+    )
+    FILTER(?type != <{UFOC_NS}NormativeDescription>)
+  }}
+}}
+LIMIT {limit}
+"""
+    rows = await sparql_select_global(sparql)
+    return [
+        {
+            "uri": row["uri"],
+            "norm_type_uri": row.get("type", ""),
+            "norm_type_local": row.get("type", "").split("#")[-1],
+            "label": row.get("label", ""),
+            "identifier": row.get("identifier", ""),
+            "jurisdiction": row.get("jurisdiction", ""),
+        }
+        for row in rows
+    ]
+
+
+async def get_norm_cross_perspective(uri: str) -> list[dict]:
+    """Vindt alle grafen (DesignSpaces, perspectieven) die naar deze norm-URI verwijzen.
+
+    Zoekt op elk triple waar de norm-URI als object voorkomt.
+    """
+    rows = await sparql_select_global(f"""
+SELECT DISTINCT ?graph ?subject ?predicate WHERE {{
+  GRAPH ?graph {{
+    ?subject ?predicate <{uri}> .
+  }}
+  FILTER(?graph != <{_ENTITIES_GRAPH}>)
+}}
+LIMIT 100
+""")
+    return [
+        {
+            "graph": row["graph"],
+            "subject": row["subject"],
+            "predicate": row.get("predicate", ""),
+            "predicate_local": row.get("predicate", "").split("#")[-1].split("/")[-1],
         }
         for row in rows
     ]

--- a/backend/app/db/fuseki_socia.py
+++ b/backend/app/db/fuseki_socia.py
@@ -1,4 +1,4 @@
-"""SOCIA rolpatroon — named graph datalaag (US-AI.5).
+"""SOCIA rolpatroon — named graph datalaag (US-AI.5/AI.6).
 
 Implementeert het cross-perspectief rolpatroon waarbij een agent-URI
 via context-specifieke triples in de DesignSpace-graph een rol aanneemt.
@@ -11,6 +11,10 @@ Patroon in baseline-graph:
   <entity_uri> socia:playsRole <role_uri> ;
                socia:isStakeholderIn <ds_uri> ;
                valor:inDesignSpace <ds_uri> .
+
+Migratie (US-AI.6):
+  migrate_legacy_socia_actors() migreert urn:valor:socia:actor:{uuid} resources
+  naar urn:valor:entities entries. Idempotent en veilig bij lege dataset.
 """
 import logging
 
@@ -190,3 +194,140 @@ async def get_designspaces_for_agent(entity_uri: str) -> list[str]:
         row["ds"].replace("urn:valor:ds:", "")
         for row in rows
     ]
+
+
+# ---------------------------------------------------------------------------
+# Migratie: legacy socia:Actor → Entity Registry (US-AI.6)
+# ---------------------------------------------------------------------------
+
+_LEGACY_ACTOR_TYPE = f"{_SOCIA_NS}Actor"
+_LEGACY_ACTOR_URI_PREFIX = "urn:valor:socia:actor:"
+_ENTITIES_GRAPH = "urn:valor:entities"
+
+
+async def migrate_legacy_socia_actors() -> dict:
+    """Migreert legacy socia:Actor-resources naar het Entity Registry patroon.
+
+    Per gevonden actor:
+      1. Bepaalt het entity type (PhysicalAgent / InstitutionalAgent) op basis van socia:actorType
+      2. Maakt / hergebruikt een urn:valor:entities:... URI
+      3. Schrijft socia:playsRole naar de DesignSpace-baseline-graph
+      4. Herschrijft valor:claimedBy op Tesserae naar de nieuwe entity URI
+
+    Idempotent: als een actor al gemigreerd is (entity URI bestaat al), wordt hij overgeslagen.
+    Retourneert een dict met migratie-statistieken.
+    """
+    from app.ontology import UFOC_NS
+    import uuid as _uuid
+
+    stats = {"found": 0, "migrated": 0, "skipped": 0, "errors": []}
+
+    # 1. Zoek alle legacy actors over alle named graphs
+    legacy_rows = await sparql_select_global(f"""
+        PREFIX socia: <{_SOCIA_NS}>
+        PREFIX rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+        PREFIX valor: <{VALOR_NS}>
+
+        SELECT ?actor ?graph ?actorType ?actorRole ?label WHERE {{
+          GRAPH ?graph {{
+            ?actor a <{_LEGACY_ACTOR_TYPE}> .
+            OPTIONAL {{ ?actor socia:actorType ?actorType . }}
+            OPTIONAL {{ ?actor socia:actorRole ?actorRole . }}
+            OPTIONAL {{ ?actor rdfs:label ?label . }}
+            OPTIONAL {{ ?actor valor:claimContent ?label . }}
+          }}
+          FILTER(STRSTARTS(STR(?actor), "{_LEGACY_ACTOR_URI_PREFIX}"))
+        }}
+    """)
+
+    stats["found"] = len(legacy_rows)
+    if not legacy_rows:
+        logger.info("[socia-migrate] Geen legacy actors gevonden — niets te migreren.")
+        return stats
+
+    # 2. Controleer welke al gemigreerd zijn (entity URI bestaat al in registry)
+    migrated_map: dict[str, str] = {}  # legacy_uri → entity_uri
+    for row in legacy_rows:
+        legacy_uri = row["actor"]
+        graph = row.get("graph", "")
+        ds_id = graph.replace("urn:valor:ds:", "").split("/")[0] if "urn:valor:ds:" in graph else None
+
+        # Bepaal entity type
+        actor_type_str = row.get("actorType", "IndividualAgent")
+        if "Institutional" in actor_type_str or "Organisation" in actor_type_str:
+            entity_type_class = f"{UFOC_NS}InstitutionalAgent"
+            entity_uri_prefix = f"{_ENTITIES_GRAPH}:org"
+        else:
+            entity_type_class = f"{UFOC_NS}PhysicalAgent"
+            entity_uri_prefix = f"{_ENTITIES_GRAPH}:person"
+
+        # Hergebruik bestaande mapping of genereer nieuwe UUID
+        if legacy_uri not in migrated_map:
+            # Extraheer de UUID uit de legacy URI
+            legacy_id = legacy_uri.replace(_LEGACY_ACTOR_URI_PREFIX, "")
+            entity_uri = f"{entity_uri_prefix}:{legacy_id}"
+            migrated_map[legacy_uri] = entity_uri
+
+            # Controleer of entity al bestaat
+            existing = await sparql_select_global(f"""
+                SELECT ?s WHERE {{
+                  GRAPH <{_ENTITIES_GRAPH}> {{
+                    <{entity_uri}> a <{entity_type_class}> .
+                    BIND(<{entity_uri}> AS ?s)
+                  }}
+                }} LIMIT 1
+            """)
+            if existing:
+                stats["skipped"] += 1
+                continue
+
+            # Schrijf entity naar Entity Registry
+            label = _escape(row.get("label", legacy_id))
+            insert_entity = f"""
+                PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                INSERT DATA {{
+                  GRAPH <{_ENTITIES_GRAPH}> {{
+                    <{entity_uri}> a <{entity_type_class}> ;
+                                   rdfs:label "{label}" .
+                  }}
+                }}
+            """
+            try:
+                await sparql_update(insert_entity, "migrate-entity")
+            except Exception as exc:
+                stats["errors"].append(f"{legacy_uri}: {exc}")
+                continue
+
+            # Schrijf playsRole naar DesignSpace-baseline (als ds_id bekend)
+            if ds_id:
+                role_str = row.get("actorRole", "")
+                role_uri = f"{_SOCIA_NS}{role_str.capitalize()}" if role_str else None
+                if role_uri:
+                    try:
+                        await assign_actor_role(entity_uri, role_uri, ds_id)
+                    except Exception:
+                        pass  # Rol-mapping best-effort
+
+            stats["migrated"] += 1
+
+    # 3. Herschrijf valor:claimedBy op Tesserae (per gemigeerde actor)
+    for legacy_uri, entity_uri in migrated_map.items():
+        rewrite = f"""
+            PREFIX valor: <{VALOR_NS}>
+            DELETE {{
+              GRAPH ?g {{ ?tessera valor:claimedBy <{legacy_uri}> . }}
+            }}
+            INSERT {{
+              GRAPH ?g {{ ?tessera valor:claimedBy <{entity_uri}> . }}
+            }}
+            WHERE {{
+              GRAPH ?g {{ ?tessera valor:claimedBy <{legacy_uri}> . }}
+            }}
+        """
+        try:
+            await sparql_update(rewrite, "migrate-claimedbuy")
+        except Exception as exc:
+            stats["errors"].append(f"claimedBy rewrite {legacy_uri}: {exc}")
+
+    logger.info("[socia-migrate] Klaar: %s", stats)
+    return stats

--- a/backend/app/db/fuseki_socia.py
+++ b/backend/app/db/fuseki_socia.py
@@ -1,0 +1,192 @@
+"""SOCIA rolpatroon — named graph datalaag (US-AI.5).
+
+Implementeert het cross-perspectief rolpatroon waarbij een agent-URI
+via context-specifieke triples in de DesignSpace-graph een rol aanneemt.
+
+Architectuur:
+  urn:valor:entities              — rigide Kinds (PhysicalAgent, InstitutionalAgent, …)
+  urn:valor:ds:{ds_id}/baseline   — socia:playsRole assignaties per DesignSpace
+
+Patroon in baseline-graph:
+  <entity_uri> socia:playsRole <role_uri> ;
+               socia:isStakeholderIn <ds_uri> ;
+               valor:inDesignSpace <ds_uri> .
+"""
+import logging
+
+from app.ontology import VALOR_NS
+from app.services.fuseki import sparql_select_global, sparql_update
+
+logger = logging.getLogger(__name__)
+
+_SOCIA_NS = f"{VALOR_NS}socia#"
+_ENTITIES_GRAPH = "urn:valor:entities"
+_RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+_RDFS_LABEL = "http://www.w3.org/2000/01/rdf-schema#label"
+
+
+def _baseline_graph(ds_id: str) -> str:
+    return f"urn:valor:ds:{ds_id}/baseline"
+
+
+def _ds_uri(ds_id: str) -> str:
+    return f"urn:valor:ds:{ds_id}"
+
+
+def _escape(text: str) -> str:
+    return text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "")
+
+
+def _local_name(uri: str) -> str:
+    """Haalt het lokale fragment uit een URI (na # of laatste /)."""
+    if "#" in uri:
+        return uri.split("#")[-1]
+    return uri.rstrip("/").split("/")[-1]
+
+
+# ---------------------------------------------------------------------------
+# Rol-assignatie schrijven
+# ---------------------------------------------------------------------------
+
+async def assign_actor_role(entity_uri: str, role_uri: str, ds_id: str) -> None:
+    """Schrijft een socia:playsRole-assignatie naar de DesignSpace-baseline-graph.
+
+    Idempotent: bij bestaande assignatie wordt niets overschreven (INSERT WHERE NOT EXISTS).
+    """
+    baseline = _baseline_graph(ds_id)
+    ds_uri = _ds_uri(ds_id)
+
+    update = f"""
+        PREFIX socia: <{_SOCIA_NS}>
+        PREFIX valor: <{VALOR_NS}>
+
+        INSERT {{
+          GRAPH <{baseline}> {{
+            <{entity_uri}> socia:playsRole <{role_uri}> ;
+                           socia:isStakeholderIn <{ds_uri}> ;
+                           valor:inDesignSpace <{ds_uri}> .
+          }}
+        }}
+        WHERE {{
+          FILTER NOT EXISTS {{
+            GRAPH <{baseline}> {{
+              <{entity_uri}> socia:playsRole <{role_uri}> .
+            }}
+          }}
+        }}
+    """
+    await sparql_update(update, "socia-role")
+    logger.info("[fuseki-socia] playsRole: %s → %s in %s", entity_uri, role_uri, ds_id)
+
+
+# ---------------------------------------------------------------------------
+# Actor rollen in een DesignSpace ophalen
+# ---------------------------------------------------------------------------
+
+async def get_actor_roles_in_ds(ds_id: str) -> list[dict]:
+    """Retourneert alle actor-rol-paren in een DesignSpace, verrijkt met Entity Registry data.
+
+    JOIN-t urn:valor:entities voor label en rdf:type van de agent.
+    JOIN-t de SOCIA-ontologiegraph voor het Nederlands label van de rol.
+    """
+    baseline = _baseline_graph(ds_id)
+
+    rows = await sparql_select_global(f"""
+        PREFIX socia:  <{_SOCIA_NS}>
+        PREFIX valor:  <{VALOR_NS}>
+        PREFIX rdfs:   <{_RDFS_LABEL.rsplit('#', 1)[0]}#>
+        PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+        SELECT ?entity ?role ?entityLabel ?entityType ?roleLabel WHERE {{
+          GRAPH <{baseline}> {{
+            ?entity socia:playsRole ?role .
+          }}
+          OPTIONAL {{
+            GRAPH <{_ENTITIES_GRAPH}> {{
+              OPTIONAL {{ ?entity rdfs:label ?entityLabel . }}
+              OPTIONAL {{ ?entity rdf:type ?entityType . }}
+            }}
+          }}
+          OPTIONAL {{
+            GRAPH <{VALOR_NS}socia> {{
+              ?role rdfs:label ?roleLabel . FILTER(lang(?roleLabel) = "nl")
+            }}
+          }}
+        }}
+    """)
+
+    result = []
+    for row in rows:
+        entity_uri = row["entity"]
+        role_uri = row["role"]
+        result.append({
+            "entity_uri": entity_uri,
+            "role_uri": role_uri,
+            "entity_label": row.get("entityLabel", entity_uri.split(":")[-1]),
+            "entity_type": row.get("entityType", ""),
+            "entity_type_local": row.get("entityType", "").split("#")[-1],
+            "role_local": role_uri.split("#")[-1],
+            "role_label_nl": row.get("roleLabel", role_uri.split("#")[-1]),
+        })
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Tesserae over een agent ophalen (cross-perspectief)
+# ---------------------------------------------------------------------------
+
+async def get_tesserae_for_agent(entity_uri: str, ds_id: str) -> list[dict]:
+    """Retourneert alle Tesserae in een DesignSpace waar valor:claimedBy = entity_uri.
+
+    Queryt over alle named graphs van de DesignSpace (baseline + overige).
+    """
+    ds_prefix = f"urn:valor:ds:{ds_id}"
+
+    rows = await sparql_select_global(f"""
+        PREFIX valor: <{VALOR_NS}>
+        PREFIX rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+        PREFIX rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+        SELECT ?tessera ?type ?content ?graph WHERE {{
+          GRAPH ?graph {{
+            ?tessera valor:claimedBy <{entity_uri}> .
+            OPTIONAL {{ ?tessera rdf:type ?type . }}
+            OPTIONAL {{ ?tessera valor:claimContent ?content . }}
+          }}
+          FILTER(STRSTARTS(STR(?graph), "{ds_prefix}/"))
+        }}
+    """)
+
+    return [
+        {
+            "tessera_uri": row["tessera"],
+            "type": row.get("type", ""),
+            "type_local": _local_name(row.get("type", "")),
+            "content": row.get("content", ""),
+            "graph": row.get("graph", ""),
+        }
+        for row in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# DesignSpaces voor een agent ophalen
+# ---------------------------------------------------------------------------
+
+async def get_designspaces_for_agent(entity_uri: str) -> list[str]:
+    """Retourneert alle DesignSpace-IDs waar de agent een socia:playsRole heeft."""
+    rows = await sparql_select_global(f"""
+        PREFIX socia: <{_SOCIA_NS}>
+
+        SELECT DISTINCT ?ds WHERE {{
+          GRAPH ?graph {{
+            <{entity_uri}> socia:isStakeholderIn ?ds .
+          }}
+          FILTER(STRSTARTS(STR(?graph), "urn:valor:ds:"))
+        }}
+    """)
+
+    return [
+        row["ds"].replace("urn:valor:ds:", "")
+        for row in rows
+    ]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -124,6 +124,13 @@ async def list_socia_ontology():
     }
 
 
+@app.get("/ontology/norms")
+async def list_norm_types():
+    """Retourneert LEXA norm types (subklassen van ufoc:NormativeDescription, uit VALOR-O ontologie)."""
+    from app.services.ontology_cache import get_norm_types
+    return {"norm_types": get_norm_types()}
+
+
 @app.get("/health")
 async def health_check():
     is_connected = await verify_connectivity()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,6 +16,7 @@ from app.routers import proposals, dashboard, threads, sessions, deliberation
 from app.routers import factors, claims, organizations, hierarchy
 from app.routers import tessera
 from app.routers import designspace
+from app.routers import entities
 
 load_dotenv()
 
@@ -95,6 +96,7 @@ app.include_router(factors.router)
 app.include_router(claims.router)
 app.include_router(tessera.router)
 app.include_router(designspace.router)
+app.include_router(entities.router)
 
 
 @app.get("/")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -111,6 +111,17 @@ async def list_epistemic_statuses():
     return get_epistemic_statuses()
 
 
+@app.get("/ontology/socia")
+async def list_socia_ontology():
+    """Retourneert SOCIA actor types, StakeholderRole instanties en DependencyType instanties (uit VALOR-O ontologie)."""
+    from app.services.ontology_cache import get_socia_actor_types, get_socia_dependency_types, get_socia_roles
+    return {
+        "actor_types": get_socia_actor_types(),
+        "roles": get_socia_roles(),
+        "dependency_types": get_socia_dependency_types(),
+    }
+
+
 @app.get("/health")
 async def health_check():
     is_connected = await verify_connectivity()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,6 +17,7 @@ from app.routers import factors, claims, organizations, hierarchy
 from app.routers import tessera
 from app.routers import designspace
 from app.routers import entities
+from app.routers import socia
 
 load_dotenv()
 
@@ -97,6 +98,7 @@ app.include_router(claims.router)
 app.include_router(tessera.router)
 app.include_router(designspace.router)
 app.include_router(entities.router)
+app.include_router(socia.router)
 
 
 @app.get("/")

--- a/backend/app/routers/entities.py
+++ b/backend/app/routers/entities.py
@@ -1,10 +1,13 @@
-"""Entity Registry API endpoints (US-AI.3).
+"""Entity Registry API endpoints (US-AI.3 / US-AI.7).
 
 Routes:
-  POST /entities/                           — nieuwe entiteit aanmaken
-  GET  /entities/search?q=&type=            — zoeken in registry
-  GET  /entities/{uri:path}                 — entiteitsdata ophalen
-  GET  /entities/{uri:path}/roles?ds_id=    — rollen per DesignSpace
+  POST /entities/                                 — nieuwe entiteit aanmaken
+  GET  /entities/search?q=&type=                  — zoeken in registry
+  POST /entities/norms/                           — normatief object aanmaken
+  GET  /entities/norms/search?q=&jurisdiction=    — normen zoeken
+  GET  /entities/norms/{uri}/cross-perspective    — cross-perspectief verwijzingen
+  GET  /entities/{uri:path}                       — entiteitsdata ophalen
+  GET  /entities/{uri:path}/roles?ds_id=          — rollen per DesignSpace
 """
 from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -15,9 +18,12 @@ from app.db.fuseki_entities import (
     ENTITY_TYPE_MAP,
     assign_role,
     create_entity,
+    create_norm_entity,
     get_entity,
+    get_norm_cross_perspective,
     get_roles_for_entity,
     search_entities,
+    search_norms,
 )
 
 router = APIRouter(prefix="/entities", tags=["entities"])
@@ -39,6 +45,14 @@ class RoleAssignRequest(BaseModel):
     role_uri: str
     ds_id: str
     context: Optional[str] = None
+
+
+class NormCreateRequest(BaseModel):
+    norm_type_uri: str
+    label: str
+    identifier: str
+    jurisdiction: Optional[str] = None
+    effective_date: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -90,6 +104,46 @@ async def assign_role_endpoint(
         context=body.context,
     )
     return {"status": "ok", "entity_uri": body.entity_uri, "role_uri": body.role_uri, "ds_id": body.ds_id}
+
+
+@router.post("/norms/", status_code=201)
+async def create_norm_endpoint(
+    body: NormCreateRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """Maakt een normatief object aan in de Entity Registry (ufoc:NormativeDescription subtype)."""
+    uri = await create_norm_entity(
+        norm_type_uri=body.norm_type_uri,
+        label=body.label,
+        identifier=body.identifier,
+        jurisdiction=body.jurisdiction,
+        effective_date=body.effective_date,
+    )
+    return {"uri": uri, "norm_type_uri": body.norm_type_uri, "label": body.label, "identifier": body.identifier}
+
+
+@router.get("/norms/search")
+async def search_norms_endpoint(
+    q: str = Query(..., min_length=1),
+    jurisdiction: Optional[str] = Query(None),
+    limit: int = Query(20, ge=1, le=100),
+    current_user: dict = Depends(get_current_user),
+):
+    """Zoekt normatieve objecten op label of officieel kenmerk, optioneel gefilterd op jurisdictie."""
+    results = await search_norms(query=q, jurisdiction=jurisdiction, limit=limit)
+    return {"results": results, "count": len(results)}
+
+
+@router.get("/norms/{uri:path}/cross-perspective")
+async def get_norm_cross_perspective_endpoint(
+    uri: str,
+    current_user: dict = Depends(get_current_user),
+):
+    """Retourneert alle grafen (DesignSpaces, perspectieven) die naar deze norm-URI verwijzen."""
+    if not uri.startswith("urn:"):
+        uri = uri.replace("urn:/", "urn:").lstrip("/")
+    refs = await get_norm_cross_perspective(uri)
+    return {"norm_uri": uri, "references": refs, "count": len(refs)}
 
 
 @router.get("/{uri:path}/roles")

--- a/backend/app/routers/entities.py
+++ b/backend/app/routers/entities.py
@@ -1,4 +1,4 @@
-"""Entity Registry API endpoints (US-AI.3 / US-AI.7).
+"""Entity Registry API endpoints (US-AI.3 / US-AI.7 / US-AI.8).
 
 Routes:
   POST /entities/                                 — nieuwe entiteit aanmaken
@@ -6,6 +6,9 @@ Routes:
   POST /entities/norms/                           — normatief object aanmaken
   GET  /entities/norms/search?q=&jurisdiction=    — normen zoeken
   GET  /entities/norms/{uri}/cross-perspective    — cross-perspectief verwijzingen
+  POST /entities/cvars/                           — CausalVariable aanmaken
+  GET  /entities/cvars/search?q=&domain=          — CausalVariables zoeken
+  GET  /entities/cvars/{uri:path}                 — CausalVariable ophalen
   GET  /entities/{uri:path}                       — entiteitsdata ophalen
   GET  /entities/{uri:path}/roles?ds_id=          — rollen per DesignSpace
 """
@@ -17,11 +20,14 @@ from app.auth import get_current_user
 from app.db.fuseki_entities import (
     ENTITY_TYPE_MAP,
     assign_role,
+    create_causal_variable,
     create_entity,
     create_norm_entity,
+    get_cvar,
     get_entity,
     get_norm_cross_perspective,
     get_roles_for_entity,
+    search_cvars,
     search_entities,
     search_norms,
 )
@@ -53,6 +59,14 @@ class NormCreateRequest(BaseModel):
     identifier: str
     jurisdiction: Optional[str] = None
     effective_date: Optional[str] = None
+
+
+class CvarCreateRequest(BaseModel):
+    label: str
+    identifier: Optional[str] = None
+    domain: Optional[str] = None
+    unit: Optional[str] = None
+    comment: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -144,6 +158,48 @@ async def get_norm_cross_perspective_endpoint(
         uri = uri.replace("urn:/", "urn:").lstrip("/")
     refs = await get_norm_cross_perspective(uri)
     return {"norm_uri": uri, "references": refs, "count": len(refs)}
+
+
+@router.post("/cvars/", status_code=201)
+async def create_cvar_endpoint(
+    body: CvarCreateRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """Maakt een causa:CausalVariable aan in de Entity Registry."""
+    uri = await create_causal_variable(
+        label=body.label,
+        identifier=body.identifier,
+        domain=body.domain,
+        unit=body.unit,
+        comment=body.comment,
+    )
+    return {"uri": uri, "entity_type": "CausalVariable", "label": body.label}
+
+
+@router.get("/cvars/search")
+async def search_cvars_endpoint(
+    q: str = Query(..., min_length=1),
+    domain: Optional[str] = Query(None),
+    limit: int = Query(20, ge=1, le=100),
+    current_user: dict = Depends(get_current_user),
+):
+    """Zoekt causa:CausalVariable-instanties in de registry op label (substring, case-insensitief)."""
+    results = await search_cvars(query=q, domain=domain, limit=limit)
+    return {"results": results, "count": len(results)}
+
+
+@router.get("/cvars/{uri:path}")
+async def get_cvar_endpoint(
+    uri: str,
+    current_user: dict = Depends(get_current_user),
+):
+    """Haalt een CausalVariable op uit de registry op basis van URI."""
+    if not uri.startswith("urn:"):
+        uri = uri.replace("urn:/", "urn:").lstrip("/")
+    cvar = await get_cvar(uri=uri)
+    if cvar is None:
+        raise HTTPException(status_code=404, detail=f"CausalVariable niet gevonden: {uri}")
+    return cvar
 
 
 @router.get("/{uri:path}/roles")

--- a/backend/app/routers/entities.py
+++ b/backend/app/routers/entities.py
@@ -1,0 +1,120 @@
+"""Entity Registry API endpoints (US-AI.3).
+
+Routes:
+  POST /entities/                           — nieuwe entiteit aanmaken
+  GET  /entities/search?q=&type=            — zoeken in registry
+  GET  /entities/{uri:path}                 — entiteitsdata ophalen
+  GET  /entities/{uri:path}/roles?ds_id=    — rollen per DesignSpace
+"""
+from typing import Optional
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from app.auth import get_current_user
+from app.db.fuseki_entities import (
+    ENTITY_TYPE_MAP,
+    assign_role,
+    create_entity,
+    get_entity,
+    get_roles_for_entity,
+    search_entities,
+)
+
+router = APIRouter(prefix="/entities", tags=["entities"])
+
+
+# ---------------------------------------------------------------------------
+# Request / Response modellen
+# ---------------------------------------------------------------------------
+
+class EntityCreateRequest(BaseModel):
+    entity_type: str
+    label: str
+    properties: Optional[dict] = None
+    identifier: Optional[str] = None
+
+
+class RoleAssignRequest(BaseModel):
+    entity_uri: str
+    role_uri: str
+    ds_id: str
+    context: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+@router.post("/", status_code=201)
+async def create_entity_endpoint(
+    body: EntityCreateRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """Maakt een nieuwe entiteit aan in de Entity Registry."""
+    if body.entity_type not in ENTITY_TYPE_MAP:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Onbekend entity_type '{body.entity_type}'. Kies uit: {list(ENTITY_TYPE_MAP)}",
+        )
+    uri = await create_entity(
+        entity_type=body.entity_type,
+        label=body.label,
+        properties=body.properties,
+        identifier=body.identifier,
+    )
+    return {"uri": uri, "entity_type": body.entity_type, "label": body.label}
+
+
+@router.get("/search")
+async def search_entities_endpoint(
+    q: str = Query(..., min_length=1),
+    type: Optional[str] = Query(None),
+    limit: int = Query(20, ge=1, le=100),
+    current_user: dict = Depends(get_current_user),
+):
+    """Zoekt entiteiten in de registry op basis van label (substring, case-insensitief)."""
+    results = await search_entities(query=q, entity_type=type, limit=limit)
+    return {"results": results, "count": len(results)}
+
+
+@router.post("/roles", status_code=201)
+async def assign_role_endpoint(
+    body: RoleAssignRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """Wijst een rol toe aan een entiteit in een DesignSpace."""
+    await assign_role(
+        entity_uri=body.entity_uri,
+        role_uri=body.role_uri,
+        ds_id=body.ds_id,
+        context=body.context,
+    )
+    return {"status": "ok", "entity_uri": body.entity_uri, "role_uri": body.role_uri, "ds_id": body.ds_id}
+
+
+@router.get("/{uri:path}/roles")
+async def get_entity_roles_endpoint(
+    uri: str,
+    ds_id: str = Query(...),
+    current_user: dict = Depends(get_current_user),
+):
+    """Haalt alle rollen op voor een entiteit in een specifieke DesignSpace."""
+    # uri komt binnen als URL-pad zonder leading slash — herstel urn: prefix
+    if not uri.startswith("urn:"):
+        uri = uri.replace("urn:/", "urn:").lstrip("/")
+    roles = await get_roles_for_entity(entity_uri=uri, ds_id=ds_id)
+    return {"entity_uri": uri, "ds_id": ds_id, "roles": roles}
+
+
+@router.get("/{uri:path}")
+async def get_entity_endpoint(
+    uri: str,
+    current_user: dict = Depends(get_current_user),
+):
+    """Haalt een entiteit op uit de registry op basis van URI."""
+    if not uri.startswith("urn:"):
+        uri = uri.replace("urn:/", "urn:").lstrip("/")
+    entity = await get_entity(uri=uri)
+    if entity is None:
+        raise HTTPException(status_code=404, detail=f"Entiteit niet gevonden: {uri}")
+    return entity

--- a/backend/app/routers/socia.py
+++ b/backend/app/routers/socia.py
@@ -1,4 +1,4 @@
-"""SOCIA API-endpoints voor het cross-perspectief rolpatroon (US-AI.5)."""
+"""SOCIA API-endpoints voor het cross-perspectief rolpatroon (US-AI.5/AI.6)."""
 from fastapi import APIRouter, Depends, Query
 
 from app.auth import get_current_user
@@ -7,6 +7,7 @@ from app.db.fuseki_socia import (
     get_actor_roles_in_ds,
     get_designspaces_for_agent,
     get_tesserae_for_agent,
+    migrate_legacy_socia_actors,
 )
 
 router = APIRouter(tags=["socia"])
@@ -55,3 +56,16 @@ async def get_agent_designspaces_endpoint(
         agent_uri = agent_uri.replace("urn:/", "urn:").lstrip("/")
     ds_ids = await get_designspaces_for_agent(agent_uri)
     return {"agent_uri": agent_uri, "designspaces": ds_ids}
+
+
+@router.post("/admin/migrate-socia-actors")
+async def migrate_socia_actors_endpoint(user=Depends(get_current_user)):
+    """Migreert legacy socia:Actor-resources naar het Entity Registry patroon.
+
+    Idempotent — veilig om meerdere keren uit te voeren.
+    Vereist platform-admin rechten.
+    """
+    if not getattr(user, "is_platform_admin", False):
+        from fastapi import HTTPException
+        raise HTTPException(status_code=403, detail="Alleen platformbeheerders kunnen deze migratie uitvoeren.")
+    return await migrate_legacy_socia_actors()

--- a/backend/app/routers/socia.py
+++ b/backend/app/routers/socia.py
@@ -1,0 +1,57 @@
+"""SOCIA API-endpoints voor het cross-perspectief rolpatroon (US-AI.5)."""
+from fastapi import APIRouter, Depends, Query
+
+from app.auth import get_current_user
+from app.db.fuseki_socia import (
+    assign_actor_role,
+    get_actor_roles_in_ds,
+    get_designspaces_for_agent,
+    get_tesserae_for_agent,
+)
+
+router = APIRouter(tags=["socia"])
+
+
+@router.post("/designspace/{ds_id}/socia/roles")
+async def assign_role_endpoint(
+    ds_id: str,
+    entity_uri: str,
+    role_uri: str,
+    _user=Depends(get_current_user),
+):
+    """Wijst een socia:playsRole toe aan een agent in een DesignSpace."""
+    await assign_actor_role(entity_uri, role_uri, ds_id)
+    return {"status": "ok", "entity_uri": entity_uri, "role_uri": role_uri, "ds_id": ds_id}
+
+
+@router.get("/designspace/{ds_id}/socia/roles")
+async def get_roles_endpoint(
+    ds_id: str,
+    _user=Depends(get_current_user),
+):
+    """Retourneert alle actor-rol-paren in een DesignSpace."""
+    return await get_actor_roles_in_ds(ds_id)
+
+
+@router.get("/designspace/{ds_id}/socia/actors/{actor_uri:path}/tesserae")
+async def get_actor_tesserae_endpoint(
+    ds_id: str,
+    actor_uri: str,
+    _user=Depends(get_current_user),
+):
+    """Retourneert alle Tesserae in een DesignSpace waarop de agent is geclaimed (cross-perspectief)."""
+    if not actor_uri.startswith("urn:"):
+        actor_uri = actor_uri.replace("urn:/", "urn:").lstrip("/")
+    return await get_tesserae_for_agent(actor_uri, ds_id)
+
+
+@router.get("/agents/{agent_uri:path}/designspaces")
+async def get_agent_designspaces_endpoint(
+    agent_uri: str,
+    _user=Depends(get_current_user),
+):
+    """Retourneert alle DesignSpace-IDs waar de agent een socia:playsRole heeft."""
+    if not agent_uri.startswith("urn:"):
+        agent_uri = agent_uri.replace("urn:/", "urn:").lstrip("/")
+    ds_ids = await get_designspaces_for_agent(agent_uri)
+    return {"agent_uri": agent_uri, "designspaces": ds_ids}

--- a/backend/app/services/ontology_cache.py
+++ b/backend/app/services/ontology_cache.py
@@ -13,6 +13,9 @@ Queryt de VALOR-O ontologie-graphs in Fuseki voor:
 import logging
 
 from app.ontology import UFOC_NS, VALOR_NS, VALOR_SITE_BASE
+
+_LEXA_NS = f"{VALOR_NS}lexa-ext#"
+_LEXA_EXT_GRAPH = f"{VALOR_NS}lexa-ext"
 from app.services.fuseki import sparql_select_global
 
 logger = logging.getLogger(__name__)
@@ -44,6 +47,9 @@ _socia_actor_types: list[dict] = []
 _socia_roles: list[dict] = []
 _socia_dependency_types: list[dict] = []
 
+# LEXA norm types (subklassen van ufoc:NormativeDescription)
+_norm_types: list[dict] = []
+
 
 _DISC_GRAPH = f"{VALOR_NS}disc"
 
@@ -55,6 +61,7 @@ async def load_ontology_cache() -> None:
     global _disc_contribution_type_label_to_uri, _status_uri_to_nl_label
     global _system_situation_uris
     global _socia_actor_types, _socia_roles, _socia_dependency_types
+    global _norm_types
 
     logger.info("[ontology-cache] Ontologie-data laden van Fuseki...")
 
@@ -295,6 +302,29 @@ async def load_ontology_cache() -> None:
     ]
     logger.info("[ontology-cache] SOCIA dependency types: %s", [d["local_name"] for d in _socia_dependency_types])
 
+    # LEXA: norm types (subklassen van ufoc:NormativeDescription)
+    norm_type_rows = await sparql_select_global(f"""
+        PREFIX ufoc: <{UFOC_NS}>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        SELECT ?uri ?labelEn ?labelNl WHERE {{
+          GRAPH <{_LEXA_EXT_GRAPH}> {{
+            ?uri rdfs:subClassOf+ <{UFOC_NS}NormativeDescription> .
+            OPTIONAL {{ ?uri rdfs:label ?labelEn . FILTER(lang(?labelEn) = "en") }}
+            OPTIONAL {{ ?uri rdfs:label ?labelNl . FILTER(lang(?labelNl) = "nl") }}
+          }}
+        }}
+    """)
+    _norm_types = [
+        {
+            "uri": row["uri"],
+            "local_name": row["uri"].split("#")[-1],
+            "label_en": row.get("labelEn", row["uri"].split("#")[-1]),
+            "label_nl": row.get("labelNl", row.get("labelEn", row["uri"].split("#")[-1])),
+        }
+        for row in norm_type_rows
+    ]
+    logger.info("[ontology-cache] Norm types: %s", [t["local_name"] for t in _norm_types])
+
     if not _evidence_label_to_uri or not _status_label_to_uri or not _valid_transitions:
         logger.warning(
             "[ontology-cache] Ontologie-cache onvolledig. "
@@ -394,3 +424,8 @@ def get_socia_roles() -> list[dict]:
 def get_socia_dependency_types() -> list[dict]:
     """Retourneert socia:DependencyType instanties met URI, local_name, label_en, label_nl."""
     return _socia_dependency_types
+
+
+def get_norm_types() -> list[dict]:
+    """Retourneert LEXA norm types (subklassen van ufoc:NormativeDescription) met URI, local_name, label_en, label_nl."""
+    return _norm_types

--- a/backend/app/services/ontology_cache.py
+++ b/backend/app/services/ontology_cache.py
@@ -8,10 +8,11 @@ Queryt de VALOR-O ontologie-graphs in Fuseki voor:
   - Statussen die een DecisionEpisode vereisen (valor:requiresDecisionEpisode)
   - UncertaintyLevel instanties (PAMS-taxonomie, English label -> URI)
   - disc:ContributionType instanties (Dutch label -> URI)
+  - SOCIA: actor types, StakeholderRole instanties, DependencyType instanties
 """
 import logging
 
-from app.ontology import VALOR_NS, VALOR_SITE_BASE
+from app.ontology import UFOC_NS, VALOR_NS, VALOR_SITE_BASE
 from app.services.fuseki import sparql_select_global
 
 logger = logging.getLogger(__name__)
@@ -35,6 +36,14 @@ _disc_contribution_type_label_to_uri: dict[str, str] = {}  # "Vraag" → URI
 _status_uri_to_nl_label: dict[str, str] = {}  # URI → "Betwist" etc.
 _system_situation_uris: set[str] = set()
 
+# SOCIA ontologie-data
+_SOCIA_GRAPH = f"{VALOR_NS}socia"
+_SOCIA_NS = f"{VALOR_NS}socia#"
+# [{uri, local_name, label_en, label_nl}]
+_socia_actor_types: list[dict] = []
+_socia_roles: list[dict] = []
+_socia_dependency_types: list[dict] = []
+
 
 _DISC_GRAPH = f"{VALOR_NS}disc"
 
@@ -45,6 +54,7 @@ async def load_ontology_cache() -> None:
     global _uncertainty_label_to_uri, _participant_role_data, _rbac_role_weights
     global _disc_contribution_type_label_to_uri, _status_uri_to_nl_label
     global _system_situation_uris
+    global _socia_actor_types, _socia_roles, _socia_dependency_types
 
     logger.info("[ontology-cache] Ontologie-data laden van Fuseki...")
 
@@ -216,6 +226,75 @@ async def load_ontology_cache() -> None:
     _system_situation_uris = {row["uri"] for row in sysont_rows}
     logger.info("[ontology-cache] SystemSituation URIs: %d geladen", len(_system_situation_uris))
 
+    # SOCIA: actor types (subklassen van ufoc:Agent)
+    actor_type_rows = await sparql_select_global(f"""
+        PREFIX ufoc: <{UFOC_NS}>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        SELECT ?uri ?labelEn ?labelNl WHERE {{
+          GRAPH <{_SOCIA_GRAPH}> {{
+            ?uri rdfs:subClassOf+ <{UFOC_NS}Agent> .
+            OPTIONAL {{ ?uri rdfs:label ?labelEn . FILTER(lang(?labelEn) = "en") }}
+            OPTIONAL {{ ?uri rdfs:label ?labelNl . FILTER(lang(?labelNl) = "nl") }}
+          }}
+        }}
+    """)
+    _socia_actor_types = [
+        {
+            "uri": row["uri"],
+            "local_name": row["uri"].split("#")[-1],
+            "label_en": row.get("labelEn", row["uri"].split("#")[-1]),
+            "label_nl": row.get("labelNl", row.get("labelEn", row["uri"].split("#")[-1])),
+        }
+        for row in actor_type_rows
+    ]
+    logger.info("[ontology-cache] SOCIA actor types: %s", [t["local_name"] for t in _socia_actor_types])
+
+    # SOCIA: StakeholderRole instanties
+    role_inst_rows = await sparql_select_global(f"""
+        PREFIX socia: <{_SOCIA_NS}>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        SELECT ?uri ?labelEn ?labelNl WHERE {{
+          GRAPH <{_SOCIA_GRAPH}> {{
+            ?uri a socia:StakeholderRole .
+            OPTIONAL {{ ?uri rdfs:label ?labelEn . FILTER(lang(?labelEn) = "en") }}
+            OPTIONAL {{ ?uri rdfs:label ?labelNl . FILTER(lang(?labelNl) = "nl") }}
+          }}
+        }}
+    """)
+    _socia_roles = [
+        {
+            "uri": row["uri"],
+            "local_name": row["uri"].split("#")[-1],
+            "label_en": row.get("labelEn", row["uri"].split("#")[-1]),
+            "label_nl": row.get("labelNl", row.get("labelEn", row["uri"].split("#")[-1])),
+        }
+        for row in role_inst_rows
+    ]
+    logger.info("[ontology-cache] SOCIA rollen: %s", [r["local_name"] for r in _socia_roles])
+
+    # SOCIA: DependencyType instanties
+    dep_type_rows = await sparql_select_global(f"""
+        PREFIX socia: <{_SOCIA_NS}>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        SELECT ?uri ?labelEn ?labelNl WHERE {{
+          GRAPH <{_SOCIA_GRAPH}> {{
+            ?uri a socia:DependencyType .
+            OPTIONAL {{ ?uri rdfs:label ?labelEn . FILTER(lang(?labelEn) = "en") }}
+            OPTIONAL {{ ?uri rdfs:label ?labelNl . FILTER(lang(?labelNl) = "nl") }}
+          }}
+        }}
+    """)
+    _socia_dependency_types = [
+        {
+            "uri": row["uri"],
+            "local_name": row["uri"].split("#")[-1],
+            "label_en": row.get("labelEn", row["uri"].split("#")[-1]),
+            "label_nl": row.get("labelNl", row.get("labelEn", row["uri"].split("#")[-1])),
+        }
+        for row in dep_type_rows
+    ]
+    logger.info("[ontology-cache] SOCIA dependency types: %s", [d["local_name"] for d in _socia_dependency_types])
+
     if not _evidence_label_to_uri or not _status_label_to_uri or not _valid_transitions:
         logger.warning(
             "[ontology-cache] Ontologie-cache onvolledig. "
@@ -300,3 +379,18 @@ def rbac_to_valor_role(rbac_role: str) -> str:
 
 def get_system_situation_uris() -> set[str]:
     return _system_situation_uris
+
+
+def get_socia_actor_types() -> list[dict]:
+    """Retourneert SOCIA actor types (subklassen van ufoc:Agent) met URI, local_name, label_en, label_nl."""
+    return _socia_actor_types
+
+
+def get_socia_roles() -> list[dict]:
+    """Retourneert socia:StakeholderRole instanties met URI, local_name, label_en, label_nl."""
+    return _socia_roles
+
+
+def get_socia_dependency_types() -> list[dict]:
+    """Retourneert socia:DependencyType instanties met URI, local_name, label_en, label_nl."""
+    return _socia_dependency_types

--- a/backend/tests/integration/test_cvar_entities.py
+++ b/backend/tests/integration/test_cvar_entities.py
@@ -1,0 +1,315 @@
+"""Integratietests voor CausalVariable-functies in app.db.fuseki_entities (US-AI.8).
+
+Test:
+- create_causal_variable: URI-patroon, verplichte en optionele triples
+- search_cvars: zoeken op label, optionele domein-filter
+- get_cvar: ophalen op URI, niet-bestaande URI
+
+Gebruik:
+    cd backend
+    FUSEKI_URL=http://localhost:3030 pytest tests/integration/test_cvar_entities.py -v
+"""
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+pytestmark = pytest.mark.integration
+
+_ENTITIES_GRAPH = "urn:valor:entities"
+_CAUSA_NS = "https://valor-ecosystem.nl/ontology/causa#"
+_VALOR_NS = "https://valor-ecosystem.nl/ontology/"
+_RDFS_LABEL = "http://www.w3.org/2000/01/rdf-schema#label"
+_RDFS_COMMENT = "http://www.w3.org/2000/01/rdf-schema#comment"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _select(sparql: str) -> list[dict]:
+    from app.services.fuseki import sparql_select_global
+    return await sparql_select_global(sparql)
+
+
+async def _ask_triple(graph: str, subject: str, predicate: str, obj: str) -> bool:
+    rows = await _select(f"""
+SELECT (COUNT(*) AS ?c) WHERE {{
+  GRAPH <{graph}> {{
+    <{subject}> <{predicate}> <{obj}> .
+  }}
+}}
+""")
+    return int(rows[0]["c"]) > 0 if rows else False
+
+
+async def _ask_literal(graph: str, subject: str, predicate: str, value: str) -> bool:
+    rows = await _select(f"""
+SELECT ?val WHERE {{
+  GRAPH <{graph}> {{
+    <{subject}> <{predicate}> ?val .
+  }}
+}}
+""")
+    return any(value.lower() in str(r.get("val", "")).lower() for r in rows)
+
+
+async def _delete_cvar(uri: str) -> None:
+    from app.services.fuseki import sparql_update
+    await sparql_update(
+        f"DELETE WHERE {{ GRAPH <{_ENTITIES_GRAPH}> {{ <{uri}> ?p ?o }} }}",
+        "entities",
+    )
+
+
+# ---------------------------------------------------------------------------
+# create_causal_variable
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_create_cvar_geeft_urn_uri_terug():
+    from app.db.fuseki_entities import create_causal_variable
+    uri = await create_causal_variable(label="Test Variabele", identifier="test-var-uri")
+    try:
+        assert uri == f"{_ENTITIES_GRAPH}:cvar:test-var-uri"
+    finally:
+        await _delete_cvar(uri)
+
+
+@pytest.mark.asyncio
+async def test_create_cvar_schrijft_rdf_type():
+    from app.db.fuseki_entities import create_causal_variable
+    uri = await create_causal_variable(label="Recidivecijfer", identifier="recidivecijfer")
+    try:
+        has_type = await _ask_triple(
+            _ENTITIES_GRAPH, uri,
+            "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+            f"{_CAUSA_NS}CausalVariable",
+        )
+        assert has_type, "rdf:type causa:CausalVariable ontbreekt"
+    finally:
+        await _delete_cvar(uri)
+
+
+@pytest.mark.asyncio
+async def test_create_cvar_schrijft_label():
+    from app.db.fuseki_entities import create_causal_variable
+    uri = await create_causal_variable(label="Wachttijd jeugdzorg", identifier="wachttijd-jeugdzorg")
+    try:
+        has_label = await _ask_literal(_ENTITIES_GRAPH, uri, _RDFS_LABEL, "wachttijd jeugdzorg")
+        assert has_label, "rdfs:label ontbreekt"
+    finally:
+        await _delete_cvar(uri)
+
+
+@pytest.mark.asyncio
+async def test_create_cvar_schrijft_optioneel_domain():
+    from app.db.fuseki_entities import create_causal_variable
+    uri = await create_causal_variable(
+        label="Zorgkosten",
+        identifier="zorgkosten-test",
+        domain="gezondheidszorg",
+    )
+    try:
+        has_domain = await _ask_literal(
+            _ENTITIES_GRAPH, uri, f"{_VALOR_NS}domain", "gezondheidszorg"
+        )
+        assert has_domain, "valor:domain ontbreekt"
+    finally:
+        await _delete_cvar(uri)
+
+
+@pytest.mark.asyncio
+async def test_create_cvar_schrijft_optioneel_unit():
+    from app.db.fuseki_entities import create_causal_variable
+    uri = await create_causal_variable(
+        label="Gemiddeld Inkomen",
+        identifier="gemiddeld-inkomen-test",
+        unit="EUR/jaar",
+    )
+    try:
+        has_unit = await _ask_literal(
+            _ENTITIES_GRAPH, uri, f"{_VALOR_NS}unit", "EUR/jaar"
+        )
+        assert has_unit, "valor:unit ontbreekt"
+    finally:
+        await _delete_cvar(uri)
+
+
+@pytest.mark.asyncio
+async def test_create_cvar_schrijft_optioneel_comment():
+    from app.db.fuseki_entities import create_causal_variable
+    uri = await create_causal_variable(
+        label="Schuldendruk",
+        identifier="schuldendruk-test",
+        comment="Gemiddelde schuldenlast als % van inkomen",
+    )
+    try:
+        has_comment = await _ask_literal(
+            _ENTITIES_GRAPH, uri, _RDFS_COMMENT, "schuldenlast"
+        )
+        assert has_comment, "rdfs:comment ontbreekt"
+    finally:
+        await _delete_cvar(uri)
+
+
+@pytest.mark.asyncio
+async def test_create_cvar_zonder_identifier_genereert_uuid():
+    from app.db.fuseki_entities import create_causal_variable
+    uri = await create_causal_variable(label="Armoederisico")
+    try:
+        assert uri.startswith(f"{_ENTITIES_GRAPH}:cvar:")
+        slug = uri.split(":cvar:")[-1]
+        # UUID heeft 32 hex-chars + 4 streepjes = 36 tekens
+        assert len(slug) == 36, f"Verwacht UUID-slug maar kreeg: {slug}"
+    finally:
+        await _delete_cvar(uri)
+
+
+@pytest.mark.asyncio
+async def test_create_cvar_schrijft_entity_id():
+    from app.db.fuseki_entities import create_causal_variable
+    uri = await create_causal_variable(label="Criminaliteitscijfer", identifier="criminaliteit-test")
+    try:
+        has_id = await _ask_literal(
+            _ENTITIES_GRAPH, uri, f"{_VALOR_NS}entityId", "criminaliteit-test"
+        )
+        assert has_id, "valor:entityId ontbreekt"
+    finally:
+        await _delete_cvar(uri)
+
+
+# ---------------------------------------------------------------------------
+# search_cvars
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_search_cvars_vindt_op_label():
+    from app.db.fuseki_entities import create_causal_variable, search_cvars
+    uri = await create_causal_variable(label="Werkloosheidscijfer NL", identifier="werkloosheid-nl-search")
+    try:
+        results = await search_cvars("werkloosheid")
+        uris = [r["uri"] for r in results]
+        assert uri in uris, f"Verwachtte {uri} in zoekresultaten"
+    finally:
+        await _delete_cvar(uri)
+
+
+@pytest.mark.asyncio
+async def test_search_cvars_case_insensitief():
+    from app.db.fuseki_entities import create_causal_variable, search_cvars
+    uri = await create_causal_variable(label="Energieprijzen", identifier="energieprijzen-case-test")
+    try:
+        results = await search_cvars("ENERGIEPRIJZEN")
+        uris = [r["uri"] for r in results]
+        assert uri in uris
+    finally:
+        await _delete_cvar(uri)
+
+
+@pytest.mark.asyncio
+async def test_search_cvars_filtert_op_domain():
+    from app.db.fuseki_entities import create_causal_variable, search_cvars
+    uri_a = await create_causal_variable(
+        label="Luchtkwaliteit", identifier="luchtkwaliteit-dom-test",
+        domain="milieu"
+    )
+    uri_b = await create_causal_variable(
+        label="Zorgwachttijd", identifier="zorgwachttijd-dom-test",
+        domain="gezondheidszorg"
+    )
+    try:
+        results = await search_cvars("a", domain="milieu")
+        uris = [r["uri"] for r in results]
+        assert uri_a in uris, "milieu-variabele niet gevonden"
+        assert uri_b not in uris, "gezondheidszorg-variabele mag niet in milieu-resultaten"
+    finally:
+        await _delete_cvar(uri_a)
+        await _delete_cvar(uri_b)
+
+
+@pytest.mark.asyncio
+async def test_search_cvars_retourneert_entity_type_causalvariable():
+    from app.db.fuseki_entities import create_causal_variable, search_cvars
+    uri = await create_causal_variable(label="Participatiegraad", identifier="participatie-type-test")
+    try:
+        results = await search_cvars("participatiegraad")
+        match = next((r for r in results if r["uri"] == uri), None)
+        assert match is not None
+        assert match["entity_type"] == "CausalVariable"
+    finally:
+        await _delete_cvar(uri)
+
+
+@pytest.mark.asyncio
+async def test_search_cvars_geeft_lege_lijst_bij_geen_match():
+    from app.db.fuseki_entities import search_cvars
+    results = await search_cvars("xyznonexistentcvar12345")
+    assert results == []
+
+
+# ---------------------------------------------------------------------------
+# get_cvar
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_cvar_retourneert_volledige_data():
+    from app.db.fuseki_entities import create_causal_variable, get_cvar
+    uri = await create_causal_variable(
+        label="Belastingdruk",
+        identifier="belastingdruk-get-test",
+        domain="economie",
+        unit="%",
+        comment="Totale belastingdruk als percentage van BBP",
+    )
+    try:
+        result = await get_cvar(uri)
+        assert result is not None
+        assert result["uri"] == uri
+        assert result["entity_type"] == "CausalVariable"
+        assert "belastingdruk" in result["label"].lower()
+        assert result["domain"] == "economie"
+        assert result["unit"] == "%"
+        assert result["entity_id"] == "belastingdruk-get-test"
+    finally:
+        await _delete_cvar(uri)
+
+
+@pytest.mark.asyncio
+async def test_get_cvar_geeft_none_voor_niet_bestaande_uri():
+    from app.db.fuseki_entities import get_cvar
+    result = await get_cvar("urn:valor:entities:cvar:bestaat-niet-xyz")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_cvar_geeft_none_voor_andere_entity_type():
+    """Een PhysicalAgent mag niet als CausalVariable worden opgehaald."""
+    from app.db.fuseki_entities import create_entity, get_cvar
+    uri = await create_entity("PhysicalAgent", "Test Persoon", identifier="test-persoon-cvar-guard")
+    try:
+        result = await get_cvar(uri)
+        assert result is None, "get_cvar mag geen PhysicalAgent teruggeven"
+    finally:
+        from app.services.fuseki import sparql_update
+        await sparql_update(
+            f"DELETE WHERE {{ GRAPH <{_ENTITIES_GRAPH}> {{ <{uri}> ?p ?o }} }}",
+            "entities",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Hergebruik: zelfde slug = zelfde URI (idempotentie via slug)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_create_cvar_slug_is_deterministisch():
+    """Dezelfde identifier geeft altijd dezelfde URI (hergebruik-principe)."""
+    from app.db.fuseki_entities import create_causal_variable
+    uri1 = await create_causal_variable(label="Ongelijkheid", identifier="ongelijkheid-idem")
+    uri2 = await create_causal_variable(label="Ongelijkheid V2", identifier="ongelijkheid-idem")
+    try:
+        assert uri1 == uri2, "Dezelfde identifier moet dezelfde URI opleveren"
+    finally:
+        await _delete_cvar(uri1)

--- a/backend/tests/integration/test_entities.py
+++ b/backend/tests/integration/test_entities.py
@@ -1,0 +1,233 @@
+"""Integratietests voor app.db.fuseki_entities (US-AI.3).
+
+Test de Entity Registry: named graph urn:valor:entities, JIT-bridge,
+CRUD-operaties en rol-assignaties.
+
+Gebruik:
+    cd backend
+    FUSEKI_URL=http://localhost:3030 pytest tests/integration/test_entities.py -v
+"""
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+pytestmark = pytest.mark.integration
+
+_ENTITIES_GRAPH = "urn:valor:entities"
+TEST_SUPABASE_ID = "test-supabase-uuid-0001"
+TEST_DS_ID = "test-ds-entities"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _count_entities(entity_type_uri: str) -> int:
+    from app.services.fuseki import sparql_select_global
+    rows = await sparql_select_global(
+        f"SELECT (COUNT(?e) AS ?c) WHERE {{ GRAPH <{_ENTITIES_GRAPH}> {{ ?e a <{entity_type_uri}> }} }}"
+    )
+    return int(rows[0]["c"]) if rows else 0
+
+
+# ---------------------------------------------------------------------------
+# JIT-bridge: ensure_person_entity
+# ---------------------------------------------------------------------------
+
+async def test_ensure_person_entity_maakt_physical_agent_aan():
+    from app.db.fuseki_entities import ensure_person_entity
+    from app.ontology import UFOC_NS
+
+    uri = await ensure_person_entity(TEST_SUPABASE_ID, "Test Gebruiker")
+
+    assert uri == f"{_ENTITIES_GRAPH}:person:{TEST_SUPABASE_ID}"
+    count = await _count_entities(f"{UFOC_NS}PhysicalAgent")
+    assert count == 1
+
+
+async def test_ensure_person_entity_idempotent():
+    from app.db.fuseki_entities import ensure_person_entity
+    from app.ontology import UFOC_NS
+
+    uri1 = await ensure_person_entity(TEST_SUPABASE_ID, "Test Gebruiker")
+    uri2 = await ensure_person_entity(TEST_SUPABASE_ID, "Test Gebruiker")
+
+    assert uri1 == uri2
+    count = await _count_entities(f"{UFOC_NS}PhysicalAgent")
+    assert count == 1  # geen duplicaat
+
+
+async def test_ensure_person_entity_zonder_naam():
+    from app.db.fuseki_entities import ensure_person_entity
+    from app.ontology import UFOC_NS
+
+    uri = await ensure_person_entity(TEST_SUPABASE_ID)
+
+    assert uri is not None
+    count = await _count_entities(f"{UFOC_NS}PhysicalAgent")
+    assert count == 1
+
+
+# ---------------------------------------------------------------------------
+# create_entity
+# ---------------------------------------------------------------------------
+
+async def test_create_entity_physical_agent():
+    from app.db.fuseki_entities import create_entity
+    from app.ontology import UFOC_NS
+
+    uri = await create_entity("PhysicalAgent", "Jan de Vries")
+
+    assert "urn:valor:entities:person:" in uri
+    count = await _count_entities(f"{UFOC_NS}PhysicalAgent")
+    assert count == 1
+
+
+async def test_create_entity_institutional_agent():
+    from app.db.fuseki_entities import create_entity
+    from app.ontology import UFOC_NS
+
+    uri = await create_entity("InstitutionalAgent", "Gemeente Amsterdam")
+
+    assert "urn:valor:entities:org:" in uri
+    count = await _count_entities(f"{UFOC_NS}InstitutionalAgent")
+    assert count == 1
+
+
+async def test_create_entity_normative_description():
+    from app.db.fuseki_entities import create_entity
+    from app.ontology import UFOC_NS
+
+    uri = await create_entity(
+        "NormativeDescription",
+        "Wet op de schuldsanering",
+        identifier="wsnp-2024",
+    )
+
+    assert uri == "urn:valor:entities:norm:wsnp-2024"
+    count = await _count_entities(f"{UFOC_NS}NormativeDescription")
+    assert count == 1
+
+
+async def test_create_entity_onbekend_type_geeft_error():
+    from app.db.fuseki_entities import create_entity
+
+    with pytest.raises(ValueError, match="Onbekend entity type"):
+        await create_entity("OnbestaandType", "Test")
+
+
+async def test_create_entity_met_properties():
+    from app.db.fuseki_entities import create_entity, get_entity
+
+    uri = await create_entity(
+        "InstitutionalAgent",
+        "Ministerie van SZW",
+        properties={"kvkNumber": "12345678"},
+    )
+    entity = await get_entity(uri)
+    assert entity is not None
+    assert entity["label"] == "Ministerie van SZW"
+
+
+# ---------------------------------------------------------------------------
+# get_entity
+# ---------------------------------------------------------------------------
+
+async def test_get_entity_retourneert_data():
+    from app.db.fuseki_entities import create_entity, get_entity
+
+    uri = await create_entity("PhysicalAgent", "Piet Jansen")
+    entity = await get_entity(uri)
+
+    assert entity is not None
+    assert entity["uri"] == uri
+    assert entity["entity_type"] == "PhysicalAgent"
+    assert entity["label"] == "Piet Jansen"
+
+
+async def test_get_entity_niet_bestaand_geeft_none():
+    from app.db.fuseki_entities import get_entity
+
+    result = await get_entity("urn:valor:entities:person:bestaat-niet")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# search_entities
+# ---------------------------------------------------------------------------
+
+async def test_search_entities_vindt_op_label():
+    from app.db.fuseki_entities import create_entity, search_entities
+
+    await create_entity("PhysicalAgent", "Maria van Dijk")
+    await create_entity("PhysicalAgent", "Johan van Dijk")
+    await create_entity("InstitutionalAgent", "Gemeente Rotterdam")
+
+    results = await search_entities("van dijk")
+    assert len(results) == 2
+    labels = [r["label"] for r in results]
+    assert "Maria van Dijk" in labels
+    assert "Johan van Dijk" in labels
+
+
+async def test_search_entities_filter_op_type():
+    from app.db.fuseki_entities import create_entity, search_entities
+
+    await create_entity("PhysicalAgent", "Maria Gemeente")
+    await create_entity("InstitutionalAgent", "Gemeente Alkmaar")
+
+    results = await search_entities("gemeente", entity_type="InstitutionalAgent")
+    assert len(results) == 1
+    assert results[0]["entity_type"] == "InstitutionalAgent"
+
+
+async def test_search_entities_leeg_resultaat():
+    from app.db.fuseki_entities import search_entities
+
+    results = await search_entities("xyzOnbestaandeNaam")
+    assert results == []
+
+
+# ---------------------------------------------------------------------------
+# assign_role + get_roles_for_entity
+# ---------------------------------------------------------------------------
+
+async def test_assign_role_en_ophalen():
+    from app.db.fuseki_entities import assign_role, create_entity, get_roles_for_entity
+
+    uri = await create_entity("InstitutionalAgent", "Gemeente Utrecht")
+    role_uri = "https://valor-ecosystem.nl/ontology/socia#Implementer"
+
+    await assign_role(uri, role_uri, TEST_DS_ID, context="Schuldhulpverlening")
+    roles = await get_roles_for_entity(uri, TEST_DS_ID)
+
+    assert len(roles) == 1
+    assert roles[0]["role_uri"] == role_uri
+    assert roles[0]["context"] == "Schuldhulpverlening"
+
+
+async def test_get_roles_voor_entity_zonder_rollen():
+    from app.db.fuseki_entities import create_entity, get_roles_for_entity
+
+    uri = await create_entity("PhysicalAgent", "Anonieme Gebruiker")
+    roles = await get_roles_for_entity(uri, TEST_DS_ID)
+
+    assert roles == []
+
+
+async def test_meerdere_rollen_per_entiteit():
+    from app.db.fuseki_entities import assign_role, create_entity, get_roles_for_entity
+
+    uri = await create_entity("InstitutionalAgent", "Belastingdienst")
+    role1 = "https://valor-ecosystem.nl/ontology/socia#Supervisor"
+    role2 = "https://valor-ecosystem.nl/ontology/socia#ChainPartner"
+
+    await assign_role(uri, role1, TEST_DS_ID)
+    await assign_role(uri, role2, TEST_DS_ID)
+
+    roles = await get_roles_for_entity(uri, TEST_DS_ID)
+    role_uris = [r["role_uri"] for r in roles]
+    assert role1 in role_uris
+    assert role2 in role_uris

--- a/backend/tests/integration/test_norm_entities.py
+++ b/backend/tests/integration/test_norm_entities.py
@@ -1,0 +1,479 @@
+"""Integratietests voor norm-entity functies in app.db.fuseki_entities (US-AI.7).
+
+Test:
+- create_norm_entity: URI-patroon, verplichte triples, optionele velden
+- search_norms: zoeken op label en identifier, jurisdictie-filter
+- get_norm_cross_perspective: cross-graph verwijzingen en lege resultaten
+
+Gebruik:
+    cd backend
+    FUSEKI_URL=http://localhost:3030 pytest tests/integration/test_norm_entities.py -v
+"""
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+pytestmark = pytest.mark.integration
+
+_ENTITIES_GRAPH = "urn:valor:entities"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _select(sparql: str) -> list[dict]:
+    from app.services.fuseki import sparql_select_global
+    return await sparql_select_global(sparql)
+
+
+async def _ask_triple(graph: str, subject: str, predicate: str, obj: str) -> bool:
+    """Geeft True als de triple aanwezig is in de opgegeven graph."""
+    rows = await _select(f"""
+SELECT (COUNT(*) AS ?c) WHERE {{
+  GRAPH <{graph}> {{
+    <{subject}> <{predicate}> <{obj}> .
+  }}
+}}
+""")
+    return int(rows[0]["c"]) > 0 if rows else False
+
+
+async def _ask_literal(graph: str, subject: str, predicate: str, value: str) -> bool:
+    """Geeft True als een literal-triple aanwezig is in de opgegeven graph (case-insensitive waarde-check)."""
+    rows = await _select(f"""
+SELECT ?val WHERE {{
+  GRAPH <{graph}> {{
+    <{subject}> <{predicate}> ?val .
+  }}
+}}
+""")
+    values = [r["val"].lower() if isinstance(r["val"], str) else r["val"] for r in rows]
+    return value.lower() in values
+
+
+# ---------------------------------------------------------------------------
+# create_norm_entity — URI-patroon
+# ---------------------------------------------------------------------------
+
+async def test_create_norm_entity_geeft_slug_uri_terug():
+    from app.db.fuseki_entities import create_norm_entity
+    from app.ontology import VALOR_NS
+
+    norm_type_uri = f"{VALOR_NS}lexa-ext#Law"
+    uri = await create_norm_entity(norm_type_uri, "Wet op de schuldsanering", "wsnp-2024")
+
+    assert uri == "urn:valor:entities:norm:wsnp-2024"
+
+
+async def test_create_norm_entity_slug_vervangt_spaties():
+    from app.db.fuseki_entities import create_norm_entity
+    from app.ontology import VALOR_NS
+
+    norm_type_uri = f"{VALOR_NS}lexa-ext#Regulation"
+    uri = await create_norm_entity(norm_type_uri, "Besluit Begroting", "besluit begroting 2024")
+
+    assert uri == "urn:valor:entities:norm:besluit-begroting-2024"
+
+
+async def test_create_norm_entity_slug_vervangt_slashes():
+    from app.db.fuseki_entities import create_norm_entity
+    from app.ontology import VALOR_NS
+
+    norm_type_uri = f"{VALOR_NS}lexa-ext#Law"
+    uri = await create_norm_entity(norm_type_uri, "Wet Bijzondere Opnemingen", "wvggz/2020")
+
+    assert uri == "urn:valor:entities:norm:wvggz-2020"
+
+
+# ---------------------------------------------------------------------------
+# create_norm_entity — verplichte triples
+# ---------------------------------------------------------------------------
+
+async def test_create_norm_entity_heeft_ufoc_normative_description_type():
+    from app.db.fuseki_entities import create_norm_entity
+    from app.ontology import UFOC_NS, VALOR_NS
+
+    norm_type_uri = f"{VALOR_NS}lexa-ext#Law"
+    uri = await create_norm_entity(norm_type_uri, "Wet maatschappelijke ondersteuning", "wmo-2015")
+
+    aanwezig = await _ask_triple(
+        _ENTITIES_GRAPH,
+        uri,
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        f"{UFOC_NS}NormativeDescription",
+    )
+    assert aanwezig, "ufoc:NormativeDescription type-triple ontbreekt"
+
+
+async def test_create_norm_entity_heeft_specifiek_subtype():
+    from app.db.fuseki_entities import create_norm_entity
+    from app.ontology import VALOR_NS
+
+    norm_type_uri = f"{VALOR_NS}lexa-ext#Law"
+    uri = await create_norm_entity(norm_type_uri, "Wet maatschappelijke ondersteuning", "wmo-2015")
+
+    aanwezig = await _ask_triple(
+        _ENTITIES_GRAPH,
+        uri,
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        norm_type_uri,
+    )
+    assert aanwezig, "Specifiek subtype-triple ontbreekt"
+
+
+async def test_create_norm_entity_heeft_beide_type_triples():
+    """Norm moet zowel ufoc:NormativeDescription ALS het subtype hebben."""
+    from app.db.fuseki_entities import create_norm_entity
+    from app.ontology import UFOC_NS, VALOR_NS
+
+    norm_type_uri = f"{VALOR_NS}lexa-ext#Regulation"
+    uri = await create_norm_entity(norm_type_uri, "AMvB Inburgeringsbesluit", "inburgering-besluit-2021")
+
+    rows = await _select(f"""
+SELECT ?type WHERE {{
+  GRAPH <{_ENTITIES_GRAPH}> {{
+    <{uri}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
+  }}
+}}
+""")
+    gevonden_types = {r["type"] for r in rows}
+    assert f"{UFOC_NS}NormativeDescription" in gevonden_types, "ufoc:NormativeDescription ontbreekt"
+    assert norm_type_uri in gevonden_types, "Subtype ontbreekt"
+    assert len(gevonden_types) == 2
+
+
+# ---------------------------------------------------------------------------
+# create_norm_entity — lexa:identifier en lexa:jurisdiction
+# ---------------------------------------------------------------------------
+
+async def test_create_norm_entity_slaat_lexa_identifier_op():
+    from app.db.fuseki_entities import create_norm_entity
+    from app.ontology import VALOR_NS
+
+    _LEXA_NS = f"{VALOR_NS}lexa-ext#"
+    norm_type_uri = f"{_LEXA_NS}Law"
+    uri = await create_norm_entity(norm_type_uri, "Wet werk en bijstand", "wwb-2004")
+
+    rows = await _select(f"""
+SELECT ?id WHERE {{
+  GRAPH <{_ENTITIES_GRAPH}> {{
+    <{uri}> <{_LEXA_NS}identifier> ?id .
+  }}
+}}
+""")
+    assert rows, "lexa:identifier triple ontbreekt"
+    assert rows[0]["id"] == "wwb-2004"
+
+
+async def test_create_norm_entity_zonder_jurisdiction_slaat_niet_op():
+    from app.db.fuseki_entities import create_norm_entity
+    from app.ontology import VALOR_NS
+
+    _LEXA_NS = f"{VALOR_NS}lexa-ext#"
+    norm_type_uri = f"{_LEXA_NS}Law"
+    uri = await create_norm_entity(norm_type_uri, "Wet zonder jurisdictie", "no-jur-001")
+
+    rows = await _select(f"""
+SELECT ?jur WHERE {{
+  GRAPH <{_ENTITIES_GRAPH}> {{
+    <{uri}> <{_LEXA_NS}jurisdiction> ?jur .
+  }}
+}}
+""")
+    assert rows == [], "jurisdiction moet afwezig zijn als niet opgegeven"
+
+
+async def test_create_norm_entity_slaat_jurisdiction_op():
+    from app.db.fuseki_entities import create_norm_entity
+    from app.ontology import VALOR_NS
+
+    _LEXA_NS = f"{VALOR_NS}lexa-ext#"
+    norm_type_uri = f"{_LEXA_NS}Law"
+    uri = await create_norm_entity(
+        norm_type_uri,
+        "Wet publieke gezondheid",
+        "wpg-2008",
+        jurisdiction="NL",
+    )
+
+    rows = await _select(f"""
+SELECT ?jur WHERE {{
+  GRAPH <{_ENTITIES_GRAPH}> {{
+    <{uri}> <{_LEXA_NS}jurisdiction> ?jur .
+  }}
+}}
+""")
+    assert rows, "lexa:jurisdiction triple ontbreekt"
+    assert rows[0]["jur"] == "NL"
+
+
+async def test_create_norm_entity_slaat_effective_date_op():
+    from app.db.fuseki_entities import create_norm_entity
+    from app.ontology import VALOR_NS
+
+    _LEXA_NS = f"{VALOR_NS}lexa-ext#"
+    norm_type_uri = f"{_LEXA_NS}Law"
+    uri = await create_norm_entity(
+        norm_type_uri,
+        "Omgevingswet",
+        "ow-2024",
+        effective_date="2024-01-01",
+    )
+
+    rows = await _select(f"""
+SELECT ?datum WHERE {{
+  GRAPH <{_ENTITIES_GRAPH}> {{
+    <{uri}> <{_LEXA_NS}effectiveDate> ?datum .
+  }}
+}}
+""")
+    assert rows, "lexa:effectiveDate triple ontbreekt"
+    assert "2024-01-01" in rows[0]["datum"]
+
+
+# ---------------------------------------------------------------------------
+# search_norms — zoeken op label
+# ---------------------------------------------------------------------------
+
+async def test_search_norms_vindt_op_label_substring():
+    from app.db.fuseki_entities import create_norm_entity, search_norms
+    from app.ontology import VALOR_NS
+
+    _LEXA_NS = f"{VALOR_NS}lexa-ext#"
+    await create_norm_entity(f"{_LEXA_NS}Law", "Wet op de schuldsanering", "wsnp-2024")
+    await create_norm_entity(f"{_LEXA_NS}Law", "Schuldhulpverlening gemeenten", "wgs-2012")
+    await create_norm_entity(f"{_LEXA_NS}Regulation", "Arbeidsomstandighedenwet", "arbo-1998")
+
+    results = await search_norms("schuld")
+
+    labels = [r["label"] for r in results]
+    assert any("schuldsanering" in l.lower() for l in labels), "Wet op de schuldsanering niet gevonden"
+    assert any("schuldhulp" in l.lower() for l in labels), "Schuldhulpverlening niet gevonden"
+    assert not any("arbo" in l.lower() for l in labels), "Arbeidsomstandighedenwet mag niet in resultaten"
+
+
+async def test_search_norms_is_case_insensitief():
+    from app.db.fuseki_entities import create_norm_entity, search_norms
+    from app.ontology import VALOR_NS
+
+    _LEXA_NS = f"{VALOR_NS}lexa-ext#"
+    await create_norm_entity(f"{_LEXA_NS}Law", "Wet Maatschappelijke Ondersteuning", "wmo-2015")
+
+    results = await search_norms("MAATSCHAPPELIJKE")
+
+    assert len(results) == 1
+    assert "Maatschappelijke" in results[0]["label"]
+
+
+# ---------------------------------------------------------------------------
+# search_norms — zoeken op identifier
+# ---------------------------------------------------------------------------
+
+async def test_search_norms_vindt_op_identifier_substring():
+    from app.db.fuseki_entities import create_norm_entity, search_norms
+    from app.ontology import VALOR_NS
+
+    _LEXA_NS = f"{VALOR_NS}lexa-ext#"
+    await create_norm_entity(f"{_LEXA_NS}Law", "Wet bijzondere opnemingen psychiatrische ziekenhuizen", "bwbr0005537")
+    await create_norm_entity(f"{_LEXA_NS}Law", "Wet langdurige zorg", "wlz-2015")
+
+    results = await search_norms("bwbr")
+
+    assert len(results) == 1
+    assert results[0]["identifier"] == "bwbr0005537"
+
+
+async def test_search_norms_leeg_resultaat_bij_geen_match():
+    from app.db.fuseki_entities import create_norm_entity, search_norms
+    from app.ontology import VALOR_NS
+
+    _LEXA_NS = f"{VALOR_NS}lexa-ext#"
+    await create_norm_entity(f"{_LEXA_NS}Law", "Wet werk en zekerheid", "wwz-2015")
+
+    results = await search_norms("xyzOnbestaandeWet999")
+
+    assert results == []
+
+
+# ---------------------------------------------------------------------------
+# search_norms — jurisdictie-filter
+# ---------------------------------------------------------------------------
+
+async def test_search_norms_filtert_op_jurisdictie():
+    from app.db.fuseki_entities import create_norm_entity, search_norms
+    from app.ontology import VALOR_NS
+
+    _LEXA_NS = f"{VALOR_NS}lexa-ext#"
+    await create_norm_entity(f"{_LEXA_NS}Law", "Wet Basisregistratie Personen", "brp-2013", jurisdiction="NL")
+    await create_norm_entity(f"{_LEXA_NS}Law", "Lokale Verordening Amsterdam", "ams-2022", jurisdiction="NL-NH")
+    await create_norm_entity(f"{_LEXA_NS}Law", "GDPR", "gdpr-2018", jurisdiction="EU")
+
+    results = await search_norms("wet", jurisdiction="NL")
+
+    assert len(results) == 1
+    assert results[0]["identifier"] == "brp-2013"
+
+
+async def test_search_norms_zonder_jurisdictie_filter_geeft_alles():
+    from app.db.fuseki_entities import create_norm_entity, search_norms
+    from app.ontology import VALOR_NS
+
+    _LEXA_NS = f"{VALOR_NS}lexa-ext#"
+    await create_norm_entity(f"{_LEXA_NS}Law", "Wet sociale werkvoorziening", "wsw-2015", jurisdiction="NL")
+    await create_norm_entity(f"{_LEXA_NS}Regulation", "EU-verordening werkgelegenheid", "eu-werk-2020", jurisdiction="EU")
+
+    results = await search_norms("we")
+
+    assert len(results) == 2
+
+
+# ---------------------------------------------------------------------------
+# search_norms — teruggeef-structuur
+# ---------------------------------------------------------------------------
+
+async def test_search_norms_resultaat_bevat_verwachte_velden():
+    from app.db.fuseki_entities import create_norm_entity, search_norms
+    from app.ontology import VALOR_NS
+
+    _LEXA_NS = f"{VALOR_NS}lexa-ext#"
+    norm_type_uri = f"{_LEXA_NS}Law"
+    await create_norm_entity(norm_type_uri, "Wet open overheid", "woo-2022", jurisdiction="NL")
+
+    results = await search_norms("open overheid")
+
+    assert len(results) == 1
+    r = results[0]
+    assert "uri" in r
+    assert "norm_type_uri" in r
+    assert "norm_type_local" in r
+    assert "label" in r
+    assert "identifier" in r
+    assert "jurisdiction" in r
+    assert r["norm_type_local"] == "Law"
+    assert r["norm_type_uri"] == norm_type_uri
+
+
+# ---------------------------------------------------------------------------
+# get_norm_cross_perspective — verwijzingen in andere grafen
+# ---------------------------------------------------------------------------
+
+async def test_get_norm_cross_perspective_vindt_verwijzing_in_andere_graph():
+    from app.db.fuseki_entities import create_norm_entity, get_norm_cross_perspective
+    from app.services.fuseki import sparql_update
+    from app.ontology import VALOR_NS
+
+    _LEXA_NS = f"{VALOR_NS}lexa-ext#"
+    norm_uri = await create_norm_entity(f"{_LEXA_NS}Law", "Wet langdurige zorg", "wlz-2015")
+
+    # Voeg een verwijzing naar de norm-URI toe in een DesignSpace-graph
+    ds_graph = "urn:valor:ds:test-cross-persp/asis"
+    factor_uri = "urn:valor:tessera:factor-test-001"
+    predicate = f"{VALOR_NS}regulatedBy"
+    await sparql_update(f"""
+INSERT DATA {{
+  GRAPH <{ds_graph}> {{
+    <{factor_uri}> <{predicate}> <{norm_uri}> .
+  }}
+}}
+""", "test-cross-persp")
+
+    results = await get_norm_cross_perspective(norm_uri)
+
+    assert len(results) == 1
+    assert results[0]["graph"] == ds_graph
+    assert results[0]["subject"] == factor_uri
+    assert results[0]["predicate"] == predicate
+
+
+async def test_get_norm_cross_perspective_verwijzing_in_meerdere_grafen():
+    from app.db.fuseki_entities import create_norm_entity, get_norm_cross_perspective
+    from app.services.fuseki import sparql_update
+    from app.ontology import VALOR_NS
+
+    _LEXA_NS = f"{VALOR_NS}lexa-ext#"
+    norm_uri = await create_norm_entity(f"{_LEXA_NS}Regulation", "Besluit Jeugdwet", "bjw-2015")
+
+    predicate = f"{VALOR_NS}regulatedBy"
+
+    for i in range(1, 4):
+        graph = f"urn:valor:ds:test-ds-{i}/asis"
+        subject = f"urn:valor:tessera:factor-{i}"
+        await sparql_update(f"""
+INSERT DATA {{
+  GRAPH <{graph}> {{
+    <{subject}> <{predicate}> <{norm_uri}> .
+  }}
+}}
+""", f"test-ds-{i}")
+
+    results = await get_norm_cross_perspective(norm_uri)
+
+    assert len(results) == 3
+    grafen = {r["graph"] for r in results}
+    assert "urn:valor:ds:test-ds-1/asis" in grafen
+    assert "urn:valor:ds:test-ds-2/asis" in grafen
+    assert "urn:valor:ds:test-ds-3/asis" in grafen
+
+
+async def test_get_norm_cross_perspective_geeft_lege_lijst_zonder_verwijzingen():
+    from app.db.fuseki_entities import create_norm_entity, get_norm_cross_perspective
+    from app.ontology import VALOR_NS
+
+    _LEXA_NS = f"{VALOR_NS}lexa-ext#"
+    norm_uri = await create_norm_entity(f"{_LEXA_NS}Law", "Wet zonder verwijzingen", "geen-refs-001")
+
+    results = await get_norm_cross_perspective(norm_uri)
+
+    assert results == []
+
+
+async def test_get_norm_cross_perspective_sluit_entities_graph_uit():
+    """Verwijzingen vanuit urn:valor:entities zelf mogen niet in het resultaat."""
+    from app.db.fuseki_entities import create_norm_entity, get_norm_cross_perspective
+    from app.services.fuseki import sparql_update
+    from app.ontology import VALOR_NS, UFOC_NS
+
+    _LEXA_NS = f"{VALOR_NS}lexa-ext#"
+    norm_uri = await create_norm_entity(f"{_LEXA_NS}Law", "Wet zorg en dwang", "wzd-2020")
+
+    # Voeg een triple toe die naar de norm verwijst, MAAR in de entities-graph zelf
+    # Dit simuleert bijv. een relatie tussen twee normen in hetzelfde register
+    other_norm_uri = await create_norm_entity(f"{_LEXA_NS}Law", "Aanverwante wet", "aanverwant-001")
+    await sparql_update(f"""
+INSERT DATA {{
+  GRAPH <{_ENTITIES_GRAPH}> {{
+    <{other_norm_uri}> <{_LEXA_NS}relatedNorm> <{norm_uri}> .
+  }}
+}}
+""", "entities")
+
+    results = await get_norm_cross_perspective(norm_uri)
+
+    # entities-graph is uitgesloten — resultaat moet leeg zijn
+    assert results == []
+
+
+async def test_get_norm_cross_perspective_resultaat_bevat_predicate_local():
+    from app.db.fuseki_entities import create_norm_entity, get_norm_cross_perspective
+    from app.services.fuseki import sparql_update
+    from app.ontology import VALOR_NS
+
+    _LEXA_NS = f"{VALOR_NS}lexa-ext#"
+    norm_uri = await create_norm_entity(f"{_LEXA_NS}Law", "Wet inburgering", "wi-2021")
+
+    predicate = f"{VALOR_NS}regulatedBy"
+    await sparql_update(f"""
+INSERT DATA {{
+  GRAPH <urn:valor:ds:test-local/asis> {{
+    <urn:valor:tessera:factor-local> <{predicate}> <{norm_uri}> .
+  }}
+}}
+""", "test-local")
+
+    results = await get_norm_cross_perspective(norm_uri)
+
+    assert len(results) == 1
+    assert results[0]["predicate_local"] == "regulatedBy"

--- a/backend/tests/integration/test_socia.py
+++ b/backend/tests/integration/test_socia.py
@@ -1,0 +1,313 @@
+"""Integratietests voor app.db.fuseki_socia (US-AI.5).
+
+Test:
+- assign_actor_role: schrijft socia:playsRole naar baseline-graph; idempotent
+- get_actor_roles_in_ds: retourneert juiste actor-rol-paren
+- get_tesserae_for_agent: vindt Tesserae waar valor:claimedBy = entity_uri
+- get_designspaces_for_agent: vindt alle DSes waar agent een playsRole heeft
+
+Gebruik:
+    cd backend
+    FUSEKI_URL=http://localhost:3030 pytest tests/integration/test_socia.py -v
+"""
+import sys
+import os
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+pytestmark = pytest.mark.integration
+
+_SOCIA_NS = "https://valor-ecosystem.nl/ontology/socia#"
+_VALOR_NS = "https://valor-ecosystem.nl/ontology/"
+_ENTITIES_GRAPH = "urn:valor:entities"
+
+TEST_DS_ID = "test-ds-socia"
+TEST_DS_ID_2 = "test-ds-socia-2"
+TEST_ENTITY_URI = "urn:valor:entities:person:socia-test-001"
+TEST_ROLE_URI = f"{_SOCIA_NS}Implementer"
+TEST_ROLE_URI_2 = f"{_SOCIA_NS}Supervisor"
+
+
+def _baseline_graph(ds_id: str) -> str:
+    return f"urn:valor:ds:{ds_id}/baseline"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _insert_triple(graph_uri: str, s: str, p: str, o: str, literal: bool = False) -> None:
+    """Voegt een triple in via sparql_update. Gebruik literal=True voor string-literals als object."""
+    from app.services.fuseki import sparql_update
+
+    o_str = f'"{o}"' if literal else f"<{o}>"
+    update = f"""
+        INSERT DATA {{
+          GRAPH <{graph_uri}> {{
+            <{s}> <{p}> {o_str} .
+          }}
+        }}
+    """
+    await sparql_update(update, "test-helper")
+
+
+async def _count_triples_in_graph(graph_uri: str, s: str, p: str, o: str) -> int:
+    """Telt triples die overeenkomen met het patroon in de opgegeven graph."""
+    from app.services.fuseki import sparql_select_global
+
+    rows = await sparql_select_global(f"""
+        SELECT (COUNT(*) AS ?c) WHERE {{
+          GRAPH <{graph_uri}> {{
+            <{s}> <{p}> <{o}> .
+          }}
+        }}
+    """)
+    return int(rows[0]["c"]) if rows else 0
+
+
+# ---------------------------------------------------------------------------
+# assign_actor_role
+# ---------------------------------------------------------------------------
+
+async def test_assign_actor_role_schrijft_plays_role_triple():
+    from app.db.fuseki_socia import assign_actor_role
+
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI, TEST_DS_ID)
+
+    count = await _count_triples_in_graph(
+        _baseline_graph(TEST_DS_ID),
+        TEST_ENTITY_URI,
+        f"{_SOCIA_NS}playsRole",
+        TEST_ROLE_URI,
+    )
+    assert count == 1
+
+
+async def test_assign_actor_role_schrijft_is_stakeholder_in():
+    from app.db.fuseki_socia import assign_actor_role
+
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI, TEST_DS_ID)
+
+    count = await _count_triples_in_graph(
+        _baseline_graph(TEST_DS_ID),
+        TEST_ENTITY_URI,
+        f"{_SOCIA_NS}isStakeholderIn",
+        f"urn:valor:ds:{TEST_DS_ID}",
+    )
+    assert count == 1
+
+
+async def test_assign_actor_role_idempotent():
+    from app.db.fuseki_socia import assign_actor_role
+
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI, TEST_DS_ID)
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI, TEST_DS_ID)
+
+    count = await _count_triples_in_graph(
+        _baseline_graph(TEST_DS_ID),
+        TEST_ENTITY_URI,
+        f"{_SOCIA_NS}playsRole",
+        TEST_ROLE_URI,
+    )
+    assert count == 1
+
+
+async def test_assign_actor_role_meerdere_rollen_mogelijk():
+    from app.db.fuseki_socia import assign_actor_role
+
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI, TEST_DS_ID)
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI_2, TEST_DS_ID)
+
+    count1 = await _count_triples_in_graph(
+        _baseline_graph(TEST_DS_ID),
+        TEST_ENTITY_URI,
+        f"{_SOCIA_NS}playsRole",
+        TEST_ROLE_URI,
+    )
+    count2 = await _count_triples_in_graph(
+        _baseline_graph(TEST_DS_ID),
+        TEST_ENTITY_URI,
+        f"{_SOCIA_NS}playsRole",
+        TEST_ROLE_URI_2,
+    )
+    assert count1 == 1
+    assert count2 == 1
+
+
+# ---------------------------------------------------------------------------
+# get_actor_roles_in_ds
+# ---------------------------------------------------------------------------
+
+async def test_get_actor_roles_in_ds_retourneert_rol_paar():
+    from app.db.fuseki_socia import assign_actor_role, get_actor_roles_in_ds
+
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI, TEST_DS_ID)
+
+    roles = await get_actor_roles_in_ds(TEST_DS_ID)
+
+    assert len(roles) == 1
+    assert roles[0]["entity_uri"] == TEST_ENTITY_URI
+    assert roles[0]["role_uri"] == TEST_ROLE_URI
+
+
+async def test_get_actor_roles_in_ds_bevat_role_local():
+    from app.db.fuseki_socia import assign_actor_role, get_actor_roles_in_ds
+
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI, TEST_DS_ID)
+
+    roles = await get_actor_roles_in_ds(TEST_DS_ID)
+
+    assert roles[0]["role_local"] == "Implementer"
+
+
+async def test_get_actor_roles_in_ds_join_entity_registry():
+    from app.db.fuseki_socia import assign_actor_role, get_actor_roles_in_ds
+    from app.ontology import UFOC_NS
+
+    # Entiteit aanmaken in Entity Registry
+    type_uri = f"{UFOC_NS}PhysicalAgent"
+    await _insert_triple(_ENTITIES_GRAPH, TEST_ENTITY_URI, "http://www.w3.org/1999/02/22-rdf-syntax-ns#type", type_uri)
+    await _insert_triple(_ENTITIES_GRAPH, TEST_ENTITY_URI, "http://www.w3.org/2000/01/rdf-schema#label", "Test Persoon", literal=True)
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI, TEST_DS_ID)
+
+    roles = await get_actor_roles_in_ds(TEST_DS_ID)
+
+    match = next((r for r in roles if r["entity_uri"] == TEST_ENTITY_URI), None)
+    assert match is not None
+    assert match["entity_type"] == type_uri
+    assert match["entity_type_local"] == "PhysicalAgent"
+
+
+async def test_get_actor_roles_in_ds_leeg_resultaat():
+    from app.db.fuseki_socia import get_actor_roles_in_ds
+
+    roles = await get_actor_roles_in_ds("ds-zonder-rollen")
+
+    assert roles == []
+
+
+async def test_get_actor_roles_in_ds_isoleert_per_ds():
+    from app.db.fuseki_socia import assign_actor_role, get_actor_roles_in_ds
+
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI, TEST_DS_ID)
+
+    roles_andere_ds = await get_actor_roles_in_ds(TEST_DS_ID_2)
+
+    assert roles_andere_ds == []
+
+
+# ---------------------------------------------------------------------------
+# get_tesserae_for_agent
+# ---------------------------------------------------------------------------
+
+async def test_get_tesserae_for_agent_vindt_tessera():
+    from app.db.fuseki_socia import get_tesserae_for_agent
+
+    tessera_uri = "urn:valor:tessera:socia-test-factor-001"
+    graph = _baseline_graph(TEST_DS_ID)
+
+    await _insert_triple(graph, tessera_uri, f"{_VALOR_NS}claimedBy", TEST_ENTITY_URI)
+
+    results = await get_tesserae_for_agent(TEST_ENTITY_URI, TEST_DS_ID)
+
+    assert len(results) == 1
+    assert results[0]["tessera_uri"] == tessera_uri
+    assert results[0]["graph"] == graph
+
+
+async def test_get_tesserae_for_agent_bevat_type_en_content():
+    from app.db.fuseki_socia import get_tesserae_for_agent
+    from app.services.fuseki import sparql_update
+
+    tessera_uri = "urn:valor:tessera:socia-test-factor-002"
+    type_uri = f"{_VALOR_NS}Factor"
+    graph = _baseline_graph(TEST_DS_ID)
+
+    update = f"""
+        INSERT DATA {{
+          GRAPH <{graph}> {{
+            <{tessera_uri}> <{_VALOR_NS}claimedBy> <{TEST_ENTITY_URI}> ;
+                            <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <{type_uri}> ;
+                            <{_VALOR_NS}claimContent> "Testinhoud" .
+          }}
+        }}
+    """
+    await sparql_update(update, "test-helper")
+
+    results = await get_tesserae_for_agent(TEST_ENTITY_URI, TEST_DS_ID)
+
+    match = next((r for r in results if r["tessera_uri"] == tessera_uri), None)
+    assert match is not None
+    assert match["type"] == type_uri
+    assert match["type_local"] == "Factor"
+    assert match["content"] == "Testinhoud"
+
+
+async def test_get_tesserae_for_agent_leeg_resultaat():
+    from app.db.fuseki_socia import get_tesserae_for_agent
+
+    results = await get_tesserae_for_agent("urn:valor:entities:person:bestaat-niet", TEST_DS_ID)
+
+    assert results == []
+
+
+async def test_get_tesserae_for_agent_isoleert_per_ds():
+    from app.db.fuseki_socia import get_tesserae_for_agent
+
+    tessera_uri = "urn:valor:tessera:socia-test-factor-003"
+    graph_andere_ds = _baseline_graph(TEST_DS_ID_2)
+
+    await _insert_triple(graph_andere_ds, tessera_uri, f"{_VALOR_NS}claimedBy", TEST_ENTITY_URI)
+
+    # DS2-tessera mag NIET zichtbaar zijn via DS1-query
+    results = await get_tesserae_for_agent(TEST_ENTITY_URI, TEST_DS_ID)
+    uris = [r["tessera_uri"] for r in results]
+    assert tessera_uri not in uris
+
+
+# ---------------------------------------------------------------------------
+# get_designspaces_for_agent
+# ---------------------------------------------------------------------------
+
+async def test_get_designspaces_for_agent_retourneert_ds_id():
+    from app.db.fuseki_socia import assign_actor_role, get_designspaces_for_agent
+
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI, TEST_DS_ID)
+
+    ds_ids = await get_designspaces_for_agent(TEST_ENTITY_URI)
+
+    assert TEST_DS_ID in ds_ids
+
+
+async def test_get_designspaces_for_agent_meerdere_ds():
+    from app.db.fuseki_socia import assign_actor_role, get_designspaces_for_agent
+
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI, TEST_DS_ID)
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI_2, TEST_DS_ID_2)
+
+    ds_ids = await get_designspaces_for_agent(TEST_ENTITY_URI)
+
+    assert TEST_DS_ID in ds_ids
+    assert TEST_DS_ID_2 in ds_ids
+
+
+async def test_get_designspaces_for_agent_leeg_resultaat():
+    from app.db.fuseki_socia import get_designspaces_for_agent
+
+    ds_ids = await get_designspaces_for_agent("urn:valor:entities:person:bestaat-niet")
+
+    assert ds_ids == []
+
+
+async def test_get_designspaces_for_agent_geen_duplicaten():
+    from app.db.fuseki_socia import assign_actor_role, get_designspaces_for_agent
+
+    # Twee rollen in dezelfde DS — DISTINCT moet zorgen voor één DS-ID
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI, TEST_DS_ID)
+    await assign_actor_role(TEST_ENTITY_URI, TEST_ROLE_URI_2, TEST_DS_ID)
+
+    ds_ids = await get_designspaces_for_agent(TEST_ENTITY_URI)
+
+    assert ds_ids.count(TEST_DS_ID) == 1

--- a/docs/valor-ecosystem.md
+++ b/docs/valor-ecosystem.md
@@ -257,6 +257,118 @@ Een `valor:Participant` is een `ufoc:Agent` met een rol (`Initiator`, `Contribut
 
 ---
 
+## 2B. Entity Identiteitsarchitectuur
+
+### 2B.1 Kernprincipe
+
+VALOR werkt met twee categorisch onderscheiden soorten entiteiten: rigide Kinds en anti-rigide rollen. Een rigide Kind is een type waarvan de instanties noodzakelijkerwijs tot dat type behoren zolang ze bestaan — een persoon is altijd een `ufoc:PhysicalAgent`, ongeacht in welk vraagstuk of perspectief ze verschijnt. Een anti-rigide rol is een type waarvan de instanties contingent lid zijn — dezelfde persoon kan een `socia:HumanStakeholder` zijn in het SOCIA-perspectief en een `lexa:SubjectOfNorm` in LEXA, afhankelijk van de context.
+
+Het kernprincipe van de Entity Identiteitsarchitectuur: **elk rigide Kind in VALOR heeft één persistente URI in de Entity Registry (`urn:valor:entities`)**. Deze URI wordt hergebruikt in alle DesignSpaces en perspectieven. Anti-rigide rollen worden per perspectief of DesignSpace toegewezen in de baseline-graph van de betreffende DesignSpace (`urn:valor:ds:{ds_id}/baseline`).
+
+Dit principe heeft drie directe architectuurvoordelen:
+
+1. **Identiteitsintegriteit over DesignSpaces** — dezelfde burger, organisatie of wet verschijnt in meerdere vraagstukken altijd als dezelfde URI. Cross-DesignSpace queries zijn daarmee semantisch correct zonder disambiguatie-overhead.
+2. **Perspectief-isolatie** — roltoewijzingen zijn geïsoleerd per DesignSpace en perspectief. Een entiteit kan in de ene context als stakeholder verschijnen en in een andere als rechtspersoon, zonder dat die rolassignaties elkaar beïnvloeden.
+3. **Ontologische zuiverheid** — de Entity Registry bevat uitsluitend rigide Kinds (ontologisch stabiel); perspectieven bevatten uitsluitend rollen en relaties (contextafhankelijk). De scheiding reflecteert het UFO-onderscheid tussen sortalen types en relatieve types.
+
+### 2B.2 Kind-taxonomie (Endurants)
+
+De volgende rigide Kinds vormen de identiteitsdragende typen in VALOR. Elke entiteit die in VALOR wordt beschreven of bijhoudt, is een instantie van precies één van deze Kinds (het principe van single instantiation voor sortal types).
+
+| Kind | gUFO-type | Module | Identiteitscriterium |
+|------|-----------|--------|---------------------|
+| `ufoc:PhysicalAgent` | `gufo:FunctionalComplex` | UFO-C | Lichamelijke continuïteit |
+| `ufoc:InstitutionalAgent` | `gufo:FunctionalComplex` | UFO-C | Collectieve erkenning |
+| `valor:Issue` | `gufo:SocialObject` | VALOR-CORE | Constitutieve situatie + betrokken community |
+| `delibera:Tessera` | `gufo:SocialObject` | DELIBERA | De bewering zelf (propositionele identiteit) |
+| `causa:CausalVariable` | `gufo:Quality` | CAUSA | Het gemeten construct |
+| `causa:CausalClaim` | `gufo:IntrinsicMode` | CAUSA | Kind van de Belief-mode |
+| `ufoc:NormativeDescription` | `gufo:SocialObject` | LEXA | De normatieve tekst zelf |
+
+**Belangrijk onderscheid:** `ufoc:Agent` is een **Category** (rigid non-sortal) en niet een Kind — het groepeert `PhysicalAgent` en `InstitutionalAgent` met elk hun eigen identiteitscriterium. Een agent-URI in VALOR is altijd een instantie van een van de twee subkind-types, nooit van `ufoc:Agent` direct.
+
+### 2B.3 Rolmatrix per Perspectief
+
+Dezelfde entiteit verschijnt in verschillende perspectieven via rol-assigning relaties. De onderstaande matrix toont hoe rigide Kinds worden gekoppeld aan perspectief-specifieke rollen.
+
+| Entiteit | gUFO-type | SOCIA | CAUSA | ACTA | LEXA |
+|----------|-----------|-------|-------|------|------|
+| Persoon | `ufoc:PhysicalAgent` | `socia:HumanStakeholder` | — | `acta:ActorRole` | `lexa:SubjectOfNorm` |
+| Organisatie | `ufoc:InstitutionalAgent` | `socia:OrganisationalActor` | — | `acta:AuthorisedExecutor` | `lexa:ObligatedParty` |
+| Wet/regeling | `ufoc:NormativeDescription` | — | causale randvoorwaarde | `acta:LegalBasis` | `lexa:NormativeSource` |
+| Factor | `causa:CausalVariable` | — | `causa:Factor` | `acta:CapabilityRequirement` | — |
+
+Rollen zijn geen nieuwe URIs — ze zijn eigenschappen die worden toegekend aan de persistente Kind-URI. De triple `<urn:valor:entities:person:abc> socia:playsRole socia:HumanStakeholder` staat in de baseline-graph van de betreffende DesignSpace, niet in de Entity Registry zelf.
+
+### 2B.4 Named Graph Architectuur
+
+```
+urn:valor:entities                ← Persistente rigide Kinds (platform-breed)
+urn:valor:ds:{ds_id}/baseline     ← Rolassignaties, Tesserae, perspectief-specifieke data
+```
+
+De Entity Registry is een **platform-brede** named graph: zij bevat de fundamentele identiteitsbeschrijvingen die over alle DesignSpaces heen gelden. De baseline-graph is **DesignSpace-specifiek**: zij bevat alles wat contextueel is — rollen, relaties, Tesserae, fasegebonden beweringen.
+
+### 2B.5 Supabase–Fuseki Identiteitsbrug
+
+VALOR-gebruikers authenticeren via Supabase. Bij elke eerste login wordt Just-in-Time (JIT) een `ufoc:PhysicalAgent`-instantie aangemaakt in `urn:valor:entities`, gekoppeld aan de Supabase UUID van de gebruiker.
+
+URI-patroon voor interne gebruikers:
+```
+urn:valor:entities:person:{supabase_uuid}
+```
+
+De JIT-brug garandeert dat elke deelnemer bij zijn eerste interactie met een DesignSpace een ontologisch correcte identiteit heeft. De Supabase-identiteit (auth) en de VALOR-O entiteit (kennis) zijn daarmee expliciet verbonden maar gescheiden: de auth-laag blijft in Supabase/Neo4j, de kennislaag staat in Fuseki.
+
+### 2B.6 Intern vs. Extern Onderscheid
+
+VALOR onderscheidt twee categorieën entiteiten in de registry:
+
+**Interne entiteiten** zijn VALOR-gebruikers met een Supabase-account. Ze worden aangemaakt via de JIT-brug bij login.
+
+**Externe entiteiten** zijn beschreven actoren (burgers, organisaties, wetten) zonder VALOR-account. Ze worden aangemaakt in `urn:valor:entities` door een deelnemer die ze beschrijft als onderdeel van een DesignSpace. Externe personen en organisaties zijn volledig gelijkwaardig aan interne entiteiten in de ontologie — het enige verschil is de oorsprong van de URI en de afwezigheid van een Supabase-koppeling.
+
+### 2B.7 Cross-perspectief Rolpatroon
+
+Het standaard Turtle-patroon voor roltoewijzing in een DesignSpace:
+
+```turtle
+# In urn:valor:ds:{ds_id}/baseline:
+<urn:valor:entities:person:abc> socia:playsRole socia:PrincipalRole ;
+    socia:isStakeholderIn <urn:valor:issue:{issue_id}> .
+
+<urn:valor:entities:norm:wob2022> lexa:isApplicableIn <urn:valor:issue:{issue_id}> ;
+    acta:isLegalBasisFor <urn:valor:entities:action:xyz> .
+```
+
+De entiteit-URIs (`urn:valor:entities:*`) blijven stabiel over tijd en DesignSpaces. Alleen de roltoewijzings-triples veranderen per context.
+
+### 2B.8 Vijf Invariante Structuurparen
+
+Door de hele VALOR-architectuur heen keren vijf structuurparen terug als architecturele invarianten. Ze zijn aanwezig in elk vraagstuk, elk perspectief en elke fase:
+
+1. **Agent ↔ Issue** — wie draagt het vraagstuk? (SOCIA-koppeling; legitimeringsbron van het ecosysteem)
+2. **CausalClaim ↔ Intervention** — theorie van verandering (CAUSA-kern; de beleidstheoretische rationale)
+3. **TransactionType ↔ ValueExperience** — wat wordt gedaan en wat ervaart de burger? (ACTA–AXIA-koppeling via COVER)
+4. **Tessera ↔ DecisionEpisode** — wat wordt beweerd en wanneer beslist? (DELIBERA-kern; epistemische provenance)
+5. **Capability ↔ TransactionType** — kan het ook echt? (CAPAX-gate; haalbaarheidscheck)
+
+Deze vijf paren zijn de minimale structuur van elk coherent VALOR-model. Een DesignSpace zonder volledig ingevulde structuurparen is per definitie onvolledig — detecteerbaar via SPARQL-constraints op de SHACL-shapes.
+
+### 2B.9 URI-conventies Entity Registry
+
+```
+urn:valor:entities:person:{supabase_uuid}    ← interne gebruikers (JIT-aangemaakt bij login)
+urn:valor:entities:person:{random_uuid}      ← externe personen (aangemaakt door deelnemer)
+urn:valor:entities:org:{random_uuid}         ← organisaties (intern of extern)
+urn:valor:entities:norm:{slug}               ← wetten en regelingen (bijv. norm:wob2022)
+urn:valor:entities:cvar:{slug-of-uuid}       ← causale variabelen (Factors)
+```
+
+Het `slug`-patroon voor normen maakt mensleesbare URIs mogelijk (`norm:wob2022`, `norm:avg`) terwijl de UUID-variant gebruikt wordt wanneer geen stabiele naam beschikbaar is. Bij conflicts (twee deelnemers maken dezelfde norm met een andere slug aan) is de Entity Registry de canonieke bron; deduplicatie is een beheerstaak.
+
+---
+
 ## 3. Claim-architectuur en Epistemische Statusmachine
 
 ### 3.1 Elke modelleerelement is een Tessera

--- a/frontend/src/perspectives/socia/hooks/useSociaOntology.ts
+++ b/frontend/src/perspectives/socia/hooks/useSociaOntology.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect, useRef } from 'react';
+import { api, type SociaOntology } from '../../../services/api';
+
+const _cache: { data: SociaOntology | null } = { data: null };
+
+interface UseSociaOntologyResult {
+    ontology: SociaOntology | null;
+    loading: boolean;
+    error: Error | null;
+}
+
+export function useSociaOntology(): UseSociaOntologyResult {
+    const [ontology, setOntology] = useState<SociaOntology | null>(_cache.data);
+    const [loading, setLoading] = useState(_cache.data === null);
+    const [error, setError] = useState<Error | null>(null);
+    const fetchedRef = useRef(_cache.data !== null);
+
+    useEffect(() => {
+        if (fetchedRef.current) return;
+        fetchedRef.current = true;
+
+        api.getSociaOntology()
+            .then((data) => {
+                _cache.data = data;
+                setOntology(data);
+            })
+            .catch((err) => setError(err instanceof Error ? err : new Error(String(err))))
+            .finally(() => setLoading(false));
+    }, []);
+
+    return { ontology, loading, error };
+}

--- a/frontend/src/perspectives/socia/views/edges/DependencyEdge.tsx
+++ b/frontend/src/perspectives/socia/views/edges/DependencyEdge.tsx
@@ -1,0 +1,18 @@
+import { useSociaOntology } from '../../hooks/useSociaOntology';
+
+interface DependencyEdgeProps {
+    dependency_type_uri: string;
+}
+
+export function DependencyEdge({ dependency_type_uri }: DependencyEdgeProps) {
+    const { ontology } = useSociaOntology();
+
+    const depType = ontology?.dependency_types.find((d) => d.uri === dependency_type_uri);
+    const label = depType?.label_nl ?? dependency_type_uri.split('#').pop() ?? '';
+
+    return (
+        <span className="text-xs px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
+            {label}
+        </span>
+    );
+}

--- a/frontend/src/perspectives/socia/views/modals/CreateActorModal.tsx
+++ b/frontend/src/perspectives/socia/views/modals/CreateActorModal.tsx
@@ -5,85 +5,206 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useSociaOntology } from '../../hooks/useSociaOntology';
+import { api, type EntityRegistryEntry } from '@/services/api';
+
+type Step = 'search' | 'create-new';
 
 interface CreateActorModalProps {
+    dsId: string;
     open: boolean;
     onClose: () => void;
-    onSubmit: (data: { label: string; actor_type_uri: string; role_uri?: string }) => void;
+    onSubmit: (entityUri: string, roleUri?: string) => void;
 }
 
-export function CreateActorModal({ open, onClose, onSubmit }: CreateActorModalProps) {
-    const { ontology, loading } = useSociaOntology();
-    const [label, setLabel] = useState('');
-    const [actorTypeUri, setActorTypeUri] = useState('');
+export function CreateActorModal({ dsId, open, onClose, onSubmit }: CreateActorModalProps) {
+    const { ontology, loading: ontologyLoading } = useSociaOntology();
+
+    const [step, setStep] = useState<Step>('search');
+    const [query, setQuery] = useState('');
+    const [searchResults, setSearchResults] = useState<EntityRegistryEntry[]>([]);
+    const [searching, setSearching] = useState(false);
+    const [selectedUri, setSelectedUri] = useState('');
     const [roleUri, setRoleUri] = useState('');
 
-    function handleSubmit() {
-        if (!label.trim() || !actorTypeUri) return;
-        onSubmit({ label: label.trim(), actor_type_uri: actorTypeUri, role_uri: roleUri || undefined });
-        setLabel('');
-        setActorTypeUri('');
+    // Nieuwe actor aanmaken
+    const [newLabel, setNewLabel] = useState('');
+    const [newTypeUri, setNewTypeUri] = useState('');
+    const [creating, setCreating] = useState(false);
+
+    async function handleSearch() {
+        if (!query.trim()) return;
+        setSearching(true);
+        try {
+            const results = await api.searchEntities(query.trim());
+            setSearchResults(results);
+        } finally {
+            setSearching(false);
+        }
+    }
+
+    async function handleSelectExisting() {
+        if (!selectedUri) return;
+        if (roleUri) {
+            await api.assignSociaRole(dsId, selectedUri, roleUri);
+        }
+        onSubmit(selectedUri, roleUri || undefined);
+        handleClose();
+    }
+
+    async function handleCreateNew() {
+        if (!newLabel.trim() || !newTypeUri) return;
+        setCreating(true);
+        try {
+            const typeLocalName = newTypeUri.split('#').pop() ?? 'PhysicalAgent';
+            const entry = await api.createEntity({ entity_type: typeLocalName, label: newLabel.trim() });
+            if (roleUri) {
+                await api.assignSociaRole(dsId, entry.uri, roleUri);
+            }
+            onSubmit(entry.uri, roleUri || undefined);
+            handleClose();
+        } finally {
+            setCreating(false);
+        }
+    }
+
+    function handleClose() {
+        setStep('search');
+        setQuery('');
+        setSearchResults([]);
+        setSelectedUri('');
         setRoleUri('');
+        setNewLabel('');
+        setNewTypeUri('');
+        onClose();
     }
 
     return (
-        <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
+        <Dialog open={open} onOpenChange={(o) => { if (!o) handleClose(); }}>
             <DialogContent>
                 <DialogHeader>
                     <DialogTitle>Actor toevoegen</DialogTitle>
                 </DialogHeader>
 
-                <div className="space-y-4 py-2">
-                    <div className="space-y-1">
-                        <Label htmlFor="actor-label">Naam</Label>
-                        <Input
-                            id="actor-label"
-                            value={label}
-                            onChange={(e) => setLabel(e.target.value)}
-                            placeholder="Naam van de actor"
-                        />
-                    </div>
+                {step === 'search' && (
+                    <div className="space-y-4 py-2">
+                        <div className="space-y-1">
+                            <Label>Zoek in register</Label>
+                            <div className="flex gap-2">
+                                <Input
+                                    value={query}
+                                    onChange={(e) => setQuery(e.target.value)}
+                                    onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+                                    placeholder="Naam van persoon, organisatie…"
+                                />
+                                <Button variant="outline" onClick={handleSearch} disabled={searching}>
+                                    {searching ? 'Zoeken…' : 'Zoeken'}
+                                </Button>
+                            </div>
+                        </div>
 
-                    <div className="space-y-1">
-                        <Label htmlFor="actor-type">Type</Label>
-                        <Select value={actorTypeUri} onValueChange={setActorTypeUri} disabled={loading}>
-                            <SelectTrigger id="actor-type">
-                                <SelectValue placeholder={loading ? 'Laden...' : 'Kies een type'} />
-                            </SelectTrigger>
-                            <SelectContent>
-                                {ontology?.actor_types.map((t) => (
-                                    <SelectItem key={t.uri} value={t.uri}>
-                                        {t.label_nl}
-                                    </SelectItem>
-                                ))}
-                            </SelectContent>
-                        </Select>
-                    </div>
+                        {searchResults.length > 0 && (
+                            <div className="space-y-1">
+                                <Label>Resultaten</Label>
+                                <div className="border rounded-md divide-y max-h-48 overflow-y-auto">
+                                    {searchResults.map((entry) => (
+                                        <button
+                                            key={entry.uri}
+                                            type="button"
+                                            onClick={() => setSelectedUri(entry.uri)}
+                                            className={`w-full text-left px-3 py-2 text-sm hover:bg-muted transition-colors ${selectedUri === entry.uri ? 'bg-muted font-medium' : ''}`}
+                                        >
+                                            <span>{entry.label ?? entry.uri.split(':').pop()}</span>
+                                            {entry.entity_type_local && (
+                                                <span className="ml-2 text-xs text-muted-foreground">{entry.entity_type_local}</span>
+                                            )}
+                                        </button>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
 
-                    <div className="space-y-1">
-                        <Label htmlFor="actor-role">Rol (optioneel)</Label>
-                        <Select value={roleUri} onValueChange={setRoleUri} disabled={loading}>
-                            <SelectTrigger id="actor-role">
-                                <SelectValue placeholder={loading ? 'Laden...' : 'Kies een rol'} />
-                            </SelectTrigger>
-                            <SelectContent>
-                                <SelectItem value="">— geen rol —</SelectItem>
-                                {ontology?.roles.map((r) => (
-                                    <SelectItem key={r.uri} value={r.uri}>
-                                        {r.label_nl}
-                                    </SelectItem>
-                                ))}
-                            </SelectContent>
-                        </Select>
-                    </div>
-                </div>
+                        {searchResults.length === 0 && query && !searching && (
+                            <p className="text-sm text-muted-foreground">
+                                Geen resultaten. Je kunt een nieuwe externe actor aanmaken.
+                            </p>
+                        )}
 
-                <DialogFooter>
-                    <Button variant="outline" onClick={onClose}>Annuleren</Button>
-                    <Button onClick={handleSubmit} disabled={!label.trim() || !actorTypeUri}>
-                        Toevoegen
-                    </Button>
-                </DialogFooter>
+                        <div className="space-y-1">
+                            <Label htmlFor="role-select">Rol (optioneel)</Label>
+                            <Select value={roleUri} onValueChange={setRoleUri} disabled={ontologyLoading}>
+                                <SelectTrigger id="role-select">
+                                    <SelectValue placeholder={ontologyLoading ? 'Laden…' : 'Kies een rol'} />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="">— geen rol —</SelectItem>
+                                    {ontology?.roles.map((r) => (
+                                        <SelectItem key={r.uri} value={r.uri}>{r.label_nl}</SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        </div>
+
+                        <DialogFooter className="flex-col sm:flex-row gap-2">
+                            <Button variant="outline" onClick={() => setStep('create-new')} className="sm:mr-auto">
+                                Nieuwe externe actor
+                            </Button>
+                            <Button variant="outline" onClick={handleClose}>Annuleren</Button>
+                            <Button onClick={handleSelectExisting} disabled={!selectedUri}>
+                                Toevoegen
+                            </Button>
+                        </DialogFooter>
+                    </div>
+                )}
+
+                {step === 'create-new' && (
+                    <div className="space-y-4 py-2">
+                        <div className="space-y-1">
+                            <Label htmlFor="new-label">Naam</Label>
+                            <Input
+                                id="new-label"
+                                value={newLabel}
+                                onChange={(e) => setNewLabel(e.target.value)}
+                                placeholder="Naam van de actor"
+                            />
+                        </div>
+
+                        <div className="space-y-1">
+                            <Label htmlFor="new-type">Type</Label>
+                            <Select value={newTypeUri} onValueChange={setNewTypeUri} disabled={ontologyLoading}>
+                                <SelectTrigger id="new-type">
+                                    <SelectValue placeholder={ontologyLoading ? 'Laden…' : 'Kies een type'} />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {ontology?.actor_types.map((t) => (
+                                        <SelectItem key={t.uri} value={t.uri}>{t.label_nl}</SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        </div>
+
+                        <div className="space-y-1">
+                            <Label htmlFor="new-role">Rol (optioneel)</Label>
+                            <Select value={roleUri} onValueChange={setRoleUri} disabled={ontologyLoading}>
+                                <SelectTrigger id="new-role">
+                                    <SelectValue placeholder={ontologyLoading ? 'Laden…' : 'Kies een rol'} />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="">— geen rol —</SelectItem>
+                                    {ontology?.roles.map((r) => (
+                                        <SelectItem key={r.uri} value={r.uri}>{r.label_nl}</SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        </div>
+
+                        <DialogFooter>
+                            <Button variant="outline" onClick={() => setStep('search')}>Terug</Button>
+                            <Button onClick={handleCreateNew} disabled={!newLabel.trim() || !newTypeUri || creating}>
+                                {creating ? 'Aanmaken…' : 'Aanmaken'}
+                            </Button>
+                        </DialogFooter>
+                    </div>
+                )}
             </DialogContent>
         </Dialog>
     );

--- a/frontend/src/perspectives/socia/views/modals/CreateActorModal.tsx
+++ b/frontend/src/perspectives/socia/views/modals/CreateActorModal.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useSociaOntology } from '../../hooks/useSociaOntology';
+
+interface CreateActorModalProps {
+    open: boolean;
+    onClose: () => void;
+    onSubmit: (data: { label: string; actor_type_uri: string; role_uri?: string }) => void;
+}
+
+export function CreateActorModal({ open, onClose, onSubmit }: CreateActorModalProps) {
+    const { ontology, loading } = useSociaOntology();
+    const [label, setLabel] = useState('');
+    const [actorTypeUri, setActorTypeUri] = useState('');
+    const [roleUri, setRoleUri] = useState('');
+
+    function handleSubmit() {
+        if (!label.trim() || !actorTypeUri) return;
+        onSubmit({ label: label.trim(), actor_type_uri: actorTypeUri, role_uri: roleUri || undefined });
+        setLabel('');
+        setActorTypeUri('');
+        setRoleUri('');
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Actor toevoegen</DialogTitle>
+                </DialogHeader>
+
+                <div className="space-y-4 py-2">
+                    <div className="space-y-1">
+                        <Label htmlFor="actor-label">Naam</Label>
+                        <Input
+                            id="actor-label"
+                            value={label}
+                            onChange={(e) => setLabel(e.target.value)}
+                            placeholder="Naam van de actor"
+                        />
+                    </div>
+
+                    <div className="space-y-1">
+                        <Label htmlFor="actor-type">Type</Label>
+                        <Select value={actorTypeUri} onValueChange={setActorTypeUri} disabled={loading}>
+                            <SelectTrigger id="actor-type">
+                                <SelectValue placeholder={loading ? 'Laden...' : 'Kies een type'} />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {ontology?.actor_types.map((t) => (
+                                    <SelectItem key={t.uri} value={t.uri}>
+                                        {t.label_nl}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+
+                    <div className="space-y-1">
+                        <Label htmlFor="actor-role">Rol (optioneel)</Label>
+                        <Select value={roleUri} onValueChange={setRoleUri} disabled={loading}>
+                            <SelectTrigger id="actor-role">
+                                <SelectValue placeholder={loading ? 'Laden...' : 'Kies een rol'} />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="">— geen rol —</SelectItem>
+                                {ontology?.roles.map((r) => (
+                                    <SelectItem key={r.uri} value={r.uri}>
+                                        {r.label_nl}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                </div>
+
+                <DialogFooter>
+                    <Button variant="outline" onClick={onClose}>Annuleren</Button>
+                    <Button onClick={handleSubmit} disabled={!label.trim() || !actorTypeUri}>
+                        Toevoegen
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/frontend/src/perspectives/socia/views/modals/EditActorModal.tsx
+++ b/frontend/src/perspectives/socia/views/modals/EditActorModal.tsx
@@ -1,0 +1,102 @@
+import { useState, useEffect } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useSociaOntology } from '../../hooks/useSociaOntology';
+
+interface Actor {
+    uri: string;
+    label: string;
+    actor_type_uri: string;
+    role_uri?: string;
+}
+
+interface EditActorModalProps {
+    open: boolean;
+    actor: Actor | null;
+    onClose: () => void;
+    onSubmit: (data: { label: string; actor_type_uri: string; role_uri?: string }) => void;
+}
+
+export function EditActorModal({ open, actor, onClose, onSubmit }: EditActorModalProps) {
+    const { ontology, loading } = useSociaOntology();
+    const [label, setLabel] = useState('');
+    const [actorTypeUri, setActorTypeUri] = useState('');
+    const [roleUri, setRoleUri] = useState('');
+
+    useEffect(() => {
+        if (actor) {
+            setLabel(actor.label);
+            setActorTypeUri(actor.actor_type_uri);
+            setRoleUri(actor.role_uri ?? '');
+        }
+    }, [actor]);
+
+    function handleSubmit() {
+        if (!label.trim() || !actorTypeUri) return;
+        onSubmit({ label: label.trim(), actor_type_uri: actorTypeUri, role_uri: roleUri || undefined });
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Actor bewerken</DialogTitle>
+                </DialogHeader>
+
+                <div className="space-y-4 py-2">
+                    <div className="space-y-1">
+                        <Label htmlFor="edit-actor-label">Naam</Label>
+                        <Input
+                            id="edit-actor-label"
+                            value={label}
+                            onChange={(e) => setLabel(e.target.value)}
+                        />
+                    </div>
+
+                    <div className="space-y-1">
+                        <Label htmlFor="edit-actor-type">Type</Label>
+                        <Select value={actorTypeUri} onValueChange={setActorTypeUri} disabled={loading}>
+                            <SelectTrigger id="edit-actor-type">
+                                <SelectValue placeholder={loading ? 'Laden...' : 'Kies een type'} />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {ontology?.actor_types.map((t) => (
+                                    <SelectItem key={t.uri} value={t.uri}>
+                                        {t.label_nl}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+
+                    <div className="space-y-1">
+                        <Label htmlFor="edit-actor-role">Rol (optioneel)</Label>
+                        <Select value={roleUri} onValueChange={setRoleUri} disabled={loading}>
+                            <SelectTrigger id="edit-actor-role">
+                                <SelectValue placeholder={loading ? 'Laden...' : 'Kies een rol'} />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="">— geen rol —</SelectItem>
+                                {ontology?.roles.map((r) => (
+                                    <SelectItem key={r.uri} value={r.uri}>
+                                        {r.label_nl}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                </div>
+
+                <DialogFooter>
+                    <Button variant="outline" onClick={onClose}>Annuleren</Button>
+                    <Button onClick={handleSubmit} disabled={!label.trim() || !actorTypeUri}>
+                        Opslaan
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/frontend/src/perspectives/socia/views/modals/EditActorModal.tsx
+++ b/frontend/src/perspectives/socia/views/modals/EditActorModal.tsx
@@ -1,43 +1,52 @@
 import { useState, useEffect } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useSociaOntology } from '../../hooks/useSociaOntology';
+import { api } from '@/services/api';
 
-interface Actor {
-    uri: string;
-    label: string;
-    actor_type_uri: string;
-    role_uri?: string;
+interface ActorRoleEntry {
+    entity_uri: string;
+    entity_label?: string;
+    entity_type_local?: string;
+    role_uri: string;
+    role_label_nl?: string;
 }
 
 interface EditActorModalProps {
+    dsId: string;
     open: boolean;
-    actor: Actor | null;
+    actor: ActorRoleEntry | null;
     onClose: () => void;
-    onSubmit: (data: { label: string; actor_type_uri: string; role_uri?: string }) => void;
+    onSubmit: (entityUri: string, roleUri?: string) => void;
 }
 
-export function EditActorModal({ open, actor, onClose, onSubmit }: EditActorModalProps) {
-    const { ontology, loading } = useSociaOntology();
-    const [label, setLabel] = useState('');
-    const [actorTypeUri, setActorTypeUri] = useState('');
+export function EditActorModal({ dsId, open, actor, onClose, onSubmit }: EditActorModalProps) {
+    const { ontology, loading: ontologyLoading } = useSociaOntology();
     const [roleUri, setRoleUri] = useState('');
+    const [saving, setSaving] = useState(false);
 
     useEffect(() => {
-        if (actor) {
-            setLabel(actor.label);
-            setActorTypeUri(actor.actor_type_uri);
-            setRoleUri(actor.role_uri ?? '');
-        }
+        if (actor) setRoleUri(actor.role_uri ?? '');
     }, [actor]);
 
-    function handleSubmit() {
-        if (!label.trim() || !actorTypeUri) return;
-        onSubmit({ label: label.trim(), actor_type_uri: actorTypeUri, role_uri: roleUri || undefined });
+    async function handleSave() {
+        if (!actor) return;
+        setSaving(true);
+        try {
+            if (roleUri && roleUri !== actor.role_uri) {
+                await api.assignSociaRole(dsId, actor.entity_uri, roleUri);
+            }
+            onSubmit(actor.entity_uri, roleUri || undefined);
+            onClose();
+        } finally {
+            setSaving(false);
+        }
     }
+
+    const displayName = actor?.entity_label ?? actor?.entity_uri.split(':').pop() ?? '';
+    const typeLabel = actor?.entity_type_local ?? '';
 
     return (
         <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
@@ -47,43 +56,27 @@ export function EditActorModal({ open, actor, onClose, onSubmit }: EditActorModa
                 </DialogHeader>
 
                 <div className="space-y-4 py-2">
-                    <div className="space-y-1">
-                        <Label htmlFor="edit-actor-label">Naam</Label>
-                        <Input
-                            id="edit-actor-label"
-                            value={label}
-                            onChange={(e) => setLabel(e.target.value)}
-                        />
+                    {/* Entity Registry profiel — read-only */}
+                    <div className="rounded-md border border-border bg-muted/40 px-3 py-2 space-y-1">
+                        <p className="text-xs text-muted-foreground">Registerprofiel (alleen-lezen)</p>
+                        <p className="text-sm font-medium">{displayName}</p>
+                        {typeLabel && (
+                            <p className="text-xs text-muted-foreground">{typeLabel}</p>
+                        )}
+                        <p className="text-xs text-muted-foreground font-mono truncate">{actor?.entity_uri}</p>
                     </div>
 
+                    {/* Rolassignatie — bewerkbaar */}
                     <div className="space-y-1">
-                        <Label htmlFor="edit-actor-type">Type</Label>
-                        <Select value={actorTypeUri} onValueChange={setActorTypeUri} disabled={loading}>
-                            <SelectTrigger id="edit-actor-type">
-                                <SelectValue placeholder={loading ? 'Laden...' : 'Kies een type'} />
-                            </SelectTrigger>
-                            <SelectContent>
-                                {ontology?.actor_types.map((t) => (
-                                    <SelectItem key={t.uri} value={t.uri}>
-                                        {t.label_nl}
-                                    </SelectItem>
-                                ))}
-                            </SelectContent>
-                        </Select>
-                    </div>
-
-                    <div className="space-y-1">
-                        <Label htmlFor="edit-actor-role">Rol (optioneel)</Label>
-                        <Select value={roleUri} onValueChange={setRoleUri} disabled={loading}>
-                            <SelectTrigger id="edit-actor-role">
-                                <SelectValue placeholder={loading ? 'Laden...' : 'Kies een rol'} />
+                        <Label htmlFor="edit-role">Rol in deze werkruimte</Label>
+                        <Select value={roleUri} onValueChange={setRoleUri} disabled={ontologyLoading}>
+                            <SelectTrigger id="edit-role">
+                                <SelectValue placeholder={ontologyLoading ? 'Laden…' : 'Kies een rol'} />
                             </SelectTrigger>
                             <SelectContent>
                                 <SelectItem value="">— geen rol —</SelectItem>
                                 {ontology?.roles.map((r) => (
-                                    <SelectItem key={r.uri} value={r.uri}>
-                                        {r.label_nl}
-                                    </SelectItem>
+                                    <SelectItem key={r.uri} value={r.uri}>{r.label_nl}</SelectItem>
                                 ))}
                             </SelectContent>
                         </Select>
@@ -92,8 +85,8 @@ export function EditActorModal({ open, actor, onClose, onSubmit }: EditActorModa
 
                 <DialogFooter>
                     <Button variant="outline" onClick={onClose}>Annuleren</Button>
-                    <Button onClick={handleSubmit} disabled={!label.trim() || !actorTypeUri}>
-                        Opslaan
+                    <Button onClick={handleSave} disabled={saving || !actor}>
+                        {saving ? 'Opslaan…' : 'Opslaan'}
                     </Button>
                 </DialogFooter>
             </DialogContent>

--- a/frontend/src/perspectives/socia/views/nodes/ActorNode.tsx
+++ b/frontend/src/perspectives/socia/views/nodes/ActorNode.tsx
@@ -1,0 +1,30 @@
+import { useSociaOntology } from '../../hooks/useSociaOntology';
+
+interface ActorNodeProps {
+    label: string;
+    actor_type_uri: string;
+    role_uri?: string;
+}
+
+export function ActorNode({ label, actor_type_uri, role_uri }: ActorNodeProps) {
+    const { ontology } = useSociaOntology();
+
+    const actorType = ontology?.actor_types.find((t) => t.uri === actor_type_uri);
+    const role = role_uri ? ontology?.roles.find((r) => r.uri === role_uri) : null;
+
+    return (
+        <div className="flex flex-col items-center gap-1 px-3 py-2 rounded-lg border border-border bg-card text-card-foreground shadow-sm min-w-[120px]">
+            <span className="text-sm font-medium truncate max-w-[160px]">{label}</span>
+            {actorType && (
+                <span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+                    {actorType.label_nl}
+                </span>
+            )}
+            {role && (
+                <span className="text-xs px-2 py-0.5 rounded-full bg-primary/10 text-primary">
+                    {role.label_nl}
+                </span>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -63,6 +63,19 @@ export interface ValidationResult {
     message: string;
 }
 
+export interface SociaOntologyEntry {
+    uri: string;
+    local_name: string;
+    label_en: string;
+    label_nl: string;
+}
+
+export interface SociaOntology {
+    actor_types: SociaOntologyEntry[];
+    roles: SociaOntologyEntry[];
+    dependency_types: SociaOntologyEntry[];
+}
+
 export interface AgentResponse {
     agent_name: string;
     perspective: string;
@@ -616,6 +629,11 @@ export const api = {
     // Ontologie endpoints
     getEpistemicStatuses: async (): Promise<{ uri: string; label_en: string; label_nl: string }[]> => {
         const response = await apiClient.get('/ontology/epistemic-statuses');
+        return response.data;
+    },
+
+    getSociaOntology: async (): Promise<SociaOntology> => {
+        const response = await apiClient.get<SociaOntology>('/ontology/socia');
         return response.data;
     },
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -63,6 +63,14 @@ export interface ValidationResult {
     message: string;
 }
 
+export interface EntityRegistryEntry {
+    uri: string;
+    label?: string;
+    entity_type?: string;
+    entity_type_local?: string;
+    supabase_id?: string;
+}
+
 export interface SociaOntologyEntry {
     uri: string;
     local_name: string;
@@ -635,6 +643,25 @@ export const api = {
     getSociaOntology: async (): Promise<SociaOntology> => {
         const response = await apiClient.get<SociaOntology>('/ontology/socia');
         return response.data;
+    },
+
+    // Entity Registry
+    searchEntities: async (q: string, entityType?: string, limit = 20): Promise<EntityRegistryEntry[]> => {
+        const params: Record<string, string | number> = { q, limit };
+        if (entityType) params.type = entityType;
+        const response = await apiClient.get<EntityRegistryEntry[]>('/entities/search', { params });
+        return response.data;
+    },
+
+    createEntity: async (data: { entity_type: string; label: string; properties?: Record<string, string>; identifier?: string }): Promise<EntityRegistryEntry> => {
+        const response = await apiClient.post<EntityRegistryEntry>('/entities/', data);
+        return response.data;
+    },
+
+    assignSociaRole: async (dsId: string, entityUri: string, roleUri: string): Promise<void> => {
+        await apiClient.post(`/designspace/${dsId}/socia/roles`, null, {
+            params: { entity_uri: entityUri, role_uri: roleUri },
+        });
     },
 
     // Threads (Fuseki-backed disc endpoints, Epic 16)


### PR DESCRIPTION
## Epic 18 — Entity Identiteitsarchitectuur

Sluit Epic #481. Alle 8 User Stories gemerged.

## Geleverde User Stories

| US | Issue | Beschrijving |
|----|-------|--------------|
| US-AI.1 | #482 | Architectuurdocumentatie `valor-ecosystem.md` |
| US-AI.2 | #483 | Ontologie-patches: StakeholderRole, actortypes, NormativeDescription |
| US-AI.3 | #484 | Entity Registry Backend + JIT Supabase-bridge |
| US-AI.4 | #485 | Ontologie-gedreven SOCIA types |
| US-AI.5 | #486 | Cross-perspectief rolpatroon (`socia:playsRole`) |
| US-AI.6 | #487 | SOCIA-refactoring: migratie naar Entity Registry |
| US-AI.7 | #488 | Normatieve Objecten in Entity Registry |
| US-AI.8 | #489 | CausalVariable Entity Registry: Factors als persistente Kinds |

## Architectuurresultaat

- **`urn:valor:entities`** — platformbrede named graph als single source of truth voor alle rigide Kinds
- **5 rigide Kinds**: `PhysicalAgent`, `InstitutionalAgent`, `NormativeDescription`, `SocialObject`, `CausalVariable`
- **JIT-bridge**: Supabase-gebruikers worden automatisch als `PhysicalAgent` aangemaakt
- **Rol-assignaties** in `urn:valor:ds:{ds_id}/baseline` via `valor:playsRole`
- **SOCIA-perspectief** volledig gemigreerd naar Entity Registry
- **19 LEXA norm-typen** beschikbaar als `NormativeDescription` subklassen
- **`causa:CausalVariable`** herbruikbaar across CAUSA-modellen via slug-gebaseerde URIs

## Gedeblokkeerde volgende stappen

- Epic 6 actor CRUD (US-6.2+)
- Epic 9 ACTA actor-refs + LEXA normatieve objecten
- Epic 14 IssueCommunity agent-leden
- CAPAX cross-perspectief Factor-referenties

🤖 Generated with [Claude Code](https://claude.com/claude-code)