### PR TITLE
feat(axia): Heatmap-overlay op Causa-workspace (US-7.3) #310

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,6 +18,7 @@ from app.routers import tessera
 from app.routers import designspace
 from app.routers import entities
 from app.routers import socia
+from app.routers import axia
 
 load_dotenv()
 
@@ -99,6 +100,7 @@ app.include_router(tessera.router)
 app.include_router(designspace.router)
 app.include_router(entities.router)
 app.include_router(socia.router)
+app.include_router(axia.router)
 
 
 @app.get("/")

--- a/backend/app/routers/axia.py
+++ b/backend/app/routers/axia.py
@@ -1,0 +1,232 @@
+import uuid
+import logging
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from app.auth import get_current_user
+from app.db.permissions import check_permission
+from app.models.domain import Role
+from app.services.fuseki import sparql_select, sparql_update, record_provenance_activity
+from app.ontology import VALOR_NS
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/designspace",
+    tags=["axia"],
+)
+
+AXIA_NS = "https://valor-ecosystem.nl/ontology/axia#"
+COVER_NS = "https://valor-ecosystem.nl/ontology/cover#"
+XSD_NS = "http://www.w3.org/2001/XMLSchema#"
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+class ValueClaimOut(BaseModel):
+    tessera_uri: str
+    tessera_id: str
+    claim_content: str
+    value_type_uri: str
+    value_type_label: str
+    claimed_by: str
+    claimed_at: str
+
+
+class ValueCanvasOut(BaseModel):
+    design_space_id: str
+    groups: dict[str, list[ValueClaimOut]]
+
+
+class CreateValueTensionRequest(BaseModel):
+    value_type_a_uri: str
+    value_type_b_uri: str
+    description: str
+
+
+class ValueTensionOut(BaseModel):
+    tessera_uri: str
+    tessera_id: str
+    value_type_a_uri: str
+    value_type_b_uri: str
+    description: str
+    created_by: str
+    created_at: str
+
+
+# ---------------------------------------------------------------------------
+# US-7.1: GET value-claims gegroepeerd per ValueType
+# ---------------------------------------------------------------------------
+
+@router.get("/{ds_id}/value-claims", response_model=ValueCanvasOut)
+async def get_value_claims(
+    ds_id: str,
+    user: dict = Depends(get_current_user),
+) -> ValueCanvasOut:
+    user_id = user["id"]
+
+    has_permission = await check_permission(user_id, ds_id, Role.VIEWER)
+    if not has_permission:
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten voor deze DesignSpace.")
+
+    graph_uri = f"urn:valor:ds:{ds_id}:baseline"
+
+    query = f"""PREFIX axia: <{AXIA_NS}>
+PREFIX cover: <{COVER_NS}>
+PREFIX valor: <{VALOR_NS}>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?tessera ?content ?valueType ?valueTypeLabel ?claimedBy ?claimedAt WHERE {{
+  GRAPH <{graph_uri}> {{
+    ?tessera a axia:ValueClaim ;
+             valor:claimContent ?content ;
+             valor:claimedBy ?claimedBy ;
+             valor:claimedAt ?claimedAt .
+    OPTIONAL {{
+      ?tessera axia:groundedIn ?valueType .
+    }}
+    OPTIONAL {{
+      ?tessera axia:valueType ?valueType .
+    }}
+    OPTIONAL {{
+      ?valueType rdfs:label ?valueTypeLabel .
+    }}
+  }}
+}}
+ORDER BY ?valueType"""
+
+    rows = await sparql_select(query, ds_id)
+
+    groups: dict[str, list[ValueClaimOut]] = {}
+    for row in rows:
+        tessera_uri = row.get("tessera", "")
+        tessera_id = tessera_uri.rsplit(":", 1)[-1]
+        value_type_uri = row.get("valueType", "")
+        value_type_label = row.get("valueTypeLabel", value_type_uri.rsplit("#", 1)[-1] if "#" in value_type_uri else value_type_uri.rsplit("/", 1)[-1])
+
+        claim = ValueClaimOut(
+            tessera_uri=tessera_uri,
+            tessera_id=tessera_id,
+            claim_content=row.get("content", ""),
+            value_type_uri=value_type_uri,
+            value_type_label=value_type_label,
+            claimed_by=row.get("claimedBy", "").rsplit(":", 1)[-1],
+            claimed_at=row.get("claimedAt", ""),
+        )
+
+        groups.setdefault(value_type_uri, []).append(claim)
+
+    return ValueCanvasOut(design_space_id=ds_id, groups=groups)
+
+
+# ---------------------------------------------------------------------------
+# US-7.2: POST value-tension
+# ---------------------------------------------------------------------------
+
+@router.post("/{ds_id}/value-tension", response_model=ValueTensionOut, status_code=201)
+async def create_value_tension(
+    ds_id: str,
+    request: CreateValueTensionRequest,
+    user: dict = Depends(get_current_user),
+) -> ValueTensionOut:
+    user_id = user["id"]
+
+    has_permission = await check_permission(user_id, ds_id, Role.MEMBER)
+    if not has_permission:
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten voor deze DesignSpace.")
+
+    tessera_id = str(uuid.uuid4())
+    tessera_uri = f"urn:valor:tessera:{tessera_id}"
+    user_uri = f"urn:valor:user:{user_id}"
+    created_at = datetime.now(timezone.utc).isoformat()
+    graph_uri = f"urn:valor:ds:{ds_id}:baseline"
+
+    escaped_desc = request.description.replace("\\", "\\\\").replace('"', '\\"')
+
+    sparql = f"""PREFIX axia: <{AXIA_NS}>
+PREFIX cover: <{COVER_NS}>
+PREFIX valor: <{VALOR_NS}>
+PREFIX xsd: <{XSD_NS}>
+
+INSERT DATA {{
+  GRAPH <{graph_uri}> {{
+    <{tessera_uri}> a axia:ValueTensionClaim ;
+      a valor:Tessera ;
+      valor:claimContent "{escaped_desc}"@nl ;
+      axia:tensionBetween <{request.value_type_a_uri}> ;
+      axia:tensionBetween <{request.value_type_b_uri}> ;
+      axia:spanningWaarde <{request.value_type_a_uri}> ;
+      axia:spanningWaarde <{request.value_type_b_uri}> ;
+      valor:claimedBy <{user_uri}> ;
+      valor:claimedAt "{created_at}"^^xsd:dateTime .
+  }}
+}}"""
+
+    await sparql_update(sparql, ds_id)
+
+    await record_provenance_activity(
+        ds_id,
+        "ValueTensionCreated",
+        user_uri,
+        generated=tessera_uri,
+    )
+
+    logger.info("ValueTensionClaim aangemaakt: %s in DesignSpace %s door %s", tessera_uri, ds_id, user_id)
+
+    return ValueTensionOut(
+        tessera_uri=tessera_uri,
+        tessera_id=tessera_id,
+        value_type_a_uri=request.value_type_a_uri,
+        value_type_b_uri=request.value_type_b_uri,
+        description=request.description,
+        created_by=user_id,
+        created_at=created_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# US-7.3: GET value-implications per factor
+# ---------------------------------------------------------------------------
+
+class DesignImplicationCount(BaseModel):
+    factor_uri: str
+    implication_count: int
+
+
+@router.get("/{ds_id}/value-implications", response_model=list[DesignImplicationCount])
+async def get_value_implications(
+    ds_id: str,
+    user: dict = Depends(get_current_user),
+) -> list[DesignImplicationCount]:
+    user_id = user["id"]
+
+    has_permission = await check_permission(user_id, ds_id, Role.VIEWER)
+    if not has_permission:
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten voor deze DesignSpace.")
+
+    graph_uri = f"urn:valor:ds:{ds_id}:baseline"
+
+    query = f"""PREFIX axia: <{AXIA_NS}>
+
+SELECT ?factor (COUNT(?implication) AS ?count) WHERE {{
+  GRAPH <{graph_uri}> {{
+    ?implication a axia:DesignImplication ;
+                 axia:impliesFor ?factor .
+  }}
+}}
+GROUP BY ?factor
+ORDER BY DESC(?count)"""
+
+    rows = await sparql_select(query, ds_id)
+
+    return [
+        DesignImplicationCount(
+            factor_uri=row["factor"],
+            implication_count=int(row["count"]),
+        )
+        for row in rows
+    ]

--- a/frontend/src/perspectives/axia/HeatmapOverlay.tsx
+++ b/frontend/src/perspectives/axia/HeatmapOverlay.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useState, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { api } from '@/services/api';
+import type { DesignImplicationCount } from '@/services/api';
+
+interface NodePosition {
+    id: string;
+    x: number;
+    y: number;
+    width?: number;
+    height?: number;
+}
+
+interface HeatmapOverlayProps {
+    designSpaceId: string;
+    /** ReactFlow instance — used to get node screen positions */
+    rfInstance: any | null;
+    /** Array of node ids present in the graph */
+    nodeIds: string[];
+}
+
+/**
+ * Legt een oranje intensiteitsoverlay over de Causa-nodes op basis van
+ * het aantal axia:DesignImplication relaties per factor-URI.
+ *
+ * De overlay toont een knop om te activeren/deactiveren. Wanneer actief
+ * worden de nodes ingekleurd op basis van hun implication-count
+ * (0 = transparant, max = oranje-rood).
+ */
+export function HeatmapOverlay({ designSpaceId, rfInstance, nodeIds }: HeatmapOverlayProps) {
+    const [active, setActive] = useState(false);
+    const [implications, setImplications] = useState<DesignImplicationCount[]>([]);
+    const [nodePositions, setNodePositions] = useState<NodePosition[]>([]);
+    const [loading, setLoading] = useState(false);
+
+    const fetchImplications = useCallback(async () => {
+        setLoading(true);
+        try {
+            const data = await api.getValueImplications(designSpaceId);
+            setImplications(data);
+        } catch {
+            setImplications([]);
+        } finally {
+            setLoading(false);
+        }
+    }, [designSpaceId]);
+
+    // Laad implications wanneer overlay geactiveerd wordt
+    useEffect(() => {
+        if (active) {
+            fetchImplications();
+        }
+    }, [active, fetchImplications]);
+
+    // Sync node posities vanuit rfInstance
+    useEffect(() => {
+        if (!active || !rfInstance) return;
+
+        const updatePositions = () => {
+            try {
+                const rfNodes = rfInstance.getNodes?.() ?? [];
+                const positions: NodePosition[] = rfNodes
+                    .filter((n: any) => nodeIds.includes(n.id))
+                    .map((n: any) => ({
+                        id: n.id,
+                        x: n.position.x,
+                        y: n.position.y,
+                        width: n.width ?? 140,
+                        height: n.height ?? 100,
+                    }));
+                setNodePositions(positions);
+            } catch {
+                // rfInstance nog niet klaar
+            }
+        };
+
+        updatePositions();
+        // Periodiek updaten zodat posities meebewegen na drag
+        const interval = setInterval(updatePositions, 500);
+        return () => clearInterval(interval);
+    }, [active, rfInstance, nodeIds]);
+
+    // Normaliseer counts → intensiteit 0..1
+    const maxCount = Math.max(1, ...implications.map((i) => i.implication_count));
+
+    // Map factor_uri → count (gebruik het trailing segment als node-id lookup)
+    const countByFactorUri = new Map<string, number>(
+        implications.map((i) => [i.factor_uri, i.implication_count])
+    );
+
+    // Zoek count voor een node-id: probeer directe match, dan URI-suffix match
+    const countForNode = (nodeId: string): number => {
+        if (countByFactorUri.has(nodeId)) return countByFactorUri.get(nodeId)!;
+        // Factor-URI kan er zo uitzien: urn:valor:factor:abc123 — match suffix
+        for (const [uri, count] of countByFactorUri) {
+            if (uri.endsWith(nodeId) || uri.endsWith(`:${nodeId}`)) return count;
+        }
+        return 0;
+    };
+
+    const intensityToColor = (count: number): string => {
+        if (count === 0) return 'transparent';
+        const t = count / maxCount;
+        // Oranje-gradient: licht oranje → oranje-rood
+        const r = Math.round(255);
+        const g = Math.round(165 * (1 - t * 0.7));
+        const b = 0;
+        const a = 0.15 + t * 0.45;
+        return `rgba(${r},${g},${b},${a})`;
+    };
+
+    return (
+        <>
+            <Button
+                size="sm"
+                variant={active ? 'default' : 'outline'}
+                className="h-8 px-3 text-xs"
+                onClick={() => setActive((v) => !v)}
+                disabled={loading}
+                title="Waarde-implicaties heatmap"
+            >
+                {loading ? 'Laden...' : active ? 'Heatmap uit' : 'Heatmap aan'}
+            </Button>
+
+            {active && nodePositions.length > 0 && (
+                <HeatmapLayer
+                    nodePositions={nodePositions}
+                    countForNode={countForNode}
+                    intensityToColor={intensityToColor}
+                    rfInstance={rfInstance}
+                />
+            )}
+        </>
+    );
+}
+
+interface HeatmapLayerProps {
+    nodePositions: NodePosition[];
+    countForNode: (nodeId: string) => number;
+    intensityToColor: (count: number) => string;
+    rfInstance: any | null;
+}
+
+function HeatmapLayer({ nodePositions, countForNode, intensityToColor, rfInstance }: HeatmapLayerProps) {
+    // Zet ReactFlow-coördinaten om naar schermcoördinaten
+    const getScreenPos = (x: number, y: number): { x: number; y: number } => {
+        if (!rfInstance?.flowToScreenPosition) return { x, y };
+        return rfInstance.flowToScreenPosition({ x, y });
+    };
+
+    return (
+        <div
+            className="absolute inset-0 pointer-events-none"
+            style={{ zIndex: 10 }}
+            aria-hidden
+        >
+            {nodePositions.map((node) => {
+                const count = countForNode(node.id);
+                const color = intensityToColor(count);
+                if (color === 'transparent') return null;
+
+                const w = node.width ?? 140;
+                const h = node.height ?? 100;
+
+                // node.position is center-based (ReactFlow nodeOrigin [0.5, 0.5])
+                const screenPos = getScreenPos(node.x - w / 2, node.y - h / 2);
+
+                return (
+                    <div
+                        key={node.id}
+                        style={{
+                            position: 'absolute',
+                            left: screenPos.x,
+                            top: screenPos.y,
+                            width: w,
+                            height: h,
+                            backgroundColor: color,
+                            borderRadius: 6,
+                            transition: 'background-color 0.3s',
+                            boxShadow: `0 0 12px 4px ${color}`,
+                        }}
+                    />
+                );
+            })}
+        </div>
+    );
+}

--- a/frontend/src/perspectives/axia/ValueCanvas.tsx
+++ b/frontend/src/perspectives/axia/ValueCanvas.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from 'react';
+import { api } from '@/services/api';
+import type { ValueCanvasResponse, ValueClaimItem } from '@/services/api';
+
+interface ValueCanvasProps {
+    designSpaceId: string;
+}
+
+export function ValueCanvas({ designSpaceId }: ValueCanvasProps) {
+    const [data, setData] = useState<ValueCanvasResponse | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        async function load() {
+            setLoading(true);
+            setError(null);
+            try {
+                const result = await api.getValueClaims(designSpaceId);
+                if (!cancelled) {
+                    setData(result);
+                }
+            } catch {
+                if (!cancelled) {
+                    setError('Kon waardeclaims niet laden.');
+                }
+            } finally {
+                if (!cancelled) {
+                    setLoading(false);
+                }
+            }
+        }
+
+        load();
+        return () => { cancelled = true; };
+    }, [designSpaceId]);
+
+    if (loading) {
+        return (
+            <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
+                Waardeclaims laden...
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="flex items-center justify-center h-full text-destructive text-sm">
+                {error}
+            </div>
+        );
+    }
+
+    if (!data || Object.keys(data.groups).length === 0) {
+        return (
+            <div className="flex items-center justify-center h-full text-muted-foreground text-sm italic">
+                Geen waardeclaims gevonden voor deze DesignSpace.
+            </div>
+        );
+    }
+
+    const groups = Object.entries(data.groups);
+
+    return (
+        <div className="h-full w-full overflow-x-auto">
+            <div className="flex gap-4 p-4 min-h-full">
+                {groups.map(([valueTypeUri, claims]) => (
+                    <ValueTypeColumn
+                        key={valueTypeUri}
+                        valueTypeUri={valueTypeUri}
+                        valueTypeLabel={claims[0]?.value_type_label ?? valueTypeUri}
+                        claims={claims}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+}
+
+interface ValueTypeColumnProps {
+    valueTypeUri: string;
+    valueTypeLabel: string;
+    claims: ValueClaimItem[];
+}
+
+function ValueTypeColumn({ valueTypeLabel, claims }: ValueTypeColumnProps) {
+    return (
+        <div className="flex flex-col gap-2 min-w-[220px] max-w-[280px]">
+            <div className="rounded-md bg-zinc-100 dark:bg-zinc-800 px-3 py-2">
+                <h3 className="text-sm font-semibold text-zinc-700 dark:text-zinc-200 truncate" title={valueTypeLabel}>
+                    {valueTypeLabel}
+                </h3>
+                <span className="text-xs text-muted-foreground">{claims.length} claim{claims.length !== 1 ? 's' : ''}</span>
+            </div>
+            <div className="flex flex-col gap-2">
+                {claims.map((claim) => (
+                    <ValueClaimCard key={claim.tessera_id} claim={claim} />
+                ))}
+            </div>
+        </div>
+    );
+}
+
+interface ValueClaimCardProps {
+    claim: ValueClaimItem;
+}
+
+function ValueClaimCard({ claim }: ValueClaimCardProps) {
+    return (
+        <div className="rounded-md border border-border bg-card p-3 shadow-sm">
+            <p className="text-sm text-card-foreground leading-snug">{claim.claim_content}</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+                Door {claim.claimed_by} &middot; {new Date(claim.claimed_at).toLocaleDateString('nl-NL')}
+            </p>
+        </div>
+    );
+}

--- a/frontend/src/perspectives/axia/ValueTensionView.tsx
+++ b/frontend/src/perspectives/axia/ValueTensionView.tsx
@@ -1,0 +1,289 @@
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { api } from '@/services/api';
+import type { ValueCanvasResponse, ValueTensionResponse, CreateValueTensionPayload } from '@/services/api';
+
+interface ValueTensionViewProps {
+    designSpaceId: string;
+}
+
+interface TensionEdge {
+    id: string;
+    labelA: string;
+    labelB: string;
+    uriA: string;
+    uriB: string;
+    description: string;
+}
+
+export function ValueTensionView({ designSpaceId }: ValueTensionViewProps) {
+    const [canvas, setCanvas] = useState<ValueCanvasResponse | null>(null);
+    const [tensions, setTensions] = useState<TensionEdge[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    // Form state
+    const [formOpen, setFormOpen] = useState(false);
+    const [selectedA, setSelectedA] = useState('');
+    const [selectedB, setSelectedB] = useState('');
+    const [description, setDescription] = useState('');
+    const [submitting, setSubmitting] = useState(false);
+    const [formError, setFormError] = useState<string | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        async function load() {
+            setLoading(true);
+            setError(null);
+            try {
+                const result = await api.getValueClaims(designSpaceId);
+                if (!cancelled) setCanvas(result);
+            } catch {
+                if (!cancelled) setError('Kon waardeclaims niet laden.');
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        }
+
+        load();
+        return () => { cancelled = true; };
+    }, [designSpaceId]);
+
+    const valueTypes = canvas
+        ? Object.entries(canvas.groups).map(([uri, claims]) => ({
+              uri,
+              label: claims[0]?.value_type_label ?? uri.split('#').pop() ?? uri,
+          }))
+        : [];
+
+    const handleSubmit = async () => {
+        if (!selectedA || !selectedB || !description.trim()) {
+            setFormError('Vul alle velden in.');
+            return;
+        }
+        if (selectedA === selectedB) {
+            setFormError('Kies twee verschillende waardetypen.');
+            return;
+        }
+
+        setSubmitting(true);
+        setFormError(null);
+
+        const payload: CreateValueTensionPayload = {
+            value_type_a_uri: selectedA,
+            value_type_b_uri: selectedB,
+            description: description.trim(),
+        };
+
+        try {
+            const result: ValueTensionResponse = await api.createValueTension(designSpaceId, payload);
+            const labelA = valueTypes.find((v) => v.uri === result.value_type_a_uri)?.label ?? result.value_type_a_uri;
+            const labelB = valueTypes.find((v) => v.uri === result.value_type_b_uri)?.label ?? result.value_type_b_uri;
+
+            setTensions((prev) => [
+                ...prev,
+                {
+                    id: result.tessera_id,
+                    labelA,
+                    labelB,
+                    uriA: result.value_type_a_uri,
+                    uriB: result.value_type_b_uri,
+                    description: result.description,
+                },
+            ]);
+
+            setFormOpen(false);
+            setSelectedA('');
+            setSelectedB('');
+            setDescription('');
+        } catch {
+            setFormError('Opslaan mislukt. Probeer opnieuw.');
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    if (loading) {
+        return (
+            <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
+                Laden...
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="flex items-center justify-center h-full text-destructive text-sm">
+                {error}
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex flex-col h-full gap-4 p-4">
+            <div className="flex items-center justify-between">
+                <h2 className="text-base font-semibold">Waardespanningen</h2>
+                <Button size="sm" onClick={() => setFormOpen((v) => !v)}>
+                    {formOpen ? 'Annuleren' : 'Spanning toevoegen'}
+                </Button>
+            </div>
+
+            {formOpen && (
+                <div className="rounded-md border border-border bg-card p-4 flex flex-col gap-3">
+                    <div className="flex flex-col gap-1">
+                        <label className="text-xs font-medium text-muted-foreground">Waardetype A</label>
+                        <select
+                            className="rounded-md border border-input bg-background px-3 py-1.5 text-sm"
+                            value={selectedA}
+                            onChange={(e) => setSelectedA(e.target.value)}
+                        >
+                            <option value="">— Kies waardetype —</option>
+                            {valueTypes.map((v) => (
+                                <option key={v.uri} value={v.uri}>{v.label}</option>
+                            ))}
+                        </select>
+                    </div>
+                    <div className="flex flex-col gap-1">
+                        <label className="text-xs font-medium text-muted-foreground">Waardetype B</label>
+                        <select
+                            className="rounded-md border border-input bg-background px-3 py-1.5 text-sm"
+                            value={selectedB}
+                            onChange={(e) => setSelectedB(e.target.value)}
+                        >
+                            <option value="">— Kies waardetype —</option>
+                            {valueTypes.map((v) => (
+                                <option key={v.uri} value={v.uri}>{v.label}</option>
+                            ))}
+                        </select>
+                    </div>
+                    <div className="flex flex-col gap-1">
+                        <label className="text-xs font-medium text-muted-foreground">Beschrijving</label>
+                        <textarea
+                            className="rounded-md border border-input bg-background px-3 py-1.5 text-sm resize-none"
+                            rows={3}
+                            value={description}
+                            onChange={(e) => setDescription(e.target.value)}
+                            placeholder="Omschrijf de spanning tussen de twee waardetypen..."
+                        />
+                    </div>
+                    {formError && (
+                        <p className="text-xs text-destructive">{formError}</p>
+                    )}
+                    <Button size="sm" onClick={handleSubmit} disabled={submitting}>
+                        {submitting ? 'Opslaan...' : 'Opslaan'}
+                    </Button>
+                </div>
+            )}
+
+            {tensions.length === 0 && !formOpen && (
+                <p className="text-sm text-muted-foreground italic">
+                    Nog geen waardespanningen gedefinieerd.
+                </p>
+            )}
+
+            {tensions.length > 0 && (
+                <TensionGraph valueTypes={valueTypes} tensions={tensions} />
+            )}
+        </div>
+    );
+}
+
+interface ValueTypeNode {
+    uri: string;
+    label: string;
+}
+
+interface TensionGraphProps {
+    valueTypes: ValueTypeNode[];
+    tensions: TensionEdge[];
+}
+
+function TensionGraph({ valueTypes, tensions }: TensionGraphProps) {
+    // Bepaal welke valueTypes betrokken zijn
+    const involvedUris = new Set<string>();
+    tensions.forEach((t) => {
+        involvedUris.add(t.uriA);
+        involvedUris.add(t.uriB);
+    });
+    const nodes = valueTypes.filter((v) => involvedUris.has(v.uri));
+
+    // Positioneer nodes in een cirkel
+    const cx = 250;
+    const cy = 180;
+    const r = 130;
+    const positions: Record<string, { x: number; y: number }> = {};
+    nodes.forEach((node, i) => {
+        const angle = (2 * Math.PI * i) / nodes.length - Math.PI / 2;
+        positions[node.uri] = {
+            x: cx + r * Math.cos(angle),
+            y: cy + r * Math.sin(angle),
+        };
+    });
+
+    return (
+        <div className="flex flex-col gap-3">
+            <svg
+                viewBox="0 0 500 360"
+                className="w-full max-w-lg rounded-md border border-border bg-muted/30"
+                aria-label="Waardespanningsdiagram"
+            >
+                {/* Edges */}
+                {tensions.map((tension) => {
+                    const posA = positions[tension.uriA];
+                    const posB = positions[tension.uriB];
+                    if (!posA || !posB) return null;
+                    return (
+                        <line
+                            key={tension.id}
+                            x1={posA.x}
+                            y1={posA.y}
+                            x2={posB.x}
+                            y2={posB.y}
+                            stroke="hsl(var(--destructive))"
+                            strokeWidth={2}
+                            strokeDasharray="6 3"
+                            opacity={0.7}
+                        />
+                    );
+                })}
+                {/* Nodes */}
+                {nodes.map((node) => {
+                    const pos = positions[node.uri];
+                    if (!pos) return null;
+                    return (
+                        <g key={node.uri}>
+                            <circle cx={pos.x} cy={pos.y} r={28} fill="hsl(var(--card))" stroke="hsl(var(--border))" strokeWidth={1.5} />
+                            <text
+                                x={pos.x}
+                                y={pos.y}
+                                textAnchor="middle"
+                                dominantBaseline="middle"
+                                fontSize={9}
+                                fill="hsl(var(--card-foreground))"
+                                className="select-none"
+                            >
+                                {node.label.length > 12 ? node.label.slice(0, 11) + '…' : node.label}
+                            </text>
+                        </g>
+                    );
+                })}
+            </svg>
+
+            {/* Legende */}
+            <div className="flex flex-col gap-1">
+                {tensions.map((t) => (
+                    <div key={t.id} className="flex items-start gap-2 text-sm">
+                        <span className="mt-0.5 text-destructive font-bold">—</span>
+                        <div>
+                            <span className="font-medium">{t.labelA}</span>
+                            <span className="text-muted-foreground mx-1">vs.</span>
+                            <span className="font-medium">{t.labelB}</span>
+                            <p className="text-xs text-muted-foreground">{t.description}</p>
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/perspectives/causa/Shell.tsx
+++ b/frontend/src/perspectives/causa/Shell.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { Plus, Layers } from "lucide-react";
+import { HeatmapOverlay } from '@/perspectives/axia/HeatmapOverlay';
 import { useEffect, useMemo, useState, useRef } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { getNodesBounds } from 'reactflow';
@@ -348,6 +349,14 @@ export const CausaShell = ({ themeId, websocket, currentUserId, onSelect, onOpen
                             <TooltipContent>Conditiedekking overlay</TooltipContent>
                         </Tooltip>
                     </TooltipProvider>
+                )}
+
+                {designSpaceId && (
+                    <HeatmapOverlay
+                        designSpaceId={designSpaceId}
+                        rfInstance={rfInstance}
+                        nodeIds={nodes.map((n) => n.id)}
+                    />
                 )}
 
             </PerspectiveToolbar>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -817,7 +817,23 @@ WHERE {
     completePhase: async (sessionId: string, phase: 'refine' | 'ranking' | 'consent') => {
         const response = await apiClient.post(`/sessions/${sessionId}/complete-phase`, { phase });
         return response.data;
-    }
+    },
+
+    // Axia
+    getValueClaims: async (dsId: string): Promise<ValueCanvasResponse> => {
+        const response = await apiClient.get<ValueCanvasResponse>(`/designspace/${dsId}/value-claims`);
+        return response.data;
+    },
+
+    createValueTension: async (dsId: string, payload: CreateValueTensionPayload): Promise<ValueTensionResponse> => {
+        const response = await apiClient.post<ValueTensionResponse>(`/designspace/${dsId}/value-tension`, payload);
+        return response.data;
+    },
+
+    getValueImplications: async (dsId: string): Promise<DesignImplicationCount[]> => {
+        const response = await apiClient.get<DesignImplicationCount[]>(`/designspace/${dsId}/value-implications`);
+        return response.data;
+    },
 };
 
 export interface ConversationMessage {
@@ -1033,6 +1049,43 @@ function parseDecisionTimeline(raw: DecisionTimelineRaw): DecisionEpisodeRaw[] {
     }
 
     return Array.from(episodesMap.values());
+}
+
+// Axia interfaces
+export interface ValueClaimItem {
+    tessera_uri: string;
+    tessera_id: string;
+    claim_content: string;
+    value_type_uri: string;
+    value_type_label: string;
+    claimed_by: string;
+    claimed_at: string;
+}
+
+export interface ValueCanvasResponse {
+    design_space_id: string;
+    groups: Record<string, ValueClaimItem[]>;
+}
+
+export interface CreateValueTensionPayload {
+    value_type_a_uri: string;
+    value_type_b_uri: string;
+    description: string;
+}
+
+export interface ValueTensionResponse {
+    tessera_uri: string;
+    tessera_id: string;
+    value_type_a_uri: string;
+    value_type_b_uri: string;
+    description: string;
+    created_by: string;
+    created_at: string;
+}
+
+export interface DesignImplicationCount {
+    factor_uri: string;
+    implication_count: number;
 }
 
 export type LifecycleStatus = 'draft' | 'proposed' | 'accepted' | 'rejected' | 'deprecated';


### PR DESCRIPTION
## Samenvatting

- Backend: `GET /designspace/{ds_id}/value-implications` in `axia.py` — telt `axia:DesignImplication` relaties per factor-URI via SPARQL GROUP BY
- Frontend: `HeatmapOverlay.tsx` — toggle-knop in de Causa-toolbar, oranje-gradient overlay per node op basis van implication-count
  - 0 implications = transparant
  - max implications = oranje-rood met gloed
  - Node-posities worden gelezen uit `rfInstance.getNodes` + `flowToScreenPosition`
- Geïntegreerd in `CausaShell.tsx` naast de bestaande conditiedekking-overlay

## Afhankelijkheden

Bouwt voort op `feature/issue-308-waardencanvas` (cherry-picked). Merge volgorde: US-7.1 → US-7.2 → US-7.3.

## Testplan

- [ ] `GET /designspace/{ds_id}/value-implications` retourneert `[{ factor_uri, implication_count }]` gesorteerd op count desc
- [ ] Knop "Heatmap aan" verschijnt in de Causa-toolbar wanneer `designSpaceId` aanwezig is
- [ ] Klikken op de knop laadt implications en toont oranje overlay op nodes
- [ ] Nodes zonder implications krijgen geen kleur
- [ ] Node met hoogste count krijgt de meest intensieve kleur
- [ ] Overlay verdwijnt bij "Heatmap uit"
- [ ] TypeScript check geslaagd

Sluit #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)