### PR TITLE
feat(socia): StakeholderGroepen met DEMOS-representativiteit (US-6.5) #387

### DIFF
--- a/backend/app/db/fuseki_socia.py
+++ b/backend/app/db/fuseki_socia.py
@@ -548,6 +548,157 @@ async def get_ecosystem_agents(ds_id: str) -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
+# StakeholderGroepen (US-6.5)
+# ---------------------------------------------------------------------------
+
+_DEMOS_NS = "https://valor-ecosystem.nl/ontology/demos#"
+_VALID_INTEREST_LEVELS = {"High", "Medium", "Low"}
+
+
+async def create_stakeholder_group(
+    ds_id: str,
+    label: str,
+    interest_level: str,
+    represented_by_uri: str | None,
+    user_id: str,
+) -> dict:
+    """Registreert een socia:StakeholderGroup met demos:interestLevel in Fuseki.
+
+    Opgeslagen in urn:valor:ds:{ds_id}/baseline.
+    """
+    if interest_level not in _VALID_INTEREST_LEVELS:
+        raise ValueError(
+            f"Ongeldig interest_level '{interest_level}'. "
+            f"Geldige waarden: {sorted(_VALID_INTEREST_LEVELS)}"
+        )
+
+    group_id = str(_uuid_mod.uuid4())
+    group_uri = f"urn:valor:socia:group:{group_id}"
+    user_uri = f"urn:valor:user:{user_id}"
+    created_at = datetime.now(timezone.utc).isoformat()
+    escaped_label = _escape(label)
+    baseline = _baseline_graph(ds_id)
+
+    represented_triple = (
+        f'    <{group_uri}> <{_DEMOS_NS}representedBy> <{represented_by_uri}> .'
+        if represented_by_uri
+        else ""
+    )
+
+    update = f"""PREFIX socia: <{_SOCIA_NS}>
+PREFIX demos: <{_DEMOS_NS}>
+PREFIX rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX valor: <{VALOR_NS}>
+PREFIX xsd:   <{_XSD_NS}>
+
+INSERT DATA {{
+  GRAPH <{baseline}> {{
+    <{group_uri}> a <{_SOCIA_NS}StakeholderGroup> ;
+      rdfs:label "{escaped_label}" ;
+      <{_DEMOS_NS}interestLevel> "{interest_level}" ;
+      valor:inDesignSpace <{_ds_uri(ds_id)}> ;
+      valor:claimedBy <{user_uri}> ;
+      valor:claimedAt "{created_at}"^^xsd:dateTime .
+{represented_triple}
+  }}
+}}"""
+
+    await sparql_update(update, ds_id)
+
+    await record_provenance_activity(
+        ds_id,
+        "StakeholderGroupCreated",
+        user_uri,
+        generated=group_uri,
+    )
+
+    logger.info(
+        "[fuseki-socia] StakeholderGroup aangemaakt: %s (%s) in %s door %s",
+        group_uri, interest_level, ds_id, user_id,
+    )
+
+    return {
+        "group_id": group_id,
+        "group_uri": group_uri,
+        "label": label,
+        "interest_level": interest_level,
+        "represented_by_uri": represented_by_uri,
+        "is_represented": represented_by_uri is not None,
+        "created_by": user_id,
+        "created_at": created_at,
+        "design_space_id": ds_id,
+    }
+
+
+async def get_stakeholder_groups(ds_id: str) -> list[dict]:
+    """Haalt alle socia:StakeholderGroups op uit de baseline-graph van een DesignSpace.
+
+    Retourneert per groep ook of er een demos:representedBy aanwezig is (is_represented).
+    """
+    baseline = _baseline_graph(ds_id)
+
+    rows = await sparql_select_global(f"""
+        PREFIX socia:  <{_SOCIA_NS}>
+        PREFIX demos:  <{_DEMOS_NS}>
+        PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
+
+        SELECT ?group ?label ?interestLevel (BOUND(?rep) AS ?isRepresented) ?rep WHERE {{
+          GRAPH <{baseline}> {{
+            ?group a <{_SOCIA_NS}StakeholderGroup> ;
+                   rdfs:label ?label ;
+                   <{_DEMOS_NS}interestLevel> ?interestLevel .
+            OPTIONAL {{ ?group <{_DEMOS_NS}representedBy> ?rep . }}
+          }}
+        }}
+    """)
+
+    return [
+        {
+            "group_uri": row["group"],
+            "label": row.get("label", row["group"].split(":")[-1]),
+            "interest_level": row.get("interestLevel", ""),
+            "is_represented": str(row.get("isRepresented", "false")).lower() == "true",
+            "represented_by_uri": row.get("rep"),
+        }
+        for row in rows
+    ]
+
+
+async def get_high_interest_groups(ds_id: str) -> list[dict]:
+    """Filtert socia:StakeholderGroups op interestLevel = 'High' met representatiestatus.
+
+    Bedoeld voor DEMOS InclusivityCoverage-berekening.
+    """
+    baseline = _baseline_graph(ds_id)
+
+    rows = await sparql_select_global(f"""
+        PREFIX socia:  <{_SOCIA_NS}>
+        PREFIX demos:  <{_DEMOS_NS}>
+        PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
+
+        SELECT ?group ?label (BOUND(?rep) AS ?isRepresented) ?rep WHERE {{
+          GRAPH <{baseline}> {{
+            ?group a <{_SOCIA_NS}StakeholderGroup> ;
+                   rdfs:label ?label ;
+                   <{_DEMOS_NS}interestLevel> "High" .
+            OPTIONAL {{ ?group <{_DEMOS_NS}representedBy> ?rep . }}
+          }}
+        }}
+    """)
+
+    return [
+        {
+            "group_uri": row["group"],
+            "label": row.get("label", row["group"].split(":")[-1]),
+            "interest_level": "High",
+            "is_represented": str(row.get("isRepresented", "false")).lower() == "true",
+            "represented_by_uri": row.get("rep"),
+        }
+        for row in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Migratie: legacy socia:Actor → Entity Registry (US-AI.6)
 # ---------------------------------------------------------------------------
 

--- a/backend/app/routers/socia.py
+++ b/backend/app/routers/socia.py
@@ -8,9 +8,12 @@ from app.db.fuseki_socia import (
     assign_actor_role,
     create_ecosystem_agent,
     create_stakeholder_claim,
+    create_stakeholder_group,
     get_actor_roles_in_ds,
     get_designspaces_for_agent,
     get_ecosystem_agents,
+    get_high_interest_groups,
+    get_stakeholder_groups,
     get_stakeholder_map,
     get_tesserae_for_agent,
     migrate_legacy_socia_actors,
@@ -31,6 +34,12 @@ class CreateEcosystemAgentRequest(BaseModel):
     label: str
     commitment_duration: str  # "Permanent" | "ProjectBased" | "Experimental"
     member_agent_uris: List[str] = []
+
+
+class CreateStakeholderGroupRequest(BaseModel):
+    label: str
+    interest_level: str  # "High" | "Medium" | "Low"
+    represented_by_uri: str | None = None
 
 
 @router.post("/designspace/{ds_id}/socia/roles")
@@ -144,6 +153,49 @@ async def get_ecosystem_agents_endpoint(
 ):
     """Haalt alle nexus:EcosystemAgents op met CollaborationCondition-status."""
     return await get_ecosystem_agents(ds_id)
+
+
+@router.post("/designspace/{ds_id}/stakeholder-group", status_code=201)
+async def create_stakeholder_group_endpoint(
+    ds_id: str,
+    request: CreateStakeholderGroupRequest,
+    user: dict = Depends(get_current_user),
+):
+    """Registreert een socia:StakeholderGroup met demos:interestLevel in Fuseki."""
+    has_permission = await check_permission(user["id"], ds_id, Role.MEMBER)
+    if not has_permission:
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten voor deze DesignSpace.")
+
+    try:
+        result = await create_stakeholder_group(
+            ds_id=ds_id,
+            label=request.label,
+            interest_level=request.interest_level,
+            represented_by_uri=request.represented_by_uri,
+            user_id=user["id"],
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    return result
+
+
+@router.get("/designspace/{ds_id}/stakeholder-groups")
+async def get_stakeholder_groups_endpoint(
+    ds_id: str,
+    _user=Depends(get_current_user),
+):
+    """Haalt alle socia:StakeholderGroups op met interestLevel en representatiestatus."""
+    return await get_stakeholder_groups(ds_id)
+
+
+@router.get("/designspace/{ds_id}/stakeholder-groups/high-interest")
+async def get_high_interest_groups_endpoint(
+    ds_id: str,
+    _user=Depends(get_current_user),
+):
+    """Retourneert alle StakeholderGroups met interestLevel = High (DEMOS InclusivityCoverage)."""
+    return await get_high_interest_groups(ds_id)
 
 
 @router.post("/admin/migrate-socia-actors")

--- a/frontend/src/perspectives/socia/views/StakeholderGroupPanel.tsx
+++ b/frontend/src/perspectives/socia/views/StakeholderGroupPanel.tsx
@@ -1,0 +1,263 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Users } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import {
+    api,
+    type InterestLevel,
+    type StakeholderGroup,
+} from '@/services/api';
+
+// ---------------------------------------------------------------------------
+// Constanten
+// ---------------------------------------------------------------------------
+
+const INTEREST_OPTIONS: { value: InterestLevel; label: string }[] = [
+    { value: 'High', label: 'Hoog' },
+    { value: 'Medium', label: 'Middel' },
+    { value: 'Low', label: 'Laag' },
+];
+
+const INTEREST_BADGE_CLASS: Record<InterestLevel, string> = {
+    High: 'bg-destructive/15 text-destructive border-destructive/30',
+    Medium: 'bg-yellow-500/15 text-yellow-700 border-yellow-500/30 dark:text-yellow-400',
+    Low: 'bg-green-500/15 text-green-700 border-green-500/30 dark:text-green-400',
+};
+
+// ---------------------------------------------------------------------------
+// Groepskaart
+// ---------------------------------------------------------------------------
+
+function GroupCard({ group }: { group: StakeholderGroup }) {
+    const interestOpt = INTEREST_OPTIONS.find((o) => o.value === group.interest_level);
+
+    return (
+        <div className="border border-border rounded-lg p-3 space-y-1.5 bg-card">
+            <div className="flex items-start justify-between gap-2">
+                <div className="flex items-center gap-2 min-w-0">
+                    <Users className="h-4 w-4 shrink-0 text-primary" />
+                    <span className="text-sm font-medium truncate">{group.label}</span>
+                </div>
+                <Badge
+                    variant="outline"
+                    className={`text-xs shrink-0 ${INTEREST_BADGE_CLASS[group.interest_level]}`}
+                >
+                    {interestOpt?.label ?? group.interest_level}
+                </Badge>
+            </div>
+            <p className="text-xs text-muted-foreground">
+                Vertegenwoordigd:{' '}
+                <span className={group.is_represented ? 'text-primary' : 'text-muted-foreground'}>
+                    {group.is_represented ? 'Ja' : 'Nee'}
+                </span>
+            </p>
+            {group.represented_by_uri && (
+                <p className="text-xs text-muted-foreground truncate" title={group.represented_by_uri}>
+                    {group.represented_by_uri}
+                </p>
+            )}
+        </div>
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Aanmaakformulier
+// ---------------------------------------------------------------------------
+
+interface CreateFormProps {
+    dsId: string;
+    onCreated: () => void;
+    onCancel: () => void;
+}
+
+function CreateStakeholderGroupForm({ dsId, onCreated, onCancel }: CreateFormProps) {
+    const [label, setLabel] = useState('');
+    const [interestLevel, setInterestLevel] = useState<InterestLevel>('Medium');
+    const [representedByUri, setRepresentedByUri] = useState('');
+    const [submitting, setSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!label.trim()) return;
+        setSubmitting(true);
+        setError(null);
+        try {
+            await api.createStakeholderGroup(dsId, {
+                label: label.trim(),
+                interest_level: interestLevel,
+                represented_by_uri: representedByUri.trim() || undefined,
+            });
+            onCreated();
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Onbekende fout');
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <form onSubmit={handleSubmit} className="space-y-4 border border-border rounded-lg p-4 bg-muted/30">
+            <p className="text-sm font-medium">Nieuwe StakeholderGroep</p>
+
+            <div className="space-y-1.5">
+                <Label htmlFor="sg-label">Naam</Label>
+                <Input
+                    id="sg-label"
+                    value={label}
+                    onChange={(e) => setLabel(e.target.value)}
+                    placeholder="Naam van de stakeholdergroep"
+                    required
+                />
+            </div>
+
+            <div className="space-y-1.5">
+                <Label htmlFor="sg-interest">Interesseniveau</Label>
+                <Select
+                    value={interestLevel}
+                    onValueChange={(v) => setInterestLevel(v as InterestLevel)}
+                >
+                    <SelectTrigger id="sg-interest">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        {INTEREST_OPTIONS.map((opt) => (
+                            <SelectItem key={opt.value} value={opt.value}>
+                                {opt.label}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            </div>
+
+            <div className="space-y-1.5">
+                <Label htmlFor="sg-represented">Vertegenwoordigd door (optioneel)</Label>
+                <Input
+                    id="sg-represented"
+                    value={representedByUri}
+                    onChange={(e) => setRepresentedByUri(e.target.value)}
+                    placeholder="URI van IssueCommunity-lid"
+                />
+            </div>
+
+            {error && <p className="text-xs text-destructive">{error}</p>}
+
+            <div className="flex gap-2 justify-end">
+                <Button type="button" variant="ghost" size="sm" onClick={onCancel}>
+                    Annuleren
+                </Button>
+                <Button type="submit" size="sm" disabled={submitting || !label.trim()}>
+                    {submitting ? 'Opslaan\u2026' : 'Aanmaken'}
+                </Button>
+            </div>
+        </form>
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Hoofdcomponent
+// ---------------------------------------------------------------------------
+
+interface StakeholderGroupPanelProps {
+    dsId: string;
+}
+
+export function StakeholderGroupPanel({ dsId }: StakeholderGroupPanelProps) {
+    const [groups, setGroups] = useState<StakeholderGroup[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [showForm, setShowForm] = useState(false);
+
+    const load = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const data = await api.getStakeholderGroups(dsId);
+            setGroups(data);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Onbekende fout');
+        } finally {
+            setLoading(false);
+        }
+    }, [dsId]);
+
+    useEffect(() => {
+        load();
+    }, [load]);
+
+    const handleCreated = () => {
+        setShowForm(false);
+        load();
+    };
+
+    return (
+        <div className="flex flex-col gap-4 p-4">
+            <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                    <Users className="h-4 w-4 text-primary" />
+                    <span className="text-sm font-semibold">StakeholderGroepen</span>
+                    {groups.length > 0 && (
+                        <Badge variant="secondary" className="text-xs">
+                            {groups.length}
+                        </Badge>
+                    )}
+                </div>
+                {!showForm && (
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setShowForm(true)}
+                        className="gap-1"
+                    >
+                        <span className="text-base leading-none">+</span>
+                        Nieuw
+                    </Button>
+                )}
+            </div>
+
+            {showForm && (
+                <CreateStakeholderGroupForm
+                    dsId={dsId}
+                    onCreated={handleCreated}
+                    onCancel={() => setShowForm(false)}
+                />
+            )}
+
+            {loading && (
+                <p className="text-xs text-muted-foreground">Laden\u2026</p>
+            )}
+
+            {error && (
+                <div className="flex flex-col gap-1">
+                    <p className="text-xs text-destructive">Fout: {error}</p>
+                    <button
+                        type="button"
+                        onClick={load}
+                        className="text-xs underline text-muted-foreground hover:text-foreground self-start"
+                    >
+                        Opnieuw proberen
+                    </button>
+                </div>
+            )}
+
+            {!loading && !error && groups.length === 0 && !showForm && (
+                <p className="text-xs text-muted-foreground">
+                    Nog geen StakeholderGroepen in deze DesignSpace.
+                </p>
+            )}
+
+            {groups.map((group) => (
+                <GroupCard key={group.group_uri} group={group} />
+            ))}
+        </div>
+    );
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -163,6 +163,35 @@ export interface CreateEcosystemAgentResponse {
     design_space_id: string;
 }
 
+// StakeholderGroepen (US-6.5)
+export type InterestLevel = 'High' | 'Medium' | 'Low';
+
+export interface CreateStakeholderGroupRequest {
+    label: string;
+    interest_level: InterestLevel;
+    represented_by_uri?: string;
+}
+
+export interface StakeholderGroup {
+    group_uri: string;
+    label: string;
+    interest_level: InterestLevel;
+    is_represented: boolean;
+    represented_by_uri: string | null;
+}
+
+export interface CreateStakeholderGroupResponse {
+    group_id: string;
+    group_uri: string;
+    label: string;
+    interest_level: InterestLevel;
+    represented_by_uri: string | null;
+    is_represented: boolean;
+    created_by: string;
+    created_at: string;
+    design_space_id: string;
+}
+
 export interface AgentResponse {
     agent_name: string;
     perspective: string;
@@ -773,6 +802,28 @@ export const api = {
 
     getEcosystemAgents: async (dsId: string): Promise<EcosystemAgent[]> => {
         const response = await apiClient.get<EcosystemAgent[]>(`/designspace/${dsId}/ecosystem-agents`);
+        return response.data;
+    },
+
+    // StakeholderGroepen (US-6.5)
+    createStakeholderGroup: async (
+        dsId: string,
+        data: CreateStakeholderGroupRequest,
+    ): Promise<CreateStakeholderGroupResponse> => {
+        const response = await apiClient.post<CreateStakeholderGroupResponse>(
+            `/designspace/${dsId}/stakeholder-group`,
+            data,
+        );
+        return response.data;
+    },
+
+    getStakeholderGroups: async (dsId: string): Promise<StakeholderGroup[]> => {
+        const response = await apiClient.get<StakeholderGroup[]>(`/designspace/${dsId}/stakeholder-groups`);
+        return response.data;
+    },
+
+    getHighInterestGroups: async (dsId: string): Promise<StakeholderGroup[]> => {
+        const response = await apiClient.get<StakeholderGroup[]>(`/designspace/${dsId}/stakeholder-groups/high-interest`);
         return response.data;
     },
 


### PR DESCRIPTION
## Summary

- Voegt `POST /designspace/{ds_id}/stakeholder-group` toe voor registratie van `socia:StakeholderGroup` met `demos:interestLevel` (`High`/`Medium`/`Low`) en optionele `demos:representedBy`-link naar een IssueCommunity-lid
- Voegt `GET /designspace/{ds_id}/stakeholder-groups` toe met interestLevel en representatiestatus (`is_represented: bool`)
- Voegt `GET /designspace/{ds_id}/stakeholder-groups/high-interest` toe voor DEMOS InclusivityCoverage-filtering
- Schrijft alles naar `urn:valor:ds:{ds_id}/baseline` conform het socia-patroon
- Frontend: `StakeholderGroupPanel.tsx` met aanmaakformulier en interestLevel-badge (rood=High, geel=Medium, groen=Low)

## Test plan

- [ ] `POST /designspace/{ds_id}/stakeholder-group` met `interest_level: "High"` en zonder `represented_by_uri` — verwacht 201, `is_represented: false`
- [ ] Zelfde POST met geldige `represented_by_uri` — verwacht `is_represented: true`
- [ ] POST met ongeldig `interest_level` (`"Critical"`) — verwacht 422
- [ ] `GET /designspace/{ds_id}/stakeholder-groups` — retourneert aangemelde groepen
- [ ] `GET /designspace/{ds_id}/stakeholder-groups/high-interest` — retourneert alleen High-groepen
- [ ] Frontend: formulier opent, validatie werkt, badge toont correcte kleur per niveau

🤖 Generated with [Claude Code](https://claude.com/claude-code)