### PR TITLE
feat(socia): Stakeholderkaart — actoren + IntentionalDependency-edges (US-6.1) #306

### DIFF
--- a/backend/app/db/fuseki_socia.py
+++ b/backend/app/db/fuseki_socia.py
@@ -49,6 +49,94 @@ def _local_name(uri: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Stakeholderkaart ophalen (US-6.1)
+# ---------------------------------------------------------------------------
+
+async def get_stakeholder_map(ds_id: str) -> dict:
+    """Haalt actoren en socia:IntentionalDependency-edges op uit de DesignSpace-baseline-graph.
+
+    Retourneert:
+      {
+        "actors": [{"uri": str, "label": str, "entity_type": str, "role_uri": str|None, "role_label_nl": str|None}],
+        "dependencies": [{"from_uri": str, "to_uri": str, "dependency_type": str, "dependency_label_nl": str}]
+      }
+    """
+    baseline = _baseline_graph(ds_id)
+    _RDFS = "http://www.w3.org/2000/01/rdf-schema#"
+
+    # Actoren: alle entiteiten met socia:isStakeholderIn in de baseline-graph
+    actor_rows = await sparql_select_global(f"""
+        PREFIX socia:  <{_SOCIA_NS}>
+        PREFIX valor:  <{VALOR_NS}>
+        PREFIX rdfs:   <{_RDFS}>
+        PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+        SELECT DISTINCT ?entity ?entityLabel ?entityType ?role ?roleLabel WHERE {{
+          GRAPH <{baseline}> {{
+            ?entity socia:isStakeholderIn <{_ds_uri(ds_id)}> .
+            OPTIONAL {{ ?entity socia:playsRole ?role . }}
+          }}
+          OPTIONAL {{
+            GRAPH <{_ENTITIES_GRAPH}> {{
+              OPTIONAL {{ ?entity rdfs:label ?entityLabel . }}
+              OPTIONAL {{ ?entity rdf:type ?entityType . }}
+            }}
+          }}
+          OPTIONAL {{
+            GRAPH <{VALOR_NS}socia> {{
+              ?role rdfs:label ?roleLabel . FILTER(lang(?roleLabel) = "nl")
+            }}
+          }}
+        }}
+    """)
+
+    actors = []
+    for row in actor_rows:
+        entity_uri = row["entity"]
+        actors.append({
+            "uri": entity_uri,
+            "label": row.get("entityLabel") or entity_uri.split(":")[-1],
+            "entity_type": row.get("entityType", ""),
+            "entity_type_local": _local_name(row.get("entityType", "")),
+            "role_uri": row.get("role"),
+            "role_label_nl": row.get("roleLabel"),
+        })
+
+    # IntentionalDependency-edges
+    dep_rows = await sparql_select_global(f"""
+        PREFIX socia:  <{_SOCIA_NS}>
+        PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
+
+        SELECT ?from ?to ?depType ?depLabel WHERE {{
+          GRAPH <{baseline}> {{
+            ?dep a socia:IntentionalDependency ;
+                 socia:dependsOn ?to ;
+                 socia:dependedUponBy ?from .
+            OPTIONAL {{ ?dep socia:dependencyType ?depType . }}
+          }}
+          OPTIONAL {{
+            GRAPH <{VALOR_NS}socia> {{
+              ?depType rdfs:label ?depLabel . FILTER(lang(?depLabel) = "nl")
+            }}
+          }}
+        }}
+    """)
+
+    dependencies = [
+        {
+            "from_uri": row["from"],
+            "to_uri": row["to"],
+            "dependency_type": row.get("depType", f"{_SOCIA_NS}IntentionalDependency"),
+            "dependency_type_local": _local_name(row.get("depType", "IntentionalDependency")),
+            "dependency_label_nl": row.get("depLabel") or _local_name(row.get("depType", "afhankelijkheid")),
+        }
+        for row in dep_rows
+    ]
+
+    return {"actors": actors, "dependencies": dependencies}
+
+
+# ---------------------------------------------------------------------------
 # Rol-assignatie schrijven
 # ---------------------------------------------------------------------------
 

--- a/backend/app/routers/socia.py
+++ b/backend/app/routers/socia.py
@@ -6,6 +6,7 @@ from app.db.fuseki_socia import (
     assign_actor_role,
     get_actor_roles_in_ds,
     get_designspaces_for_agent,
+    get_stakeholder_map,
     get_tesserae_for_agent,
     migrate_legacy_socia_actors,
 )
@@ -56,6 +57,15 @@ async def get_agent_designspaces_endpoint(
         agent_uri = agent_uri.replace("urn:/", "urn:").lstrip("/")
     ds_ids = await get_designspaces_for_agent(agent_uri)
     return {"agent_uri": agent_uri, "designspaces": ds_ids}
+
+
+@router.get("/designspace/{ds_id}/stakeholder-map")
+async def get_stakeholder_map_endpoint(
+    ds_id: str,
+    _user=Depends(get_current_user),
+):
+    """Retourneert de stakeholderkaart: actoren en IntentionalDependency-edges voor een DesignSpace."""
+    return await get_stakeholder_map(ds_id)
 
 
 @router.post("/admin/migrate-socia-actors")

--- a/frontend/src/perspectives/socia/views/StakeholderMap.tsx
+++ b/frontend/src/perspectives/socia/views/StakeholderMap.tsx
@@ -1,0 +1,185 @@
+import { useCallback, useEffect, useState } from 'react';
+import ReactFlow, {
+    Background,
+    Controls,
+    useNodesState,
+    useEdgesState,
+    MarkerType,
+    type Node,
+    type Edge,
+} from 'reactflow';
+import 'reactflow/dist/style.css';
+import { api, type StakeholderActor, type StakeholderDependency } from '@/services/api';
+import { useSociaOntology } from '../hooks/useSociaOntology';
+
+// ---------------------------------------------------------------------------
+// Node-types
+// ---------------------------------------------------------------------------
+
+interface ActorNodeData {
+    label: string;
+    entityTypeLocal: string;
+    roleLabel: string | null;
+}
+
+function ActorFlowNode({ data }: { data: ActorNodeData }) {
+    return (
+        <div className="flex flex-col items-center gap-1 px-3 py-2 rounded-lg border border-border bg-card text-card-foreground shadow-sm min-w-[130px] max-w-[200px]">
+            <span className="text-sm font-medium text-center leading-tight">{data.label}</span>
+            {data.entityTypeLocal && (
+                <span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+                    {data.entityTypeLocal}
+                </span>
+            )}
+            {data.roleLabel && (
+                <span className="text-xs px-2 py-0.5 rounded-full bg-primary/10 text-primary">
+                    {data.roleLabel}
+                </span>
+            )}
+        </div>
+    );
+}
+
+const NODE_TYPES = { actor: ActorFlowNode };
+
+// ---------------------------------------------------------------------------
+// Layout hulpfunctie (eenvoudige cirkelindeling)
+// ---------------------------------------------------------------------------
+
+function circleLayout(actors: StakeholderActor[]): { x: number; y: number }[] {
+    const n = actors.length;
+    if (n === 0) return [];
+    const radius = Math.max(180, n * 50);
+    return actors.map((_, i) => {
+        const angle = (2 * Math.PI * i) / n - Math.PI / 2;
+        return {
+            x: 400 + radius * Math.cos(angle),
+            y: 320 + radius * Math.sin(angle),
+        };
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Conversie helpers
+// ---------------------------------------------------------------------------
+
+function actorsToNodes(
+    actors: StakeholderActor[],
+    positions: { x: number; y: number }[],
+): Node<ActorNodeData>[] {
+    return actors.map((actor, i) => ({
+        id: actor.uri,
+        type: 'actor',
+        position: positions[i] ?? { x: i * 200, y: 0 },
+        data: {
+            label: actor.label,
+            entityTypeLocal: actor.entity_type_local,
+            roleLabel: actor.role_label_nl ?? null,
+        },
+    }));
+}
+
+function dependenciesToEdges(deps: StakeholderDependency[]): Edge[] {
+    return deps.map((dep, i) => ({
+        id: `dep-${i}`,
+        source: dep.from_uri,
+        target: dep.to_uri,
+        label: dep.dependency_label_nl,
+        markerEnd: { type: MarkerType.ArrowClosed },
+        style: { strokeWidth: 1.5 },
+        labelStyle: { fontSize: 11 },
+    }));
+}
+
+// ---------------------------------------------------------------------------
+// Hoofdcomponent
+// ---------------------------------------------------------------------------
+
+interface StakeholderMapProps {
+    dsId: string;
+}
+
+export function StakeholderMap({ dsId }: StakeholderMapProps) {
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    useSociaOntology(); // preload ontologie-cache voor labels in de toekomst
+
+    const [nodes, setNodes, onNodesChange] = useNodesState<ActorNodeData>([]);
+    const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+
+    const load = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const map = await api.getStakeholderMap(dsId);
+            const positions = circleLayout(map.actors);
+            setNodes(actorsToNodes(map.actors, positions));
+            setEdges(dependenciesToEdges(map.dependencies));
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Onbekende fout');
+        } finally {
+            setLoading(false);
+        }
+    }, [dsId, setNodes, setEdges]);
+
+    useEffect(() => {
+        load();
+    }, [load]);
+
+    const nodeCount = nodes.length;
+    const edgeCount = edges.length;
+
+    if (loading) {
+        return (
+            <div className="flex items-center justify-center h-64 text-muted-foreground text-sm">
+                Stakeholderkaart laden…
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="flex flex-col items-center justify-center h-64 gap-2">
+                <p className="text-sm text-destructive">Fout bij laden: {error}</p>
+                <button
+                    type="button"
+                    onClick={load}
+                    className="text-sm underline text-muted-foreground hover:text-foreground"
+                >
+                    Opnieuw proberen
+                </button>
+            </div>
+        );
+    }
+
+    if (nodeCount === 0) {
+        return (
+            <div className="flex items-center justify-center h-64 text-muted-foreground text-sm">
+                Geen actoren gevonden in deze DesignSpace.
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex flex-col h-full">
+            <div className="flex items-center gap-4 px-4 py-2 border-b border-border text-xs text-muted-foreground">
+                <span>{nodeCount} actor{nodeCount !== 1 ? 'en' : ''}</span>
+                <span>{edgeCount} afhankelijkhe{edgeCount !== 1 ? 'den' : 'id'}</span>
+            </div>
+            <div className="flex-1 min-h-0">
+                <ReactFlow
+                    nodes={nodes}
+                    edges={edges}
+                    onNodesChange={onNodesChange}
+                    onEdgesChange={onEdgesChange}
+                    nodeTypes={NODE_TYPES}
+                    fitView
+                    fitViewOptions={{ padding: 0.2 }}
+                >
+                    <Background />
+                    <Controls />
+                </ReactFlow>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -84,6 +84,28 @@ export interface SociaOntology {
     dependency_types: SociaOntologyEntry[];
 }
 
+export interface StakeholderActor {
+    uri: string;
+    label: string;
+    entity_type: string;
+    entity_type_local: string;
+    role_uri: string | null;
+    role_label_nl: string | null;
+}
+
+export interface StakeholderDependency {
+    from_uri: string;
+    to_uri: string;
+    dependency_type: string;
+    dependency_type_local: string;
+    dependency_label_nl: string;
+}
+
+export interface StakeholderMap {
+    actors: StakeholderActor[];
+    dependencies: StakeholderDependency[];
+}
+
 export interface AgentResponse {
     agent_name: string;
     perspective: string;
@@ -662,6 +684,11 @@ export const api = {
         await apiClient.post(`/designspace/${dsId}/socia/roles`, null, {
             params: { entity_uri: entityUri, role_uri: roleUri },
         });
+    },
+
+    getStakeholderMap: async (dsId: string): Promise<StakeholderMap> => {
+        const response = await apiClient.get<StakeholderMap>(`/designspace/${dsId}/stakeholder-map`);
+        return response.data;
     },
 
     // Threads (Fuseki-backed disc endpoints, Epic 16)


### PR DESCRIPTION
$(cat <<'EOF'
## Samenvatting

- Backend: `GET /designspace/{ds_id}/stakeholder-map` endpoint in `socia.py`
- `get_stakeholder_map()` SPARQL-query in `fuseki_socia.py` haalt `socia:Actor`-nodes en `socia:IntentionalDependency`-edges op uit de `urn:valor:ds:{ds_id}/baseline` graph
- Frontend: `StakeholderMap.tsx` React Flow component met cirkelindeling en edge-labels
- Nieuwe types `StakeholderMap`, `StakeholderActor`, `StakeholderDependency` + `api.getStakeholderMap()` in `api.ts`

## Acceptatiecriteria

- [x] Kaart toont actor-nodes (via `socia:isStakeholderIn` in baseline-graph)
- [x] `socia:IntentionalDependency` edges correct weergegeven met label
- [x] Opgebouwd via SPARQL queries (geen hardcoded data)

## Testplan

- [ ] Backend syntax check: `python3 -m py_compile backend/app/routers/socia.py`
- [ ] Frontend build: `cd frontend && npm run build` — geen TypeScript errors
- [ ] Handmatig: `GET /designspace/{ds_id}/stakeholder-map` retourneert `{actors: [...], dependencies: [...]}`

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)