### PR TITLE
feat(socia): EcosystemAgent + CollaborationCommitment (US-6.4) #364

### DIFF
--- a/backend/app/db/fuseki_socia.py
+++ b/backend/app/db/fuseki_socia.py
@@ -26,6 +26,7 @@ from app.services.fuseki import sparql_select_global, sparql_update, record_prov
 logger = logging.getLogger(__name__)
 
 _SOCIA_NS = f"{VALOR_NS}socia#"
+_NEXUS_NS = "https://valor-ecosystem.nl/ontology/nexus#"
 _ENTITIES_GRAPH = "urn:valor:entities"
 _RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
 _RDFS_LABEL = "http://www.w3.org/2000/01/rdf-schema#label"
@@ -375,6 +376,175 @@ async def get_designspaces_for_agent(entity_uri: str) -> list[str]:
         row["ds"].replace("urn:valor:ds:", "")
         for row in rows
     ]
+
+
+# ---------------------------------------------------------------------------
+# EcosystemAgent aanmaken (US-6.4)
+# ---------------------------------------------------------------------------
+
+_VALID_COMMITMENT_DURATIONS = {"Permanent", "ProjectBased", "Experimental"}
+
+
+async def create_ecosystem_agent(
+    ds_id: str,
+    label: str,
+    commitment_duration: str,
+    member_agent_uris: list[str],
+    user_id: str,
+) -> dict:
+    """Registreert een nexus:EcosystemAgent met nexus:CollaborationCommitment in Fuseki.
+
+    Opgeslagen in urn:valor:ds:{ds_id}/agents (AgentTesserae-graph).
+    De EcosystemAgent is een subklasse van socia:Actor.
+    """
+    if commitment_duration not in _VALID_COMMITMENT_DURATIONS:
+        raise ValueError(
+            f"Ongeldige commitment_duration '{commitment_duration}'. "
+            f"Geldige waarden: {sorted(_VALID_COMMITMENT_DURATIONS)}"
+        )
+
+    agent_id = str(_uuid_mod.uuid4())
+    agent_uri = f"urn:valor:nexus:agent:{agent_id}"
+    commitment_uri = f"urn:valor:nexus:commitment:{agent_id}"
+    user_uri = f"urn:valor:user:{user_id}"
+    created_at = datetime.now(timezone.utc).isoformat()
+
+    graph_uri = f"urn:valor:ds:{ds_id}/agents"
+    escaped_label = _escape(label)
+
+    member_triples = "\n".join(
+        f"    <{agent_uri}> <{_NEXUS_NS}hasMember> <{uri}> ."
+        for uri in member_agent_uris
+    )
+
+    update = f"""PREFIX nexus: <{_NEXUS_NS}>
+PREFIX socia: <{_SOCIA_NS}>
+PREFIX valor: <{VALOR_NS}>
+PREFIX rdfs:  <{_RDFS_LABEL.rsplit('#', 1)[0]}#>
+PREFIX xsd:   <{_XSD_NS}>
+
+INSERT DATA {{
+  GRAPH <{graph_uri}> {{
+    <{agent_uri}> a nexus:EcosystemAgent ;
+                  a socia:Actor ;
+      rdfs:label "{escaped_label}" ;
+      nexus:hasCommitment <{commitment_uri}> ;
+      valor:inDesignSpace <urn:valor:ds:{ds_id}> ;
+      valor:claimedBy <{user_uri}> ;
+      valor:claimedAt "{created_at}"^^xsd:dateTime .
+    <{commitment_uri}> a nexus:CollaborationCommitment ;
+      nexus:commitmentDuration "{commitment_duration}" .
+{member_triples}
+  }}
+}}"""
+
+    await sparql_update(update, ds_id)
+
+    await record_provenance_activity(
+        ds_id,
+        "EcosystemAgentCreated",
+        user_uri,
+        generated=agent_uri,
+    )
+
+    logger.info(
+        "[fuseki-socia] EcosystemAgent aangemaakt: %s (%s) in %s door %s",
+        agent_uri, commitment_duration, ds_id, user_id,
+    )
+
+    return {
+        "agent_id": agent_id,
+        "agent_uri": agent_uri,
+        "label": label,
+        "commitment_uri": commitment_uri,
+        "commitment_duration": commitment_duration,
+        "member_agent_uris": member_agent_uris,
+        "created_by": user_id,
+        "created_at": created_at,
+        "design_space_id": ds_id,
+    }
+
+
+async def get_ecosystem_agents(ds_id: str) -> list[dict]:
+    """Haalt alle nexus:EcosystemAgents op met CollaborationCondition-status.
+
+    Status = "Volledig" | "Gedeeltelijk" | "Onvolledig" op basis van:
+      - commit aanwezig (nexus:hasCommitment)
+      - architectuur aanwezig (nexus:hasArchitecture — optioneel triple)
+      - dispositionele config aanwezig (nexus:hasDispositionConfig — optioneel triple)
+    """
+    graph_uri = f"urn:valor:ds:{ds_id}/agents"
+
+    rows = await sparql_select_global(f"""
+        PREFIX nexus: <{_NEXUS_NS}>
+        PREFIX socia: <{_SOCIA_NS}>
+        PREFIX rdfs:  <{_RDFS_LABEL.rsplit('#', 1)[0]}#>
+        PREFIX xsd:   <{_XSD_NS}>
+
+        SELECT ?agent ?label ?commitment ?commitmentDuration
+               (BOUND(?arch) AS ?hasArchitecture)
+               (BOUND(?dispConf) AS ?hasDispositionConfig)
+        WHERE {{
+          GRAPH <{graph_uri}> {{
+            ?agent a <{_NEXUS_NS}EcosystemAgent> .
+            OPTIONAL {{ ?agent rdfs:label ?label . }}
+            OPTIONAL {{
+              ?agent <{_NEXUS_NS}hasCommitment> ?commitment .
+              OPTIONAL {{ ?commitment <{_NEXUS_NS}commitmentDuration> ?commitmentDuration . }}
+            }}
+            OPTIONAL {{ ?agent <{_NEXUS_NS}hasArchitecture> ?arch . }}
+            OPTIONAL {{ ?agent <{_NEXUS_NS}hasDispositionConfig> ?dispConf . }}
+          }}
+        }}
+    """)
+
+    # Per agent de leden ophalen
+    member_rows = await sparql_select_global(f"""
+        PREFIX nexus: <{_NEXUS_NS}>
+
+        SELECT ?agent ?member WHERE {{
+          GRAPH <{graph_uri}> {{
+            ?agent a <{_NEXUS_NS}EcosystemAgent> ;
+                   <{_NEXUS_NS}hasMember> ?member .
+          }}
+        }}
+    """)
+
+    members_by_agent: dict[str, list[str]] = {}
+    for row in member_rows:
+        agent_uri = row["agent"]
+        members_by_agent.setdefault(agent_uri, []).append(row["member"])
+
+    result = []
+    for row in rows:
+        agent_uri = row["agent"]
+        has_commit = row.get("commitment") is not None
+        has_arch = str(row.get("hasArchitecture", "false")).lower() == "true"
+        has_disp = str(row.get("hasDispositionConfig", "false")).lower() == "true"
+
+        layers_present = sum([has_commit, has_arch, has_disp])
+        if layers_present == 3:
+            condition_status = "Volledig"
+        elif layers_present >= 1:
+            condition_status = "Gedeeltelijk"
+        else:
+            condition_status = "Onvolledig"
+
+        result.append({
+            "agent_uri": agent_uri,
+            "label": row.get("label", agent_uri.split(":")[-1]),
+            "commitment_uri": row.get("commitment"),
+            "commitment_duration": row.get("commitmentDuration"),
+            "member_agent_uris": members_by_agent.get(agent_uri, []),
+            "condition_status": condition_status,
+            "condition_layers": {
+                "commitment": has_commit,
+                "architecture": has_arch,
+                "disposition_config": has_disp,
+            },
+        })
+
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/routers/socia.py
+++ b/backend/app/routers/socia.py
@@ -1,13 +1,16 @@
 """SOCIA API-endpoints voor het cross-perspectief rolpatroon (US-AI.5/AI.6)."""
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
+from typing import List
 
 from app.auth import get_current_user
 from app.db.fuseki_socia import (
     assign_actor_role,
+    create_ecosystem_agent,
     create_stakeholder_claim,
     get_actor_roles_in_ds,
     get_designspaces_for_agent,
+    get_ecosystem_agents,
     get_stakeholder_map,
     get_tesserae_for_agent,
     migrate_legacy_socia_actors,
@@ -22,6 +25,12 @@ class CreateStakeholderClaimRequest(BaseModel):
     claim_type: str  # "InterestClaim" | "GoalClaim" | "PowerClaim"
     claim_content: str
     actor_uri: str  # URI van de actor waarover de claim gaat
+
+
+class CreateEcosystemAgentRequest(BaseModel):
+    label: str
+    commitment_duration: str  # "Permanent" | "ProjectBased" | "Experimental"
+    member_agent_uris: List[str] = []
 
 
 @router.post("/designspace/{ds_id}/socia/roles")
@@ -101,6 +110,40 @@ async def create_stakeholder_claim_endpoint(
         raise HTTPException(status_code=422, detail=str(exc))
 
     return result
+
+
+@router.post("/designspace/{ds_id}/ecosystem-agent", status_code=201)
+async def create_ecosystem_agent_endpoint(
+    ds_id: str,
+    request: CreateEcosystemAgentRequest,
+    user: dict = Depends(get_current_user),
+):
+    """Registreert een nexus:EcosystemAgent met nexus:CollaborationCommitment in Fuseki."""
+    has_permission = await check_permission(user["id"], ds_id, Role.MEMBER)
+    if not has_permission:
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten voor deze DesignSpace.")
+
+    try:
+        result = await create_ecosystem_agent(
+            ds_id=ds_id,
+            label=request.label,
+            commitment_duration=request.commitment_duration,
+            member_agent_uris=request.member_agent_uris,
+            user_id=user["id"],
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    return result
+
+
+@router.get("/designspace/{ds_id}/ecosystem-agents")
+async def get_ecosystem_agents_endpoint(
+    ds_id: str,
+    _user=Depends(get_current_user),
+):
+    """Haalt alle nexus:EcosystemAgents op met CollaborationCondition-status."""
+    return await get_ecosystem_agents(ds_id)
 
 
 @router.post("/admin/migrate-socia-actors")

--- a/frontend/src/perspectives/socia/views/EcosystemAgentPanel.tsx
+++ b/frontend/src/perspectives/socia/views/EcosystemAgentPanel.tsx
@@ -1,0 +1,348 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Building2, ChevronDown, ChevronUp, Plus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import {
+    api,
+    type CommitmentDuration,
+    type EcosystemAgent,
+} from '@/services/api';
+
+// ---------------------------------------------------------------------------
+// Constanten
+// ---------------------------------------------------------------------------
+
+const COMMITMENT_OPTIONS: { value: CommitmentDuration; label: string }[] = [
+    { value: 'Permanent', label: 'Permanent' },
+    { value: 'ProjectBased', label: 'Projectgebonden' },
+    { value: 'Experimental', label: 'Experimenteel' },
+];
+
+const CONDITION_BADGE_VARIANT: Record<EcosystemAgent['condition_status'], 'default' | 'secondary' | 'destructive'> = {
+    Volledig: 'default',
+    Gedeeltelijk: 'secondary',
+    Onvolledig: 'destructive',
+};
+
+// ---------------------------------------------------------------------------
+// Subcomponent: EcosystemAgent-kaart
+// ---------------------------------------------------------------------------
+
+function AgentCard({ agent }: { agent: EcosystemAgent }) {
+    const [expanded, setExpanded] = useState(false);
+
+    return (
+        <div className="border border-border rounded-lg p-3 space-y-2 bg-card">
+            <div className="flex items-start justify-between gap-2">
+                <div className="flex items-center gap-2 min-w-0">
+                    <Building2 className="h-4 w-4 shrink-0 text-primary" />
+                    <span className="text-sm font-medium truncate">{agent.label}</span>
+                    <Badge
+                        variant="outline"
+                        className="text-xs shrink-0 border-primary/40 text-primary"
+                    >
+                        NEXUS
+                    </Badge>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                    <Badge variant={CONDITION_BADGE_VARIANT[agent.condition_status]} className="text-xs">
+                        {agent.condition_status}
+                    </Badge>
+                    <button
+                        type="button"
+                        onClick={() => setExpanded((v) => !v)}
+                        className="text-muted-foreground hover:text-foreground"
+                        aria-label={expanded ? 'Inklappen' : 'Uitklappen'}
+                    >
+                        {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+                    </button>
+                </div>
+            </div>
+
+            {agent.commitment_duration && (
+                <p className="text-xs text-muted-foreground">
+                    Commitment:{' '}
+                    {COMMITMENT_OPTIONS.find((o) => o.value === agent.commitment_duration)?.label ??
+                        agent.commitment_duration}
+                </p>
+            )}
+
+            {expanded && (
+                <div className="pt-2 space-y-2 border-t border-border">
+                    <div className="grid grid-cols-3 gap-1 text-xs">
+                        <span
+                            className={`px-2 py-1 rounded text-center ${agent.condition_layers.commitment ? 'bg-primary/10 text-primary' : 'bg-muted text-muted-foreground'}`}
+                        >
+                            Commitment
+                        </span>
+                        <span
+                            className={`px-2 py-1 rounded text-center ${agent.condition_layers.architecture ? 'bg-primary/10 text-primary' : 'bg-muted text-muted-foreground'}`}
+                        >
+                            Architectuur
+                        </span>
+                        <span
+                            className={`px-2 py-1 rounded text-center ${agent.condition_layers.disposition_config ? 'bg-primary/10 text-primary' : 'bg-muted text-muted-foreground'}`}
+                        >
+                            Dispositie
+                        </span>
+                    </div>
+                    {agent.member_agent_uris.length > 0 && (
+                        <div>
+                            <p className="text-xs text-muted-foreground mb-1">
+                                Leden ({agent.member_agent_uris.length}):
+                            </p>
+                            <ul className="space-y-0.5">
+                                {agent.member_agent_uris.map((uri) => (
+                                    <li key={uri} className="text-xs text-muted-foreground truncate">
+                                        {uri.split(':').pop()}
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Aanmaakformulier
+// ---------------------------------------------------------------------------
+
+interface CreateFormProps {
+    dsId: string;
+    onCreated: () => void;
+    onCancel: () => void;
+}
+
+function CreateEcosystemAgentForm({ dsId, onCreated, onCancel }: CreateFormProps) {
+    const [label, setLabel] = useState('');
+    const [commitmentDuration, setCommitmentDuration] = useState<CommitmentDuration>('Permanent');
+    const [memberInput, setMemberInput] = useState('');
+    const [memberUris, setMemberUris] = useState<string[]>([]);
+    const [submitting, setSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const addMember = () => {
+        const trimmed = memberInput.trim();
+        if (trimmed && !memberUris.includes(trimmed)) {
+            setMemberUris((prev) => [...prev, trimmed]);
+            setMemberInput('');
+        }
+    };
+
+    const removeMember = (uri: string) => {
+        setMemberUris((prev) => prev.filter((u) => u !== uri));
+    };
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!label.trim()) return;
+        setSubmitting(true);
+        setError(null);
+        try {
+            await api.createEcosystemAgent(dsId, {
+                label: label.trim(),
+                commitment_duration: commitmentDuration,
+                member_agent_uris: memberUris,
+            });
+            onCreated();
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Onbekende fout');
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <form onSubmit={handleSubmit} className="space-y-4 border border-border rounded-lg p-4 bg-muted/30">
+            <p className="text-sm font-medium">Nieuw EcosystemAgent</p>
+
+            <div className="space-y-1.5">
+                <Label htmlFor="ea-label">Naam</Label>
+                <Input
+                    id="ea-label"
+                    value={label}
+                    onChange={(e) => setLabel(e.target.value)}
+                    placeholder="Naam van het ecosysteem-netwerk"
+                    required
+                />
+            </div>
+
+            <div className="space-y-1.5">
+                <Label htmlFor="ea-commitment">Commitment-duur</Label>
+                <Select
+                    value={commitmentDuration}
+                    onValueChange={(v) => setCommitmentDuration(v as CommitmentDuration)}
+                >
+                    <SelectTrigger id="ea-commitment">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        {COMMITMENT_OPTIONS.map((opt) => (
+                            <SelectItem key={opt.value} value={opt.value}>
+                                {opt.label}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            </div>
+
+            <div className="space-y-1.5">
+                <Label>Leden (optioneel)</Label>
+                <div className="flex gap-2">
+                    <Input
+                        value={memberInput}
+                        onChange={(e) => setMemberInput(e.target.value)}
+                        placeholder="urn:valor:entities:..."
+                        onKeyDown={(e) => {
+                            if (e.key === 'Enter') {
+                                e.preventDefault();
+                                addMember();
+                            }
+                        }}
+                    />
+                    <Button type="button" variant="outline" size="sm" onClick={addMember}>
+                        Toevoegen
+                    </Button>
+                </div>
+                {memberUris.length > 0 && (
+                    <ul className="space-y-1 mt-1">
+                        {memberUris.map((uri) => (
+                            <li key={uri} className="flex items-center justify-between text-xs">
+                                <span className="truncate text-muted-foreground">{uri}</span>
+                                <button
+                                    type="button"
+                                    onClick={() => removeMember(uri)}
+                                    className="text-destructive hover:underline ml-2 shrink-0"
+                                >
+                                    Verwijder
+                                </button>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </div>
+
+            {error && <p className="text-xs text-destructive">{error}</p>}
+
+            <div className="flex gap-2 justify-end">
+                <Button type="button" variant="ghost" size="sm" onClick={onCancel}>
+                    Annuleren
+                </Button>
+                <Button type="submit" size="sm" disabled={submitting || !label.trim()}>
+                    {submitting ? 'Opslaan…' : 'Aanmaken'}
+                </Button>
+            </div>
+        </form>
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Hoofdcomponent
+// ---------------------------------------------------------------------------
+
+interface EcosystemAgentPanelProps {
+    dsId: string;
+}
+
+export function EcosystemAgentPanel({ dsId }: EcosystemAgentPanelProps) {
+    const [agents, setAgents] = useState<EcosystemAgent[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [showForm, setShowForm] = useState(false);
+
+    const load = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const data = await api.getEcosystemAgents(dsId);
+            setAgents(data);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Onbekende fout');
+        } finally {
+            setLoading(false);
+        }
+    }, [dsId]);
+
+    useEffect(() => {
+        load();
+    }, [load]);
+
+    const handleCreated = () => {
+        setShowForm(false);
+        load();
+    };
+
+    return (
+        <div className="flex flex-col gap-4 p-4">
+            <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                    <Building2 className="h-4 w-4 text-primary" />
+                    <span className="text-sm font-semibold">EcosystemAgents</span>
+                    {agents.length > 0 && (
+                        <Badge variant="secondary" className="text-xs">
+                            {agents.length}
+                        </Badge>
+                    )}
+                </div>
+                {!showForm && (
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setShowForm(true)}
+                        className="gap-1"
+                    >
+                        <Plus className="h-3.5 w-3.5" />
+                        Nieuw
+                    </Button>
+                )}
+            </div>
+
+            {showForm && (
+                <CreateEcosystemAgentForm
+                    dsId={dsId}
+                    onCreated={handleCreated}
+                    onCancel={() => setShowForm(false)}
+                />
+            )}
+
+            {loading && (
+                <p className="text-xs text-muted-foreground">Laden…</p>
+            )}
+
+            {error && (
+                <div className="flex flex-col gap-1">
+                    <p className="text-xs text-destructive">Fout: {error}</p>
+                    <button
+                        type="button"
+                        onClick={load}
+                        className="text-xs underline text-muted-foreground hover:text-foreground self-start"
+                    >
+                        Opnieuw proberen
+                    </button>
+                </div>
+            )}
+
+            {!loading && !error && agents.length === 0 && !showForm && (
+                <p className="text-xs text-muted-foreground">
+                    Nog geen EcosystemAgents in deze DesignSpace.
+                </p>
+            )}
+
+            {agents.map((agent) => (
+                <AgentCard key={agent.agent_uri} agent={agent} />
+            ))}
+        </div>
+    );
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -127,6 +127,42 @@ export interface StakeholderClaimResponse {
     design_space_id: string;
 }
 
+export type CommitmentDuration = 'Permanent' | 'ProjectBased' | 'Experimental';
+
+export interface CreateEcosystemAgentRequest {
+    label: string;
+    commitment_duration: CommitmentDuration;
+    member_agent_uris: string[];
+}
+
+export interface EcosystemAgentConditionLayers {
+    commitment: boolean;
+    architecture: boolean;
+    disposition_config: boolean;
+}
+
+export interface EcosystemAgent {
+    agent_uri: string;
+    label: string;
+    commitment_uri: string | null;
+    commitment_duration: CommitmentDuration | null;
+    member_agent_uris: string[];
+    condition_status: 'Volledig' | 'Gedeeltelijk' | 'Onvolledig';
+    condition_layers: EcosystemAgentConditionLayers;
+}
+
+export interface CreateEcosystemAgentResponse {
+    agent_id: string;
+    agent_uri: string;
+    label: string;
+    commitment_uri: string;
+    commitment_duration: CommitmentDuration;
+    member_agent_uris: string[];
+    created_by: string;
+    created_at: string;
+    design_space_id: string;
+}
+
 export interface AgentResponse {
     agent_name: string;
     perspective: string;
@@ -720,6 +756,23 @@ export const api = {
             `/designspace/${dsId}/stakeholder-claims`,
             data,
         );
+        return response.data;
+    },
+
+    // EcosystemAgents (US-6.4)
+    createEcosystemAgent: async (
+        dsId: string,
+        data: CreateEcosystemAgentRequest,
+    ): Promise<CreateEcosystemAgentResponse> => {
+        const response = await apiClient.post<CreateEcosystemAgentResponse>(
+            `/designspace/${dsId}/ecosystem-agent`,
+            data,
+        );
+        return response.data;
+    },
+
+    getEcosystemAgents: async (dsId: string): Promise<EcosystemAgent[]> => {
+        const response = await apiClient.get<EcosystemAgent[]>(`/designspace/${dsId}/ecosystem-agents`);
         return response.data;
     },
 


### PR DESCRIPTION
## Summary

- `POST /designspace/{ds_id}/ecosystem-agent` — registreert een `nexus:EcosystemAgent` (subklasse van `socia:Actor`) met `nexus:CollaborationCommitment` in de agents-graph
- `GET /designspace/{ds_id}/ecosystem-agents` — haalt alle EcosystemAgents op met CollaborationCondition-status (`Volledig` / `Gedeeltelijk` / `Onvolledig`) op basis van drie lagen: commitment, architectuur, dispositionele config
- `EcosystemAgentPanel.tsx` — aanmaakform + NEXUS-badge (Building2-icon) + condition-layers visualisatie
- Nieuwe types en API-calls toegevoegd aan `api.ts`

## Namespace

`nexus:` = `https://valor-ecosystem.nl/ontology/nexus#`

## Test plan

- [ ] `POST /designspace/{ds_id}/ecosystem-agent` met geldige body retourneert 201 + agent_uri
- [ ] Ongeldige `commitment_duration` geeft 422
- [ ] `GET /designspace/{ds_id}/ecosystem-agents` retourneert lijst met condition_status per agent
- [ ] Frontend: EcosystemAgentPanel toont agents met NEXUS-badge en correct condition_status
- [ ] Aanmaakform slaat op en herlaadt de lijst

Fixes #364