### PR TITLE
feat(axia): US-7.05 — DesignImplication aanmaken

### DIFF
--- a/backend/app/routers/axia.py
+++ b/backend/app/routers/axia.py
@@ -713,9 +713,78 @@ class ValueChainOut(BaseModel):
 
 
 class DesignImplicationCount(BaseModel):
-    factor_uri: str
+    tessera_uri: str
     implication_count: int
 
+
+class CreateDesignImplicationRequest(BaseModel):
+    tessera_uri: str
+    value_type_uri: str
+    polarity_uri: str
+
+
+class DesignImplicationOut(BaseModel):
+    implication_uri: str
+    tessera_uri: str
+    value_type_uri: str
+    polarity_uri: str
+    created_by: str
+    created_at: str
+
+
+# ---------------------------------------------------------------------------
+# US-7.05: POST value-implication
+# ---------------------------------------------------------------------------
+
+@router.post("/{ds_id}/value-implication", response_model=DesignImplicationOut, status_code=201)
+async def create_design_implication(
+    ds_id: str,
+    request: CreateDesignImplicationRequest,
+    user: dict = Depends(get_current_user),
+) -> DesignImplicationOut:
+    user_id = user["id"]
+
+    has_permission = await check_permission(user_id, ds_id, Role.MEMBER)
+    if not has_permission:
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten voor deze DesignSpace.")
+
+    graph_uri = f"urn:valor:ds:{ds_id}/baseline"
+    implication_id = str(uuid.uuid4())
+    implication_uri = f"urn:valor:ds:{ds_id}:design-implication:{implication_id}"
+    now = datetime.now(timezone.utc).isoformat()
+
+    sparql = f"""PREFIX axia: <{AXIA_NS}>
+PREFIX valor: <{VALOR_NS}>
+PREFIX xsd: <{XSD_NS}>
+
+INSERT DATA {{
+  GRAPH <{graph_uri}> {{
+    <{implication_uri}> a axia:DesignImplication ;
+                        axia:implicationSource <{request.tessera_uri}> ;
+                        axia:implicationTarget <{request.value_type_uri}> ;
+                        axia:implicationPolarity <{request.polarity_uri}> ;
+                        valor:createdBy <urn:valor:user:{user_id}> ;
+                        valor:createdAt "{now}"^^xsd:dateTime .
+  }}
+}}"""
+
+    await sparql_update(sparql, ds_id)
+    user_uri = f"urn:valor:user:{user_id}"
+    await record_provenance_activity(ds_id, "DesignImplicationCreated", user_uri, used=[request.tessera_uri])
+
+    return DesignImplicationOut(
+        implication_uri=implication_uri,
+        tessera_uri=request.tessera_uri,
+        value_type_uri=request.value_type_uri,
+        polarity_uri=request.polarity_uri,
+        created_by=user_uri,
+        created_at=now,
+    )
+
+
+# ---------------------------------------------------------------------------
+# US-7.05: GET value-implications (count per tessera)
+# ---------------------------------------------------------------------------
 
 @router.get("/{ds_id}/value-implications", response_model=list[DesignImplicationCount])
 async def get_value_implications(
@@ -732,21 +801,21 @@ async def get_value_implications(
 
     query = f"""PREFIX axia: <{AXIA_NS}>
 
-SELECT ?factor (COUNT(?implication) AS ?count) WHERE {{
+SELECT ?tessera (COUNT(?implication) AS ?count) WHERE {{
   GRAPH <{graph_uri}> {{
     ?implication a axia:DesignImplication ;
-                 axia:impliesFor ?factor .
+                 axia:implicationSource ?tessera .
   }}
 }}
-GROUP BY ?factor
+GROUP BY ?tessera
 ORDER BY DESC(?count)"""
 
     rows = await sparql_select_global(query)
 
     return [
         DesignImplicationCount(
-            factor_uri=row["factor"],
-            implication_count=int(row["count"]),
+            tessera_uri=row["tessera"],
+            implication_count=int(str(row["count"]).split("^^")[0].strip('"')),
         )
         for row in rows
     ]

--- a/frontend/src/perspectives/axia/HeatmapOverlay.tsx
+++ b/frontend/src/perspectives/axia/HeatmapOverlay.tsx
@@ -85,7 +85,7 @@ export function HeatmapOverlay({ designSpaceId, rfInstance, nodeIds }: HeatmapOv
 
     // Map factor_uri → count (gebruik het trailing segment als node-id lookup)
     const countByFactorUri = new Map<string, number>(
-        implications.map((i) => [i.factor_uri, i.implication_count])
+        implications.map((i) => [i.tessera_uri, i.implication_count])
     );
 
     // Zoek count voor een node-id: probeer directe match, dan URI-suffix match

--- a/frontend/src/perspectives/axia/ValueCanvas.tsx
+++ b/frontend/src/perspectives/axia/ValueCanvas.tsx
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useRef, useState, type MutableRefObject } from 'react';
+import { createPortal } from 'react-dom';
+import { Link } from 'lucide-react';
 import ReactFlow, {
     Background,
     ConnectionMode,
@@ -29,6 +31,13 @@ import {
     DialogHeader,
     DialogTitle,
 } from '@/components/ui/dialog';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
 import { api } from '@/services/api';
 import type { ValueClaimItem, ValueTensionResponse } from '@/services/api';
 import { useAxiaSchema } from './hooks/useAxiaSchema';
@@ -69,10 +78,11 @@ function polarityColors(uri?: string | null): { bg: string; text: string; label:
 
 interface ValueClaimNodeData {
     claim: ValueClaimItem;
+    implicationCount?: number;
 }
 
 function ValueClaimNode({ data }: { data: ValueClaimNodeData }) {
-    const { claim } = data;
+    const { claim, implicationCount } = data;
     const colors = polarityColors(claim.polarity_uri);
     const [hovered, setHovered] = useState(false);
 
@@ -102,6 +112,18 @@ function ValueClaimNode({ data }: { data: ValueClaimNodeData }) {
             <Handle id="target-right"  type="target" position={Position.Right}  style={handleStyle(hovered)} />
             <Handle id="target-top"    type="target" position={Position.Top}    style={handleStyle(hovered)} />
             <Handle id="target-bottom" type="target" position={Position.Bottom} style={handleStyle(hovered)} />
+
+            {/* Implicatie-badge — buiten clip-path */}
+            {(implicationCount ?? 0) > 0 && (
+                <div style={{
+                    position: 'absolute', top: 4, right: 12, zIndex: 20,
+                    background: '#2563eb', color: '#fff',
+                    borderRadius: '9999px', fontSize: 9, fontWeight: 700,
+                    padding: '1px 5px', lineHeight: 1.4, pointerEvents: 'none',
+                }}>
+                    {implicationCount}
+                </div>
+            )}
 
             {/* Hexagon */}
             <div
@@ -417,10 +439,158 @@ function EditTensionDialog({ tension, onClose, onSaved, designSpaceId }: EditTen
 }
 
 // ---------------------------------------------------------------------------
+// NodeContextMenu — rechtsklik op een ValueClaimNode
+// ---------------------------------------------------------------------------
+
+interface NodeContextMenuState {
+    claim: ValueClaimItem;
+    x: number;
+    y: number;
+}
+
+interface NodeContextMenuProps {
+    menu: NodeContextMenuState;
+    onImplication: (claim: ValueClaimItem) => void;
+    onClose: () => void;
+}
+
+function NodeContextMenu({ menu, onImplication, onClose }: NodeContextMenuProps) {
+    const ref = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const handler = (e: MouseEvent) => {
+            if (ref.current && !ref.current.contains(e.target as unknown as globalThis.Node)) onClose();
+        };
+        document.addEventListener('mousedown', handler);
+        return () => document.removeEventListener('mousedown', handler);
+    }, [onClose]);
+
+    return createPortal(
+        <div
+            ref={ref}
+            style={{ top: menu.y, left: menu.x }}
+            className="fixed z-50 min-w-[200px] p-1.5 rounded-lg bg-background/95 backdrop-blur-md border shadow-lg animate-in fade-in zoom-in-95 duration-100"
+        >
+            <div className="px-2 py-1.5 border-b mb-1">
+                <span className="text-xs font-medium text-muted-foreground truncate block max-w-[160px]">
+                    {menu.claim.claim_content}
+                </span>
+            </div>
+            <button
+                className="flex items-center gap-2 w-full px-2 py-1.5 text-sm rounded hover:bg-accent text-left"
+                onClick={() => { onImplication(menu.claim); onClose(); }}
+            >
+                <Link className="h-4 w-4 text-blue-500" />
+                Waarde-implicatie koppelen
+            </button>
+        </div>,
+        document.body,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// CreateDesignImplicationModal
+// ---------------------------------------------------------------------------
+
+interface CreateDesignImplicationModalProps {
+    claim: ValueClaimItem | null;
+    designSpaceId: string;
+    onClose: () => void;
+    onCreated: () => void;
+}
+
+function CreateDesignImplicationModal({ claim, designSpaceId, onClose, onCreated }: CreateDesignImplicationModalProps) {
+    const { schema } = useAxiaSchema();
+    const [valueTypeUri, setValueTypeUri] = useState('');
+    const [polarityUri, setPolarityUri] = useState('');
+    const [isSaving, setIsSaving] = useState(false);
+
+    useEffect(() => {
+        if (!claim) { setValueTypeUri(''); setPolarityUri(''); }
+    }, [claim]);
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!claim || !valueTypeUri || !polarityUri) return;
+        setIsSaving(true);
+        try {
+            await api.createDesignImplication(designSpaceId, {
+                tessera_uri: claim.tessera_uri,
+                value_type_uri: valueTypeUri,
+                polarity_uri: polarityUri,
+            });
+            toast.success('Waarde-implicatie gekoppeld.');
+            onCreated();
+            onClose();
+        } catch {
+            toast.error('Koppelen mislukt.');
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    const valueTypes = schema?.value_types ?? [];
+    const polarities = schema?.claim_polarities ?? [];
+
+    return (
+        <Dialog open={!!claim} onOpenChange={(open) => { if (!open) onClose(); }}>
+            <DialogContent className="sm:max-w-[400px]">
+                <DialogHeader>
+                    <DialogTitle>Waarde-implicatie koppelen</DialogTitle>
+                    <DialogDescription>
+                        {claim ? `Koppel een waardetype aan "${claim.claim_content}"` : ''}
+                    </DialogDescription>
+                </DialogHeader>
+                <form onSubmit={handleSubmit} className="grid gap-4 py-2">
+                    <div className="grid gap-2">
+                        <Label>Waardetype</Label>
+                        <Select value={valueTypeUri} onValueChange={setValueTypeUri}>
+                            <SelectTrigger>
+                                <SelectValue placeholder="Kies een waardetype" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {valueTypes.map((v) => (
+                                    <SelectItem key={v.uri} value={v.uri}>
+                                        {v.label_nl || v.label_en}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                    <div className="grid gap-2">
+                        <Label>Polariteit</Label>
+                        <Select value={polarityUri} onValueChange={setPolarityUri}>
+                            <SelectTrigger>
+                                <SelectValue placeholder="Kies een polariteit" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {polarities.map((p) => (
+                                    <SelectItem key={p.uri} value={p.uri}>
+                                        {p.label_nl || p.label_en}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                    <DialogFooter>
+                        <Button type="button" variant="outline" onClick={onClose} disabled={isSaving}>
+                            Annuleren
+                        </Button>
+                        <Button type="submit" disabled={!valueTypeUri || !polarityUri || isSaving}>
+                            {isSaving ? 'Opslaan...' : 'Koppelen'}
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+// ---------------------------------------------------------------------------
 // buildNodes — auto-layout
 // ---------------------------------------------------------------------------
 
-function buildNodes(claims: ValueClaimItem[]): Node[] {
+function buildNodes(claims: ValueClaimItem[], implicationCounts: Map<string, number> = new Map()): Node[] {
     const named: Record<string, ValueClaimItem[]> = {};
     const ungrouped: ValueClaimItem[] = [];
     for (const claim of claims) {
@@ -444,7 +614,7 @@ function buildNodes(claims: ValueClaimItem[]): Node[] {
                 id: claim.tessera_id,
                 type: 'valueClaim',
                 position: { x, y: START_Y + GROUP_HEADER_H + rowIndex * (NODE_HEIGHT + NODE_GAP) },
-                data: { claim },
+                data: { claim, implicationCount: implicationCounts.get(claim.tessera_uri) ?? 0 },
                 style: { width: HEX_W, height: HEX_H },
             });
         });
@@ -468,7 +638,9 @@ export function ValueCanvas({ designSpaceId, refreshTrigger = 0, onEdit }: Value
     const shouldFitRef = useRef(false);
     const [pendingConnection, setPendingConnection] = useState<PendingConnection | null>(null);
     const [editingTension, setEditingTension] = useState<ValueTensionResponse | null>(null);
-    useAxiaSchema(); // schema preloaden voor ValueTensionView
+    const [contextMenu, setContextMenu] = useState<NodeContextMenuState | null>(null);
+    const [implicationClaim, setImplicationClaim] = useState<ValueClaimItem | null>(null);
+    useAxiaSchema(); // schema preloaden
 
     // Houd een map bij van tessera_id → claim voor snelle lookup bij onConnect
     const claimsMapRef = useRef<Map<string, ValueClaimItem>>(new Map());
@@ -479,15 +651,17 @@ export function ValueCanvas({ designSpaceId, refreshTrigger = 0, onEdit }: Value
 
     const load = useCallback(async () => {
         try {
-            const [claimsResult, tensionsResult] = await Promise.all([
+            const [claimsResult, tensionsResult, implicationCounts] = await Promise.all([
                 api.getValueClaims(designSpaceId),
                 api.getValueTensions(designSpaceId),
+                api.getValueImplications(designSpaceId),
             ]);
 
             const flat: ValueClaimItem[] = Object.values(claimsResult.groups).flat();
             claimsMapRef.current = new Map(flat.map((c) => [c.tessera_id, c]));
 
-            const builtNodes = buildNodes(flat);
+            const implicationMap = new Map(implicationCounts.map((i) => [i.tessera_uri, i.implication_count]));
+            const builtNodes = buildNodes(flat, implicationMap);
             nodePositionsRef.current = new Map(builtNodes.map((n) => [n.id, n.position]));
             shouldFitRef.current = true;
             setNodes(builtNodes);
@@ -543,6 +717,14 @@ export function ValueCanvas({ designSpaceId, refreshTrigger = 0, onEdit }: Value
             onEdit?.(node.data.claim);
         },
         [onEdit],
+    );
+
+    const handleNodeContextMenu = useCallback(
+        (event: React.MouseEvent, node: { data: ValueClaimNodeData }) => {
+            event.preventDefault();
+            setContextMenu({ claim: node.data.claim, x: event.clientX, y: event.clientY });
+        },
+        [],
     );
 
     const handleEdgeDoubleClick = useCallback(
@@ -620,6 +802,7 @@ export function ValueCanvas({ designSpaceId, refreshTrigger = 0, onEdit }: Value
                 onConnect={handleConnect}
                 onNodeDoubleClick={handleNodeDoubleClick}
                 onEdgeDoubleClick={handleEdgeDoubleClick}
+                onNodeContextMenu={handleNodeContextMenu}
                 nodeTypes={NODE_TYPES}
                 edgeTypes={EDGE_TYPES}
                 connectionMode={ConnectionMode.Loose}
@@ -641,6 +824,21 @@ export function ValueCanvas({ designSpaceId, refreshTrigger = 0, onEdit }: Value
                 designSpaceId={designSpaceId}
                 onClose={() => setEditingTension(null)}
                 onSaved={load}
+            />
+
+            {contextMenu && (
+                <NodeContextMenu
+                    menu={contextMenu}
+                    onImplication={(claim) => setImplicationClaim(claim)}
+                    onClose={() => setContextMenu(null)}
+                />
+            )}
+
+            <CreateDesignImplicationModal
+                claim={implicationClaim}
+                designSpaceId={designSpaceId}
+                onClose={() => setImplicationClaim(null)}
+                onCreated={load}
             />
         </div>
     );

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1092,6 +1092,11 @@ WHERE {
         return response.data;
     },
 
+    createDesignImplication: async (dsId: string, payload: CreateDesignImplicationPayload): Promise<DesignImplicationResponse> => {
+        const response = await apiClient.post<DesignImplicationResponse>(`/designspace/${dsId}/value-implication`, payload);
+        return response.data;
+    },
+
     createValueCriterion: async (dsId: string, payload: CreateValueCriterionPayload): Promise<ValueCriterionResponse> => {
         const response = await apiClient.post<ValueCriterionResponse>(`/designspace/${dsId}/value-criterion`, payload);
         return response.data;
@@ -1380,8 +1385,23 @@ export interface ValueTensionListResponse {
 }
 
 export interface DesignImplicationCount {
-    factor_uri: string;
+    tessera_uri: string;
     implication_count: number;
+}
+
+export interface CreateDesignImplicationPayload {
+    tessera_uri: string;
+    value_type_uri: string;
+    polarity_uri: string;
+}
+
+export interface DesignImplicationResponse {
+    implication_uri: string;
+    tessera_uri: string;
+    value_type_uri: string;
+    polarity_uri: string;
+    created_by: string;
+    created_at: string;
 }
 
 export interface CreateValueClaimPayload {


### PR DESCRIPTION
## Summary

- `POST /designspace/{ds_id}/value-implication` — schrijft `axia:DesignImplication` met `axia:implicationSource`, `axia:implicationTarget`, `axia:implicationPolarity`
- `GET /designspace/{ds_id}/value-implications` geüpdatet naar nieuwe predicaten (`implicationSource` i.p.v. `impliesFor`)
- Rechtsklik op een `ValueClaimNode` opent een context menu met "Waarde-implicatie koppelen"
- `CreateDesignImplicationModal`: kies ValueType + Polariteit uit het AXIA-schema
- Badge op node toont het aantal gekoppelde implicaties (blauwe pill)
- `HeatmapOverlay.tsx` bijgewerkt: `factor_uri` → `tessera_uri` (breaking change in interface)

## Test plan

- [ ] Rechtsklik op een waardeclaim-hexagon → context menu verschijnt
- [ ] "Waarde-implicatie koppelen" opent dialog met ValueType + Polariteit selects
- [ ] Na opslaan: badge verschijnt op de node met count
- [ ] Meerdere implicaties op dezelfde node verhogen de teller
- [ ] Backend: `POST /designspace/{ds_id}/value-implication` geeft 201 terug

Closes #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)