### PR TITLE
feat(socia): StakeholderClaims — InterestClaim, GoalClaim, PowerClaim als Tessera (US-6.2) #307

### DIFF
--- a/backend/app/db/fuseki_socia.py
+++ b/backend/app/db/fuseki_socia.py
@@ -17,9 +17,11 @@ Migratie (US-AI.6):
   naar urn:valor:entities entries. Idempotent en veilig bij lege dataset.
 """
 import logging
+import uuid as _uuid_mod
+from datetime import datetime, timezone
 
 from app.ontology import VALOR_NS
-from app.services.fuseki import sparql_select_global, sparql_update
+from app.services.fuseki import sparql_select_global, sparql_update, record_provenance_activity
 
 logger = logging.getLogger(__name__)
 
@@ -134,6 +136,97 @@ async def get_stakeholder_map(ds_id: str) -> dict:
     ]
 
     return {"actors": actors, "dependencies": dependencies}
+
+
+# ---------------------------------------------------------------------------
+# StakeholderClaim aanmaken (US-6.2)
+# ---------------------------------------------------------------------------
+
+# Geldige claim-typen als subklassen van valor:Tessera in SOCIA-namespace
+_STAKEHOLDER_CLAIM_TYPES = {
+    "InterestClaim": f"{_SOCIA_NS}InterestClaim",
+    "GoalClaim": f"{_SOCIA_NS}GoalClaim",
+    "PowerClaim": f"{_SOCIA_NS}PowerClaim",
+}
+
+_XSD_NS = "http://www.w3.org/2001/XMLSchema#"
+
+
+async def create_stakeholder_claim(
+    ds_id: str,
+    claim_type: str,
+    claim_content: str,
+    actor_uri: str,
+    user_id: str,
+) -> dict:
+    """Schrijft een socia:InterestClaim / socia:GoalClaim / socia:PowerClaim als valor:Tessera-subklasse.
+
+    Opgeslagen in urn:valor:ds:{ds_id}/agents (AgentTesserae-graph).
+    Retourneert een dict met de aangemaakte claim-gegevens.
+    """
+    claim_type_uri = _STAKEHOLDER_CLAIM_TYPES.get(claim_type)
+    if not claim_type_uri:
+        raise ValueError(
+            f"Ongeldig claim_type '{claim_type}'. "
+            f"Geldige waarden: {sorted(_STAKEHOLDER_CLAIM_TYPES)}"
+        )
+
+    tessera_id = str(_uuid_mod.uuid4())
+    tessera_uri = f"urn:valor:tessera:{tessera_id}"
+    user_uri = f"urn:valor:user:{user_id}"
+    claimed_at = datetime.now(timezone.utc).isoformat()
+
+    # StakeholderClaims gaan in de agents-graph van de DesignSpace
+    graph_uri = f"urn:valor:ds:{ds_id}/agents"
+
+    escaped_content = _escape(claim_content)
+
+    # epistemicStatus = Proposed (harde waarde — ontologie-onafhankelijk conform Tessera-patroon)
+    proposed_uri = f"{VALOR_NS}ProposedStatus"
+
+    update = f"""PREFIX valor: <{VALOR_NS}>
+PREFIX socia:  <{_SOCIA_NS}>
+PREFIX xsd:    <{_XSD_NS}>
+
+INSERT DATA {{
+  GRAPH <{graph_uri}> {{
+    <{tessera_uri}> a <{claim_type_uri}> ;
+                   a valor:Tessera ;
+      valor:claimContent "{escaped_content}"@nl ;
+      valor:epistemicStatus <{proposed_uri}> ;
+      valor:claimedBy <{user_uri}> ;
+      valor:claimedAt "{claimed_at}"^^xsd:dateTime ;
+      valor:inDesignSpace <urn:valor:ds:{ds_id}> ;
+      socia:claimOf <{actor_uri}> .
+  }}
+}}"""
+
+    await sparql_update(update, ds_id)
+
+    await record_provenance_activity(
+        ds_id,
+        "StakeholderClaimCreated",
+        user_uri,
+        generated=tessera_uri,
+    )
+
+    logger.info(
+        "[fuseki-socia] StakeholderClaim aangemaakt: %s (%s) in %s door %s",
+        tessera_uri, claim_type, ds_id, user_id,
+    )
+
+    return {
+        "tessera_id": tessera_id,
+        "tessera_uri": tessera_uri,
+        "claim_type": claim_type,
+        "claim_type_uri": claim_type_uri,
+        "claim_content": claim_content,
+        "epistemic_status": "Proposed",
+        "actor_uri": actor_uri,
+        "claimed_by": user_id,
+        "claimed_at": claimed_at,
+        "design_space_id": ds_id,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/routers/socia.py
+++ b/backend/app/routers/socia.py
@@ -1,17 +1,27 @@
 """SOCIA API-endpoints voor het cross-perspectief rolpatroon (US-AI.5/AI.6)."""
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
 
 from app.auth import get_current_user
 from app.db.fuseki_socia import (
     assign_actor_role,
+    create_stakeholder_claim,
     get_actor_roles_in_ds,
     get_designspaces_for_agent,
     get_stakeholder_map,
     get_tesserae_for_agent,
     migrate_legacy_socia_actors,
 )
+from app.db.permissions import check_permission
+from app.models.domain import Role
 
 router = APIRouter(tags=["socia"])
+
+
+class CreateStakeholderClaimRequest(BaseModel):
+    claim_type: str  # "InterestClaim" | "GoalClaim" | "PowerClaim"
+    claim_content: str
+    actor_uri: str  # URI van de actor waarover de claim gaat
 
 
 @router.post("/designspace/{ds_id}/socia/roles")
@@ -66,6 +76,31 @@ async def get_stakeholder_map_endpoint(
 ):
     """Retourneert de stakeholderkaart: actoren en IntentionalDependency-edges voor een DesignSpace."""
     return await get_stakeholder_map(ds_id)
+
+
+@router.post("/designspace/{ds_id}/stakeholder-claims", status_code=201)
+async def create_stakeholder_claim_endpoint(
+    ds_id: str,
+    request: CreateStakeholderClaimRequest,
+    user: dict = Depends(get_current_user),
+):
+    """Maakt een socia:InterestClaim, socia:GoalClaim of socia:PowerClaim aan als Tessera-subklasse."""
+    has_permission = await check_permission(user["id"], ds_id, Role.MEMBER)
+    if not has_permission:
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten voor deze DesignSpace.")
+
+    try:
+        result = await create_stakeholder_claim(
+            ds_id=ds_id,
+            claim_type=request.claim_type,
+            claim_content=request.claim_content,
+            actor_uri=request.actor_uri,
+            user_id=user["id"],
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    return result
 
 
 @router.post("/admin/migrate-socia-actors")

--- a/frontend/src/perspectives/socia/views/StakeholderClaimsPanel.tsx
+++ b/frontend/src/perspectives/socia/views/StakeholderClaimsPanel.tsx
@@ -1,0 +1,191 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { Badge } from '@/components/ui/badge';
+import {
+    api,
+    type StakeholderClaimType,
+    type StakeholderClaimResponse,
+    type StakeholderActor,
+} from '@/services/api';
+
+// ---------------------------------------------------------------------------
+// Claim-type metadata
+// ---------------------------------------------------------------------------
+
+const CLAIM_TYPE_OPTIONS: { value: StakeholderClaimType; label: string; description: string }[] = [
+    {
+        value: 'InterestClaim',
+        label: 'Belang',
+        description: 'Wat heeft de actor te winnen of verliezen?',
+    },
+    {
+        value: 'GoalClaim',
+        label: 'Doel',
+        description: 'Wat wil de actor bereiken?',
+    },
+    {
+        value: 'PowerClaim',
+        label: 'Macht',
+        description: 'Welke invloed of macht heeft de actor?',
+    },
+];
+
+const STATUS_LABEL: Record<string, string> = {
+    Proposed: 'Voorgesteld',
+    Accepted: 'Geaccepteerd',
+    Rejected: 'Verworpen',
+};
+
+// ---------------------------------------------------------------------------
+// Subcomponent: ingediende claim
+// ---------------------------------------------------------------------------
+
+function ClaimItem({ claim }: { claim: StakeholderClaimResponse }) {
+    const typeMeta = CLAIM_TYPE_OPTIONS.find((o) => o.value === claim.claim_type);
+    const statusLabel = STATUS_LABEL[claim.epistemic_status] ?? claim.epistemic_status;
+
+    return (
+        <div className="rounded-md border border-border bg-card p-3 space-y-1">
+            <div className="flex items-center gap-2">
+                <Badge variant="outline" className="text-xs">
+                    {typeMeta?.label ?? claim.claim_type}
+                </Badge>
+                <Badge variant="secondary" className="text-xs">
+                    {statusLabel}
+                </Badge>
+            </div>
+            <p className="text-sm">{claim.claim_content}</p>
+        </div>
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Hoofdcomponent
+// ---------------------------------------------------------------------------
+
+interface StakeholderClaimsPanelProps {
+    dsId: string;
+    actors: StakeholderActor[];
+}
+
+export function StakeholderClaimsPanel({ dsId, actors }: StakeholderClaimsPanelProps) {
+    const [actorUri, setActorUri] = useState('');
+    const [claimType, setClaimType] = useState<StakeholderClaimType | ''>('');
+    const [content, setContent] = useState('');
+    const [submitting, setSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [submitted, setSubmitted] = useState<StakeholderClaimResponse[]>([]);
+
+    async function handleSubmit(e: React.FormEvent) {
+        e.preventDefault();
+        if (!actorUri || !claimType || !content.trim()) return;
+
+        setSubmitting(true);
+        setError(null);
+        try {
+            const result = await api.createStakeholderClaim(dsId, {
+                claim_type: claimType,
+                claim_content: content.trim(),
+                actor_uri: actorUri,
+            });
+            setSubmitted((prev) => [result, ...prev]);
+            setContent('');
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Onbekende fout');
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    return (
+        <div className="flex flex-col gap-4 p-4">
+            <h3 className="text-sm font-semibold">Stakeholderclaim toevoegen</h3>
+
+            <form onSubmit={handleSubmit} className="space-y-3">
+                {/* Actor selectie */}
+                <div className="space-y-1">
+                    <Label htmlFor="sc-actor">Actor</Label>
+                    <Select value={actorUri} onValueChange={setActorUri}>
+                        <SelectTrigger id="sc-actor">
+                            <SelectValue placeholder="Kies een actor" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {actors.map((a) => (
+                                <SelectItem key={a.uri} value={a.uri}>
+                                    {a.label}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+
+                {/* Claim-type */}
+                <div className="space-y-1">
+                    <Label htmlFor="sc-type">Type claim</Label>
+                    <Select
+                        value={claimType}
+                        onValueChange={(v) => setClaimType(v as StakeholderClaimType)}
+                    >
+                        <SelectTrigger id="sc-type">
+                            <SelectValue placeholder="Kies een type" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {CLAIM_TYPE_OPTIONS.map((o) => (
+                                <SelectItem key={o.value} value={o.value}>
+                                    <span>{o.label}</span>
+                                    <span className="ml-2 text-xs text-muted-foreground">
+                                        {o.description}
+                                    </span>
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+
+                {/* Inhoud */}
+                <div className="space-y-1">
+                    <Label htmlFor="sc-content">Inhoud</Label>
+                    <Input
+                        id="sc-content"
+                        value={content}
+                        onChange={(e) => setContent(e.target.value)}
+                        placeholder="Beschrijf de claim…"
+                    />
+                </div>
+
+                {error && (
+                    <p className="text-xs text-destructive">{error}</p>
+                )}
+
+                <Button
+                    type="submit"
+                    disabled={!actorUri || !claimType || !content.trim() || submitting}
+                    className="w-full"
+                >
+                    {submitting ? 'Opslaan…' : 'Claim opslaan'}
+                </Button>
+            </form>
+
+            {/* Ingediende claims in deze sessie */}
+            {submitted.length > 0 && (
+                <div className="space-y-2">
+                    <p className="text-xs text-muted-foreground font-medium uppercase tracking-wide">
+                        Zojuist toegevoegd
+                    </p>
+                    {submitted.map((c) => (
+                        <ClaimItem key={c.tessera_id} claim={c} />
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -106,6 +106,27 @@ export interface StakeholderMap {
     dependencies: StakeholderDependency[];
 }
 
+export type StakeholderClaimType = 'InterestClaim' | 'GoalClaim' | 'PowerClaim';
+
+export interface CreateStakeholderClaimRequest {
+    claim_type: StakeholderClaimType;
+    claim_content: string;
+    actor_uri: string;
+}
+
+export interface StakeholderClaimResponse {
+    tessera_id: string;
+    tessera_uri: string;
+    claim_type: StakeholderClaimType;
+    claim_type_uri: string;
+    claim_content: string;
+    epistemic_status: string;
+    actor_uri: string;
+    claimed_by: string;
+    claimed_at: string;
+    design_space_id: string;
+}
+
 export interface AgentResponse {
     agent_name: string;
     perspective: string;
@@ -688,6 +709,17 @@ export const api = {
 
     getStakeholderMap: async (dsId: string): Promise<StakeholderMap> => {
         const response = await apiClient.get<StakeholderMap>(`/designspace/${dsId}/stakeholder-map`);
+        return response.data;
+    },
+
+    createStakeholderClaim: async (
+        dsId: string,
+        data: CreateStakeholderClaimRequest,
+    ): Promise<StakeholderClaimResponse> => {
+        const response = await apiClient.post<StakeholderClaimResponse>(
+            `/designspace/${dsId}/stakeholder-claims`,
+            data,
+        );
         return response.data;
     },
 


### PR DESCRIPTION
## Samenvatting

- Backend: `create_stakeholder_claim()` in `fuseki_socia.py` schrijft `socia:InterestClaim`, `socia:GoalClaim` en `socia:PowerClaim` als `valor:Tessera`-subklassen naar de `urn:valor:ds:{ds_id}/agents` graph, met `socia:claimOf` koppeling naar de actor-URI
- Backend: `POST /designspace/{ds_id}/stakeholder-claims` endpoint in `socia.py` met RBAC-check (MEMBER vereist)
- Frontend: `StakeholderClaimsPanel.tsx` — form met actor-dropdown (gevuld vanuit de kaart), claim-type keuze (3 opties) en vrij tekstveld; toont ingediende claims met epistemische status
- Types `CreateStakeholderClaimRequest`, `StakeholderClaimResponse`, `StakeholderClaimType` + `api.createStakeholderClaim()` in `api.ts`

## Acceptatiecriteria

- [x] `InterestClaim`, `GoalClaim` en `PowerClaim` alle drie aanmaakbaar
- [x] Epistemische status zichtbaar op ingediende claims (initieel: "Voorgesteld")
- [x] Opgeslagen conform Tessera-patroon (dubbele `rdf:type`: subklasse + `valor:Tessera`)
- [x] RBAC: minimaal MEMBER-recht vereist

## Testplan

- [ ] Backend syntax: `python3 -m py_compile backend/app/routers/socia.py`
- [ ] Frontend build: `cd frontend && npm run build` — geen TypeScript-errors
- [ ] Handmatig: `POST /designspace/{ds_id}/stakeholder-claims` met elk van de 3 types retourneert 201 met `tessera_uri` en `epistemic_status: "Proposed"`
- [ ] Ongeldig `claim_type` retourneert 422 met beschrijvende foutmelding

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)