### PR TITLE
feat(axia): US-7.01 — AXIA-perspectief registreren

### DIFF
--- a/frontend/src/perspectives/axia/AxiaShell.tsx
+++ b/frontend/src/perspectives/axia/AxiaShell.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Plus, GitBranch, AlertTriangle, Loader2, AlertCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -227,6 +227,12 @@ export function AxiaShell({ designSpaceId }: AxiaShellProps) {
     const [view, setView] = useState<AxiaView>('canvas');
     const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
     const [refreshKey, setRefreshKey] = useState(0);
+
+    useEffect(() => {
+        const prev = document.title;
+        document.title = 'AXIA — Waardeperspectief';
+        return () => { document.title = prev; };
+    }, []);
 
     const handleCreated = () => {
         setRefreshKey((k) => k + 1);


### PR DESCRIPTION
## Samenvatting

Route-registratie en bootstrap waren al aanwezig uit eerdere implementatie. Deze story voegt toe:

- Paginatitel `AXIA — Waardeperspectief` bij mount via `document.title`; reset bij unmount

## Acceptatiecriteria

- [x] AXIA geregistreerd als route (`App.tsx`: `if (mode === 'AXIA') return <AxiaShell ...>`)
- [x] Bootstrap (US-7.00) wordt uitgevoerd bij mount vóór canvas (`useAxiaSchema` in AxiaShell)
- [x] Paginatitel: `AXIA — Waardeperspectief`

Closes #528