### PR TITLE
feat(axia): US-7.03 — ValueClaim aanmaken via waardepalet

### DIFF
--- a/backend/app/routers/axia.py
+++ b/backend/app/routers/axia.py
@@ -52,6 +52,7 @@ class ValueCanvasOut(BaseModel):
 class UpdateValueClaimRequest(BaseModel):
     claim_content: str | None = None
     value_type_uri: str | None = None
+    claim_polarity_uri: str | None = None
 
 
 class CreateValueTensionRequest(BaseModel):
@@ -311,25 +312,34 @@ async def update_value_claim(
     if not has_permission:
         raise HTTPException(status_code=403, detail="Onvoldoende rechten voor deze DesignSpace.")
 
-    if request.claim_content is None and request.value_type_uri is None:
-        raise HTTPException(status_code=422, detail="Minimaal claim_content of value_type_uri is vereist.")
+    if request.claim_content is None and request.value_type_uri is None and request.claim_polarity_uri is None:
+        raise HTTPException(status_code=422, detail="Minimaal één veld is vereist.")
 
     graph_uri = f"urn:valor:ds:{ds_id}/baseline"
 
     delete_parts = []
     insert_parts = []
+    where_optionals = []
 
     if request.claim_content is not None:
         escaped = request.claim_content.replace("\\", "\\\\").replace('"', '\\"')
         delete_parts.append(f'    <{tessera_uri}> valor:claimContent ?oldContent .')
         insert_parts.append(f'    <{tessera_uri}> valor:claimContent "{escaped}"@nl .')
+        where_optionals.append(f'    OPTIONAL {{ <{tessera_uri}> valor:claimContent ?oldContent . }}')
 
     if request.value_type_uri is not None:
         delete_parts.append(f'    <{tessera_uri}> axia:concernsValueType ?oldType .')
         insert_parts.append(f'    <{tessera_uri}> axia:concernsValueType <{request.value_type_uri}> .')
+        where_optionals.append(f'    OPTIONAL {{ <{tessera_uri}> axia:concernsValueType ?oldType . }}')
+
+    if request.claim_polarity_uri is not None:
+        delete_parts.append(f'    <{tessera_uri}> axia:claimPolarity ?oldPolarity .')
+        insert_parts.append(f'    <{tessera_uri}> axia:claimPolarity <{request.claim_polarity_uri}> .')
+        where_optionals.append(f'    OPTIONAL {{ <{tessera_uri}> axia:claimPolarity ?oldPolarity . }}')
 
     delete_block = "\n".join(delete_parts)
     insert_block = "\n".join(insert_parts)
+    where_block = "\n".join(where_optionals)
 
     sparql = f"""PREFIX axia: <{AXIA_NS}>
 PREFIX valor: <{VALOR_NS}>
@@ -347,8 +357,7 @@ INSERT {{
 WHERE {{
   GRAPH <{graph_uri}> {{
     <{tessera_uri}> a axia:ValueClaim .
-    OPTIONAL {{ <{tessera_uri}> valor:claimContent ?oldContent . }}
-    OPTIONAL {{ <{tessera_uri}> axia:concernsValueType ?oldType . }}
+{where_block}
   }}
 }}"""
 

--- a/backend/app/routers/axia.py
+++ b/backend/app/routers/axia.py
@@ -214,6 +214,8 @@ INSERT DATA {{
     <{tessera_uri}> a axia:ValueClaim ;
       a valor:Tessera ;
       valor:claimContent "{escaped_content}"@nl ;{value_type_triple}{polarity_triple}
+      valor:epistemicStatus <{VALOR_NS}ProposedStatus> ;
+      valor:claimType <{VALOR_NS}ToBeType> ;
       valor:claimedBy <{user_uri}> ;
       valor:claimedAt "{created_at}"^^xsd:dateTime .
   }}

--- a/frontend/src/perspectives/axia/AxiaShell.tsx
+++ b/frontend/src/perspectives/axia/AxiaShell.tsx
@@ -204,6 +204,7 @@ function EditValueClaimModal({ claim, open, onOpenChange, designSpaceId, schema,
             await api.updateValueClaim(designSpaceId, claim.tessera_uri, {
                 claim_content: inhoud.trim() || undefined,
                 value_type_uri: valueTypeUri || undefined,
+                claim_polarity_uri: polarityUri || undefined,
             });
             toast.success('Waardeclaim opgeslagen.');
             onRefresh();

--- a/frontend/src/perspectives/axia/ValueCanvas.tsx
+++ b/frontend/src/perspectives/axia/ValueCanvas.tsx
@@ -15,9 +15,9 @@ import type { ValueClaimItem } from '@/services/api';
 // ---------------------------------------------------------------------------
 
 const NODE_WIDTH = 220;
-const COL_GAP = 60;
-const NODE_HEIGHT = 110;
-const NODE_GAP = 20;
+const COL_GAP = 80;
+const NODE_HEIGHT = 120;
+const NODE_GAP = 16;
 const GROUP_HEADER_H = 32;
 const START_X = 60;
 const START_Y = 60;
@@ -26,16 +26,23 @@ const START_Y = 60;
 // Helpers
 // ---------------------------------------------------------------------------
 
-function polarityBorderClass(uri?: string | null): string {
-    if (!uri) return 'border-zinc-300 dark:border-zinc-600';
-    if (uri.includes('Supporting')) return 'border-green-500';
-    if (uri.includes('Opposing') || uri.includes('Conflicting')) return 'border-red-500';
-    if (uri.includes('Neutral')) return 'border-zinc-400';
-    return 'border-zinc-300 dark:border-zinc-600';
+const HEX_W = 220;
+const HEX_H = 120;
+// Platte hexagoon (punt links/rechts)
+const HEX_CLIP = 'polygon(8% 0%, 92% 0%, 100% 50%, 92% 100%, 8% 100%, 0% 50%)';
+
+function polarityColors(uri?: string | null): { bg: string; text: string; label: string } {
+    if (!uri) return { bg: '#e2e8f0', text: '#475569', label: '#94a3b8' };
+    if (uri.includes('Supporting')) return { bg: '#dcfce7', text: '#15803d', label: '#16a34a' };
+    if (uri.includes('Undermining') || uri.includes('Opposing') || uri.includes('Conflicting'))
+        return { bg: '#fee2e2', text: '#b91c1c', label: '#dc2626' };
+    if (uri.includes('Ambiguous') || uri.includes('Neutral'))
+        return { bg: '#fef9c3', text: '#854d0e', label: '#ca8a04' };
+    return { bg: '#e2e8f0', text: '#475569', label: '#94a3b8' };
 }
 
 // ---------------------------------------------------------------------------
-// Custom node — defined at module level so reference is stable
+// Custom node — hexagonale vorm, module-niveau voor stabiele referentie
 // ---------------------------------------------------------------------------
 
 interface ValueClaimNodeData {
@@ -44,15 +51,55 @@ interface ValueClaimNodeData {
 
 function ValueClaimNode({ data }: { data: ValueClaimNodeData }) {
     const { claim } = data;
-    const borderClass = polarityBorderClass(claim.polarity_uri);
+    const colors = polarityColors(claim.polarity_uri);
 
     return (
-        <div className={`w-[220px] rounded-md border-2 ${borderClass} bg-card shadow-sm p-3`}>
-            <p className="text-sm leading-snug text-card-foreground line-clamp-3">
+        <div
+            style={{
+                width: HEX_W,
+                height: HEX_H,
+                clipPath: HEX_CLIP,
+                backgroundColor: colors.bg,
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: '12px 32px',
+                boxSizing: 'border-box',
+                cursor: 'pointer',
+            }}
+        >
+            <p
+                style={{
+                    fontSize: 11,
+                    lineHeight: 1.4,
+                    color: colors.text,
+                    textAlign: 'center',
+                    margin: 0,
+                    overflow: 'hidden',
+                    display: '-webkit-box',
+                    WebkitLineClamp: 3,
+                    WebkitBoxOrient: 'vertical',
+                    fontWeight: 500,
+                }}
+            >
                 {claim.claim_content}
             </p>
             {claim.value_type_label && (
-                <span className="mt-2 inline-block text-xs text-muted-foreground bg-muted px-1.5 py-0.5 rounded-sm max-w-full truncate">
+                <span
+                    style={{
+                        marginTop: 4,
+                        fontSize: 9,
+                        color: colors.label,
+                        fontWeight: 600,
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.05em',
+                        maxWidth: '80%',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                    }}
+                >
                     {claim.value_type_label}
                 </span>
             )}
@@ -120,7 +167,7 @@ function buildNodes(claims: ValueClaimItem[]): Node[] {
                     y: START_Y + GROUP_HEADER_H + rowIndex * (NODE_HEIGHT + NODE_GAP),
                 },
                 data: { claim },
-                style: { width: NODE_WIDTH },
+                style: { width: HEX_W, height: HEX_H },
             });
         });
     });

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1374,6 +1374,7 @@ export interface ValueClaimCreatedResponse {
 export interface UpdateValueClaimPayload {
     claim_content?: string;
     value_type_uri?: string;
+    claim_polarity_uri?: string;
 }
 
 export interface CreateValueCriterionPayload {


### PR DESCRIPTION
## Summary

- `POST /value-claim` schrijft nu ook `valor:epistemicStatus <ProposedStatus>` en `valor:claimType <ToBeType>` conform de SPARQL-spec uit de issue
- `ValueClaimNode` omgebouwd naar hexagonale vorm via CSS `clip-path`, kleur op basis van polariteit uit design tokens:
  - Supporting → groen (`#dcfce7` / `#15803d`)
  - Undermining/Opposing → rood (`#fee2e2` / `#b91c1c`)
  - Ambiguous/Neutral → geel (`#fef9c3` / `#854d0e`)
  - Geen polariteit → grijs (`#e2e8f0`)
- Layout constants aangepast voor hexagon-hoogte (120px, gap 16px)

Closes #530

## Test plan

- [ ] Nieuwe waardeclaim aanmaken via + knop → verschijnt als hexagoon op canvas
- [ ] Polariteitskleur klopt (groen/rood/geel/grijs)
- [ ] ValueType-label zichtbaar onderaan het hexagoon
- [ ] Bestaande claims laden correct als hexagoon
- [ ] Dubbelklik opent edit-modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)