### PR TITLE
feat(axia): ValueCriterion + ValueBasedDesignRequirement + value-chain (US-7.4) #365

### DIFF
--- a/backend/app/routers/axia.py
+++ b/backend/app/routers/axia.py
@@ -192,6 +192,60 @@ INSERT DATA {{
 # US-7.3: GET value-implications per factor
 # ---------------------------------------------------------------------------
 
+class CreateValueCriterionRequest(BaseModel):
+    label: str
+    value_type_uri: str
+    grounded_in_norm_uri: str | None = None
+
+
+class ValueCriterionOut(BaseModel):
+    tessera_uri: str
+    tessera_id: str
+    label: str
+    value_type_uri: str
+    grounded_in_norm_uri: str | None
+    created_by: str
+    created_at: str
+
+
+class CreateValueBasedDesignRequirementRequest(BaseModel):
+    label: str
+    criterion_uri: str
+
+
+class ValueBasedDesignRequirementOut(BaseModel):
+    tessera_uri: str
+    tessera_id: str
+    label: str
+    criterion_uri: str
+    created_by: str
+    created_at: str
+
+
+class ValueChainRequirementItem(BaseModel):
+    tessera_uri: str
+    tessera_id: str
+    label: str
+
+
+class ValueChainCriterionItem(BaseModel):
+    tessera_uri: str
+    tessera_id: str
+    label: str
+    requirements: list[ValueChainRequirementItem]
+
+
+class ValueChainTypeItem(BaseModel):
+    value_type_uri: str
+    value_type_label: str
+    criteria: list[ValueChainCriterionItem]
+
+
+class ValueChainOut(BaseModel):
+    design_space_id: str
+    chain: list[ValueChainTypeItem]
+
+
 class DesignImplicationCount(BaseModel):
     factor_uri: str
     implication_count: int
@@ -230,3 +284,222 @@ ORDER BY DESC(?count)"""
         )
         for row in rows
     ]
+
+
+# ---------------------------------------------------------------------------
+# US-7.4: POST value-criterion
+# ---------------------------------------------------------------------------
+
+@router.post("/{ds_id}/value-criterion", response_model=ValueCriterionOut, status_code=201)
+async def create_value_criterion(
+    ds_id: str,
+    request: CreateValueCriterionRequest,
+    user: dict = Depends(get_current_user),
+) -> ValueCriterionOut:
+    user_id = user["id"]
+
+    has_permission = await check_permission(user_id, ds_id, Role.MEMBER)
+    if not has_permission:
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten voor deze DesignSpace.")
+
+    tessera_id = str(uuid.uuid4())
+    tessera_uri = f"urn:valor:tessera:{tessera_id}"
+    user_uri = f"urn:valor:user:{user_id}"
+    created_at = datetime.now(timezone.utc).isoformat()
+    graph_uri = f"urn:valor:ds:{ds_id}:baseline"
+
+    escaped_label = request.label.replace("\\", "\\\\").replace('"', '\\"')
+
+    norm_triple = ""
+    if request.grounded_in_norm_uri:
+        norm_triple = f'\n      cover:groundedIn <{request.grounded_in_norm_uri}> ;'
+
+    sparql = f"""PREFIX axia: <{AXIA_NS}>
+PREFIX cover: <{COVER_NS}>
+PREFIX valor: <{VALOR_NS}>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <{XSD_NS}>
+
+INSERT DATA {{
+  GRAPH <{graph_uri}> {{
+    <{tessera_uri}> a axia:ValueCriterion ;
+      a valor:Tessera ;
+      rdfs:label "{escaped_label}"@nl ;
+      cover:groundedIn <{request.value_type_uri}> ;{norm_triple}
+      valor:claimedBy <{user_uri}> ;
+      valor:claimedAt "{created_at}"^^xsd:dateTime .
+  }}
+}}"""
+
+    await sparql_update(sparql, ds_id)
+
+    await record_provenance_activity(
+        ds_id,
+        "ValueCriterionCreated",
+        user_uri,
+        generated=tessera_uri,
+    )
+
+    logger.info("ValueCriterion aangemaakt: %s in DesignSpace %s door %s", tessera_uri, ds_id, user_id)
+
+    return ValueCriterionOut(
+        tessera_uri=tessera_uri,
+        tessera_id=tessera_id,
+        label=request.label,
+        value_type_uri=request.value_type_uri,
+        grounded_in_norm_uri=request.grounded_in_norm_uri,
+        created_by=user_id,
+        created_at=created_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# US-7.4: POST value-based-design-requirement
+# ---------------------------------------------------------------------------
+
+@router.post("/{ds_id}/value-based-design-requirement", response_model=ValueBasedDesignRequirementOut, status_code=201)
+async def create_value_based_design_requirement(
+    ds_id: str,
+    request: CreateValueBasedDesignRequirementRequest,
+    user: dict = Depends(get_current_user),
+) -> ValueBasedDesignRequirementOut:
+    user_id = user["id"]
+
+    has_permission = await check_permission(user_id, ds_id, Role.MEMBER)
+    if not has_permission:
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten voor deze DesignSpace.")
+
+    tessera_id = str(uuid.uuid4())
+    tessera_uri = f"urn:valor:tessera:{tessera_id}"
+    user_uri = f"urn:valor:user:{user_id}"
+    created_at = datetime.now(timezone.utc).isoformat()
+    graph_uri = f"urn:valor:ds:{ds_id}:baseline"
+
+    escaped_label = request.label.replace("\\", "\\\\").replace('"', '\\"')
+
+    sparql = f"""PREFIX axia: <{AXIA_NS}>
+PREFIX valor: <{VALOR_NS}>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <{XSD_NS}>
+
+INSERT DATA {{
+  GRAPH <{graph_uri}> {{
+    <{tessera_uri}> a axia:ValueBasedDesignRequirement ;
+      a valor:Tessera ;
+      rdfs:label "{escaped_label}"@nl ;
+      valor:claimedBy <{user_uri}> ;
+      valor:claimedAt "{created_at}"^^xsd:dateTime .
+    <{request.criterion_uri}> axia:groundsRequirement <{tessera_uri}> .
+  }}
+}}"""
+
+    await sparql_update(sparql, ds_id)
+
+    await record_provenance_activity(
+        ds_id,
+        "ValueBasedDesignRequirementCreated",
+        user_uri,
+        generated=tessera_uri,
+        used=[request.criterion_uri],
+    )
+
+    logger.info(
+        "ValueBasedDesignRequirement aangemaakt: %s in DesignSpace %s door %s",
+        tessera_uri, ds_id, user_id,
+    )
+
+    return ValueBasedDesignRequirementOut(
+        tessera_uri=tessera_uri,
+        tessera_id=tessera_id,
+        label=request.label,
+        criterion_uri=request.criterion_uri,
+        created_by=user_id,
+        created_at=created_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# US-7.4: GET value-chain
+# ---------------------------------------------------------------------------
+
+@router.get("/{ds_id}/value-chain", response_model=ValueChainOut)
+async def get_value_chain(
+    ds_id: str,
+    user: dict = Depends(get_current_user),
+) -> ValueChainOut:
+    user_id = user["id"]
+
+    has_permission = await check_permission(user_id, ds_id, Role.VIEWER)
+    if not has_permission:
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten voor deze DesignSpace.")
+
+    graph_uri = f"urn:valor:ds:{ds_id}:baseline"
+
+    query = f"""PREFIX axia: <{AXIA_NS}>
+PREFIX cover: <{COVER_NS}>
+PREFIX valor: <{VALOR_NS}>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?criterion ?criterionLabel ?valueType ?valueTypeLabel ?requirement ?requirementLabel WHERE {{
+  GRAPH <{graph_uri}> {{
+    ?criterion a axia:ValueCriterion ;
+               cover:groundedIn ?valueType .
+    OPTIONAL {{ ?criterion rdfs:label ?criterionLabel . }}
+    OPTIONAL {{ ?valueType rdfs:label ?valueTypeLabel . }}
+    OPTIONAL {{
+      ?criterion axia:groundsRequirement ?requirement .
+      OPTIONAL {{ ?requirement rdfs:label ?requirementLabel . }}
+    }}
+  }}
+}}
+ORDER BY ?valueType ?criterion ?requirement"""
+
+    rows = await sparql_select(query, ds_id)
+
+    # Opbouwen geneste structuur: valueType → criteria → requirements
+    type_map: dict[str, ValueChainTypeItem] = {}
+    criterion_map: dict[str, ValueChainCriterionItem] = {}
+
+    for row in rows:
+        value_type_uri = row.get("valueType", "")
+        value_type_label = row.get("valueTypeLabel", value_type_uri.rsplit("#", 1)[-1] if "#" in value_type_uri else value_type_uri.rsplit("/", 1)[-1])
+        criterion_uri = row.get("criterion", "")
+        criterion_label = row.get("criterionLabel", criterion_uri.rsplit(":", 1)[-1])
+        criterion_id = criterion_uri.rsplit(":", 1)[-1]
+        requirement_uri = row.get("requirement", "")
+        requirement_label = row.get("requirementLabel", "")
+
+        if value_type_uri not in type_map:
+            type_map[value_type_uri] = ValueChainTypeItem(
+                value_type_uri=value_type_uri,
+                value_type_label=value_type_label,
+                criteria=[],
+            )
+
+        if criterion_uri not in criterion_map:
+            criterion_item = ValueChainCriterionItem(
+                tessera_uri=criterion_uri,
+                tessera_id=criterion_id,
+                label=criterion_label,
+                requirements=[],
+            )
+            criterion_map[criterion_uri] = criterion_item
+            type_map[value_type_uri].criteria.append(criterion_item)
+
+        if requirement_uri:
+            req_id = requirement_uri.rsplit(":", 1)[-1]
+            req_label = requirement_label or req_id
+            req_item = ValueChainRequirementItem(
+                tessera_uri=requirement_uri,
+                tessera_id=req_id,
+                label=req_label,
+            )
+            # Voorkom duplicaten bij meerdere rows voor dezelfde criterion+requirement
+            existing_req_uris = {r.tessera_uri for r in criterion_map[criterion_uri].requirements}
+            if requirement_uri not in existing_req_uris:
+                criterion_map[criterion_uri].requirements.append(req_item)
+
+    return ValueChainOut(
+        design_space_id=ds_id,
+        chain=list(type_map.values()),
+    )

--- a/frontend/src/perspectives/axia/ValueChain.tsx
+++ b/frontend/src/perspectives/axia/ValueChain.tsx
@@ -1,0 +1,278 @@
+import { useEffect, useState } from 'react';
+import { ChevronRight, Plus } from 'lucide-react';
+import { api } from '@/services/api';
+import type {
+    ValueChainResponse,
+    ValueChainTypeItem,
+    CreateValueCriterionPayload,
+    CreateValueBasedDesignRequirementPayload,
+} from '@/services/api';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface ValueChainProps {
+    designSpaceId: string;
+}
+
+interface AddCriterionFormState {
+    valueTypeUri: string;
+    label: string;
+    groundedInNormUri: string;
+}
+
+interface AddRequirementFormState {
+    criterionUri: string;
+    label: string;
+}
+
+export function ValueChain({ designSpaceId }: ValueChainProps) {
+    const [data, setData] = useState<ValueChainResponse | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [addCriterionFor, setAddCriterionFor] = useState<string | null>(null);
+    const [addRequirementFor, setAddRequirementFor] = useState<string | null>(null);
+    const [criterionForm, setCriterionForm] = useState<AddCriterionFormState>({
+        valueTypeUri: '',
+        label: '',
+        groundedInNormUri: '',
+    });
+    const [requirementForm, setRequirementForm] = useState<AddRequirementFormState>({
+        criterionUri: '',
+        label: '',
+    });
+    const [submitting, setSubmitting] = useState(false);
+
+    async function load() {
+        setLoading(true);
+        setError(null);
+        try {
+            const result = await api.getValueChain(designSpaceId);
+            setData(result);
+        } catch {
+            setError('Kon de waardeketen niet laden.');
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    useEffect(() => {
+        load();
+    }, [designSpaceId]);
+
+    async function handleAddCriterion(e: React.FormEvent) {
+        e.preventDefault();
+        if (!criterionForm.label.trim() || !criterionForm.valueTypeUri) return;
+        setSubmitting(true);
+        try {
+            const payload: CreateValueCriterionPayload = {
+                label: criterionForm.label.trim(),
+                value_type_uri: criterionForm.valueTypeUri,
+                grounded_in_norm_uri: criterionForm.groundedInNormUri.trim() || undefined,
+            };
+            await api.createValueCriterion(designSpaceId, payload);
+            setAddCriterionFor(null);
+            setCriterionForm({ valueTypeUri: '', label: '', groundedInNormUri: '' });
+            await load();
+        } catch {
+            setError('Aanmaken criterium mislukt.');
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    async function handleAddRequirement(e: React.FormEvent) {
+        e.preventDefault();
+        if (!requirementForm.label.trim() || !requirementForm.criterionUri) return;
+        setSubmitting(true);
+        try {
+            const payload: CreateValueBasedDesignRequirementPayload = {
+                label: requirementForm.label.trim(),
+                criterion_uri: requirementForm.criterionUri,
+            };
+            await api.createValueBasedDesignRequirement(designSpaceId, payload);
+            setAddRequirementFor(null);
+            setRequirementForm({ criterionUri: '', label: '' });
+            await load();
+        } catch {
+            setError('Aanmaken ontwerpeis mislukt.');
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    if (loading) {
+        return <div className="text-sm text-muted-foreground p-4">Waardeketen laden...</div>;
+    }
+
+    if (error) {
+        return <div className="text-sm text-destructive p-4">{error}</div>;
+    }
+
+    if (!data || data.chain.length === 0) {
+        return (
+            <div className="text-sm text-muted-foreground p-4">
+                Geen waardecriteria gevonden. Voeg een waardecriterium toe om de keten te starten.
+            </div>
+        );
+    }
+
+    return (
+        <div className="p-4 space-y-6">
+            <h2 className="text-base font-semibold text-zinc-900">Waardeketen</h2>
+            {data.chain.map((typeItem: ValueChainTypeItem) => (
+                <div key={typeItem.value_type_uri} className="border border-border rounded-lg overflow-hidden">
+                    {/* ValueType header */}
+                    <div className="bg-zinc-100 px-4 py-2 flex items-center justify-between">
+                        <span className="text-sm font-medium text-zinc-800">
+                            {typeItem.value_type_label}
+                        </span>
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => {
+                                setAddCriterionFor(typeItem.value_type_uri);
+                                setCriterionForm({
+                                    valueTypeUri: typeItem.value_type_uri,
+                                    label: '',
+                                    groundedInNormUri: '',
+                                });
+                            }}
+                        >
+                            <Plus className="h-3.5 w-3.5 mr-1" />
+                            Criterium
+                        </Button>
+                    </div>
+
+                    {/* Inline form: criterium toevoegen */}
+                    {addCriterionFor === typeItem.value_type_uri && (
+                        <form onSubmit={handleAddCriterion} className="px-4 py-3 border-b border-border bg-zinc-50 space-y-2">
+                            <div className="space-y-1">
+                                <Label htmlFor="criterion-label" className="text-xs">Label criterium</Label>
+                                <Input
+                                    id="criterion-label"
+                                    value={criterionForm.label}
+                                    onChange={(e) => setCriterionForm(f => ({ ...f, label: e.target.value }))}
+                                    placeholder="Bijv. Toegankelijkheid voor alle burgers"
+                                    className="h-8 text-sm"
+                                    autoFocus
+                                />
+                            </div>
+                            <div className="space-y-1">
+                                <Label htmlFor="criterion-norm" className="text-xs">Norm URI (optioneel)</Label>
+                                <Input
+                                    id="criterion-norm"
+                                    value={criterionForm.groundedInNormUri}
+                                    onChange={(e) => setCriterionForm(f => ({ ...f, groundedInNormUri: e.target.value }))}
+                                    placeholder="https://..."
+                                    className="h-8 text-sm"
+                                />
+                            </div>
+                            <div className="flex gap-2">
+                                <Button type="submit" size="sm" disabled={submitting || !criterionForm.label.trim()}>
+                                    Opslaan
+                                </Button>
+                                <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => setAddCriterionFor(null)}
+                                >
+                                    Annuleren
+                                </Button>
+                            </div>
+                        </form>
+                    )}
+
+                    {/* Criteria + requirements */}
+                    <div className="divide-y divide-border">
+                        {typeItem.criteria.map(criterion => (
+                            <div key={criterion.tessera_uri} className="px-4 py-3">
+                                <div className="flex items-start gap-2">
+                                    {/* Criterium kolom */}
+                                    <div className="flex-1 min-w-0">
+                                        <div className="text-xs font-medium text-zinc-500 uppercase tracking-wide mb-1">
+                                            Criterium
+                                        </div>
+                                        <div className="text-sm text-zinc-800">{criterion.label}</div>
+                                    </div>
+
+                                    <ChevronRight className="h-4 w-4 text-zinc-400 mt-5 shrink-0" />
+
+                                    {/* Ontwerpeisen kolom */}
+                                    <div className="flex-1 min-w-0">
+                                        <div className="flex items-center justify-between mb-1">
+                                            <div className="text-xs font-medium text-zinc-500 uppercase tracking-wide">
+                                                Ontwerpeisen
+                                            </div>
+                                            <Button
+                                                variant="ghost"
+                                                size="sm"
+                                                className="h-6 px-2 text-xs"
+                                                onClick={() => {
+                                                    setAddRequirementFor(criterion.tessera_uri);
+                                                    setRequirementForm({
+                                                        criterionUri: criterion.tessera_uri,
+                                                        label: '',
+                                                    });
+                                                }}
+                                            >
+                                                <Plus className="h-3 w-3 mr-1" />
+                                                Eis
+                                            </Button>
+                                        </div>
+
+                                        {criterion.requirements.length === 0 ? (
+                                            <div className="text-xs text-muted-foreground italic">
+                                                Nog geen ontwerpeisen
+                                            </div>
+                                        ) : (
+                                            <ul className="space-y-1">
+                                                {criterion.requirements.map(req => (
+                                                    <li key={req.tessera_uri} className="text-sm text-zinc-700 flex items-start gap-1">
+                                                        <span className="text-zinc-400 mt-0.5">—</span>
+                                                        {req.label}
+                                                    </li>
+                                                ))}
+                                            </ul>
+                                        )}
+
+                                        {/* Inline form: ontwerpeis toevoegen */}
+                                        {addRequirementFor === criterion.tessera_uri && (
+                                            <form onSubmit={handleAddRequirement} className="mt-2 space-y-2">
+                                                <Input
+                                                    value={requirementForm.label}
+                                                    onChange={(e) => setRequirementForm(f => ({ ...f, label: e.target.value }))}
+                                                    placeholder="Beschrijf de ontwerpeis..."
+                                                    className="h-8 text-sm"
+                                                    autoFocus
+                                                />
+                                                <div className="flex gap-2">
+                                                    <Button
+                                                        type="submit"
+                                                        size="sm"
+                                                        disabled={submitting || !requirementForm.label.trim()}
+                                                    >
+                                                        Opslaan
+                                                    </Button>
+                                                    <Button
+                                                        type="button"
+                                                        variant="ghost"
+                                                        size="sm"
+                                                        onClick={() => setAddRequirementFor(null)}
+                                                    >
+                                                        Annuleren
+                                                    </Button>
+                                                </div>
+                                            </form>
+                                        )}
+                                    </div>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -834,6 +834,21 @@ WHERE {
         const response = await apiClient.get<DesignImplicationCount[]>(`/designspace/${dsId}/value-implications`);
         return response.data;
     },
+
+    createValueCriterion: async (dsId: string, payload: CreateValueCriterionPayload): Promise<ValueCriterionResponse> => {
+        const response = await apiClient.post<ValueCriterionResponse>(`/designspace/${dsId}/value-criterion`, payload);
+        return response.data;
+    },
+
+    createValueBasedDesignRequirement: async (dsId: string, payload: CreateValueBasedDesignRequirementPayload): Promise<ValueBasedDesignRequirementResponse> => {
+        const response = await apiClient.post<ValueBasedDesignRequirementResponse>(`/designspace/${dsId}/value-based-design-requirement`, payload);
+        return response.data;
+    },
+
+    getValueChain: async (dsId: string): Promise<ValueChainResponse> => {
+        const response = await apiClient.get<ValueChainResponse>(`/designspace/${dsId}/value-chain`);
+        return response.data;
+    },
 };
 
 export interface ConversationMessage {
@@ -1086,6 +1101,60 @@ export interface ValueTensionResponse {
 export interface DesignImplicationCount {
     factor_uri: string;
     implication_count: number;
+}
+
+export interface CreateValueCriterionPayload {
+    label: string;
+    value_type_uri: string;
+    grounded_in_norm_uri?: string;
+}
+
+export interface ValueCriterionResponse {
+    tessera_uri: string;
+    tessera_id: string;
+    label: string;
+    value_type_uri: string;
+    grounded_in_norm_uri: string | null;
+    created_by: string;
+    created_at: string;
+}
+
+export interface CreateValueBasedDesignRequirementPayload {
+    label: string;
+    criterion_uri: string;
+}
+
+export interface ValueBasedDesignRequirementResponse {
+    tessera_uri: string;
+    tessera_id: string;
+    label: string;
+    criterion_uri: string;
+    created_by: string;
+    created_at: string;
+}
+
+export interface ValueChainRequirementItem {
+    tessera_uri: string;
+    tessera_id: string;
+    label: string;
+}
+
+export interface ValueChainCriterionItem {
+    tessera_uri: string;
+    tessera_id: string;
+    label: string;
+    requirements: ValueChainRequirementItem[];
+}
+
+export interface ValueChainTypeItem {
+    value_type_uri: string;
+    value_type_label: string;
+    criteria: ValueChainCriterionItem[];
+}
+
+export interface ValueChainResponse {
+    design_space_id: string;
+    chain: ValueChainTypeItem[];
 }
 
 export type LifecycleStatus = 'draft' | 'proposed' | 'accepted' | 'rejected' | 'deprecated';


### PR DESCRIPTION
## Samenvatting

Implementatie van US-7.4: ValueBasedDesignRequirement vanuit ValueCriterion (#365).

- `POST /designspace/{ds_id}/value-criterion` — registreert `axia:ValueCriterion` als `valor:Tessera`; slaat `cover:groundedIn` op naar de ValueType (en optioneel naar een norm-URI)
- `POST /designspace/{ds_id}/value-based-design-requirement` — registreert `axia:ValueBasedDesignRequirement` als `valor:Tessera`; slaat `axia:groundsRequirement` op van het opgegeven criterium
- `GET /designspace/{ds_id}/value-chain` — haalt de volledige keten op als geneste structuur: ValueType → ValueCriterion → ValueBasedDesignRequirement
- `ValueChain.tsx` — frontend component met twee-koloms layout (Criterium + Ontwerpeisen) per ValueType, inclusief inline formulieren voor aanmaken
- `api.ts` — uitgebreid met typen en calls voor alle drie endpoints

## Technische keuzes

- Schrijfoperaties volgen het bestaande Tessera-patroon: named graph `urn:valor:ds:{ds_id}:baseline`, dubbel type (`axia:X` + `valor:Tessera`), `record_provenance_activity` na elke mutatie
- `cover:groundedIn` linkt ValueCriterion aan ValueType (én optioneel aan norm-URI via apart veld)
- `axia:groundsRequirement` staat als triple op het criterium-subject (niet op de requirement), conform VALOR-O richting
- `used=[criterion_uri]` in provenance bij VBDR-aanmaak zodat de keten traceerbaar is

## Testplan

- [ ] `POST /designspace/{ds_id}/value-criterion` met `label`, `value_type_uri` → 201 + correcte response
- [ ] Zelfde endpoint met optionele `grounded_in_norm_uri` → extra triple aanwezig in Fuseki
- [ ] `POST /designspace/{ds_id}/value-based-design-requirement` met geldige `criterion_uri` → 201
- [ ] `GET /designspace/{ds_id}/value-chain` → geneste structuur met criteria + requirements
- [ ] Frontend: ValueChain laadt, criteria zichtbaar per ValueType, ontwerpeisen aanmaken via inline form
- [ ] RBAC: VIEWER kan niet schrijven (403), MEMBER kan schrijven

🤖 Generated with [Claude Code](https://claude.com/claude-code)