### PR TITLE
feat(axia): US-7.05 — DesignImplication koppelen vanuit CAUSA-canvas

### DIFF
--- a/backend/app/routers/axia.py
+++ b/backend/app/routers/axia.py
@@ -713,9 +713,78 @@ class ValueChainOut(BaseModel):
 
 
 class DesignImplicationCount(BaseModel):
-    factor_uri: str
+    tessera_uri: str
     implication_count: int
 
+
+class CreateDesignImplicationRequest(BaseModel):
+    tessera_uri: str
+    value_type_uri: str
+    polarity_uri: str
+
+
+class DesignImplicationOut(BaseModel):
+    implication_uri: str
+    tessera_uri: str
+    value_type_uri: str
+    polarity_uri: str
+    created_by: str
+    created_at: str
+
+
+# ---------------------------------------------------------------------------
+# US-7.05: POST value-implication
+# ---------------------------------------------------------------------------
+
+@router.post("/{ds_id}/value-implication", response_model=DesignImplicationOut, status_code=201)
+async def create_design_implication(
+    ds_id: str,
+    request: CreateDesignImplicationRequest,
+    user: dict = Depends(get_current_user),
+) -> DesignImplicationOut:
+    user_id = user["id"]
+
+    has_permission = await check_permission(user_id, ds_id, Role.MEMBER)
+    if not has_permission:
+        raise HTTPException(status_code=403, detail="Onvoldoende rechten voor deze DesignSpace.")
+
+    graph_uri = f"urn:valor:ds:{ds_id}/baseline"
+    implication_id = str(uuid.uuid4())
+    implication_uri = f"urn:valor:ds:{ds_id}:design-implication:{implication_id}"
+    now = datetime.now(timezone.utc).isoformat()
+
+    sparql = f"""PREFIX axia: <{AXIA_NS}>
+PREFIX valor: <{VALOR_NS}>
+PREFIX xsd: <{XSD_NS}>
+
+INSERT DATA {{
+  GRAPH <{graph_uri}> {{
+    <{implication_uri}> a axia:DesignImplication ;
+                        axia:implicationSource <{request.tessera_uri}> ;
+                        axia:implicationTarget <{request.value_type_uri}> ;
+                        axia:implicationPolarity <{request.polarity_uri}> ;
+                        valor:createdBy <urn:valor:user:{user_id}> ;
+                        valor:createdAt "{now}"^^xsd:dateTime .
+  }}
+}}"""
+
+    await sparql_update(sparql, ds_id)
+    user_uri = f"urn:valor:user:{user_id}"
+    await record_provenance_activity(ds_id, "DesignImplicationCreated", user_uri, used=[request.tessera_uri])
+
+    return DesignImplicationOut(
+        implication_uri=implication_uri,
+        tessera_uri=request.tessera_uri,
+        value_type_uri=request.value_type_uri,
+        polarity_uri=request.polarity_uri,
+        created_by=user_uri,
+        created_at=now,
+    )
+
+
+# ---------------------------------------------------------------------------
+# US-7.05: GET value-implications (count per tessera)
+# ---------------------------------------------------------------------------
 
 @router.get("/{ds_id}/value-implications", response_model=list[DesignImplicationCount])
 async def get_value_implications(
@@ -732,21 +801,21 @@ async def get_value_implications(
 
     query = f"""PREFIX axia: <{AXIA_NS}>
 
-SELECT ?factor (COUNT(?implication) AS ?count) WHERE {{
+SELECT ?tessera (COUNT(?implication) AS ?count) WHERE {{
   GRAPH <{graph_uri}> {{
     ?implication a axia:DesignImplication ;
-                 axia:impliesFor ?factor .
+                 axia:implicationSource ?tessera .
   }}
 }}
-GROUP BY ?factor
+GROUP BY ?tessera
 ORDER BY DESC(?count)"""
 
     rows = await sparql_select_global(query)
 
     return [
         DesignImplicationCount(
-            factor_uri=row["factor"],
-            implication_count=int(row["count"]),
+            tessera_uri=row["tessera"],
+            implication_count=int(str(row["count"]).split("^^")[0].strip('"')),
         )
         for row in rows
     ]

--- a/frontend/src/perspectives/axia/DesignImplicationModal.tsx
+++ b/frontend/src/perspectives/axia/DesignImplicationModal.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { api } from '@/services/api';
+import { useAxiaSchema } from './hooks/useAxiaSchema';
+
+interface DesignImplicationModalProps {
+    /** URI van de Tessera waaraan de implicatie wordt gekoppeld (bijv. een CausalClaim of Factor) */
+    tesseraUri: string | null;
+    /** Leesbare naam van de Tessera — voor de dialog-titel */
+    tesseraLabel: string;
+    designSpaceId: string;
+    onClose: () => void;
+    onCreated: () => void;
+}
+
+export function DesignImplicationModal({
+    tesseraUri,
+    tesseraLabel,
+    designSpaceId,
+    onClose,
+    onCreated,
+}: DesignImplicationModalProps) {
+    const { schema } = useAxiaSchema();
+    const [valueTypeUri, setValueTypeUri] = useState('');
+    const [polarityUri, setPolarityUri] = useState('');
+    const [isSaving, setIsSaving] = useState(false);
+
+    useEffect(() => {
+        if (!tesseraUri) {
+            setValueTypeUri('');
+            setPolarityUri('');
+        }
+    }, [tesseraUri]);
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!tesseraUri || !valueTypeUri || !polarityUri) return;
+        setIsSaving(true);
+        try {
+            await api.createDesignImplication(designSpaceId, {
+                tessera_uri: tesseraUri,
+                value_type_uri: valueTypeUri,
+                polarity_uri: polarityUri,
+            });
+            toast.success('Waarde-implicatie gekoppeld.');
+            onCreated();
+            onClose();
+        } catch {
+            toast.error('Koppelen mislukt.');
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    const valueTypes = schema?.value_types ?? [];
+    const polarities = schema?.claim_polarities ?? [];
+
+    return (
+        <Dialog open={!!tesseraUri} onOpenChange={(open) => { if (!open) onClose(); }}>
+            <DialogContent className="sm:max-w-[400px]">
+                <DialogHeader>
+                    <DialogTitle>Waarde-implicatie koppelen</DialogTitle>
+                    <DialogDescription>
+                        Koppel een waardetype aan <span className="font-medium">"{tesseraLabel}"</span>
+                    </DialogDescription>
+                </DialogHeader>
+                <form onSubmit={handleSubmit} className="grid gap-4 py-2">
+                    <div className="grid gap-2">
+                        <Label>Waardetype</Label>
+                        <Select value={valueTypeUri} onValueChange={setValueTypeUri}>
+                            <SelectTrigger>
+                                <SelectValue placeholder="Kies een waardetype" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {valueTypes.map((v) => (
+                                    <SelectItem key={v.uri} value={v.uri}>
+                                        {v.label_nl || v.label_en}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                    <div className="grid gap-2">
+                        <Label>Polariteit</Label>
+                        <Select value={polarityUri} onValueChange={setPolarityUri}>
+                            <SelectTrigger>
+                                <SelectValue placeholder="Kies een polariteit" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {polarities.map((p) => (
+                                    <SelectItem key={p.uri} value={p.uri}>
+                                        {p.label_nl || p.label_en}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                    <DialogFooter>
+                        <Button type="button" variant="outline" onClick={onClose} disabled={isSaving}>
+                            Annuleren
+                        </Button>
+                        <Button type="submit" disabled={!valueTypeUri || !polarityUri || isSaving}>
+                            {isSaving ? 'Opslaan...' : 'Koppelen'}
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/frontend/src/perspectives/axia/HeatmapOverlay.tsx
+++ b/frontend/src/perspectives/axia/HeatmapOverlay.tsx
@@ -85,7 +85,7 @@ export function HeatmapOverlay({ designSpaceId, rfInstance, nodeIds }: HeatmapOv
 
     // Map factor_uri → count (gebruik het trailing segment als node-id lookup)
     const countByFactorUri = new Map<string, number>(
-        implications.map((i) => [i.factor_uri, i.implication_count])
+        implications.map((i) => [i.tessera_uri, i.implication_count])
     );
 
     // Zoek count voor een node-id: probeer directe match, dan URI-suffix match

--- a/frontend/src/perspectives/causa/views/CLDView.tsx
+++ b/frontend/src/perspectives/causa/views/CLDView.tsx
@@ -18,6 +18,8 @@ import CLDEdge from './edges/CLDEdge';
 import { getGeometricHandles } from '../layout/edgeUtils';
 import { CanvasContextMenu } from '@/components/shell/CanvasContextMenu';
 import { ViewControls } from '@/components/shell/ViewControls';
+import { Link } from 'lucide-react';
+import { DesignImplicationModal } from '@/perspectives/axia/DesignImplicationModal';
 import type { ConversationContext } from '@/types/conversation';
 // api import verwijderd — disc thread stats worden later via disc endpoints geladen
 import { FloatingThreadPanel } from '@/components/Chat/FloatingThreadPanel';
@@ -100,6 +102,9 @@ export const CLDView: FunctionComponent<CLDViewProps> = ({
 
     // Context Menu State
     const [contextMenu, setContextMenu] = useState<{ visible: boolean; x: number; y: number; nodeId: string; type: string; label?: string; data?: any } | null>(null);
+
+    // DesignImplication modal state
+    const [implicationTarget, setImplicationTarget] = useState<{ uri: string; label: string } | null>(null);
 
     const onNodeContextMenu = (event: React.MouseEvent, node: any) => {
         event.preventDefault();
@@ -444,9 +449,29 @@ export const CLDView: FunctionComponent<CLDViewProps> = ({
                         onOpenObjectConversation={handleOpenObjectConversation}
                         onOpenThread={(obj) => handleOpenThread(obj.version_id || obj.id, obj.label || 'Discussie', { x: contextMenu.x, y: contextMenu.y })}
                         onEdit={(obj) => onEdit && onEdit({ type: obj.type as any, data: contextMenu.data || obj })}
+                        additionalActions={!isReadOnly ? [{
+                            id: 'design-implication',
+                            label: 'Waarde-implicatie koppelen',
+                            icon: <Link className="h-4 w-4 text-blue-500" />,
+                            onClick: (obj) => {
+                                const uri = contextMenu.data?.tessera_uri || contextMenu.data?.version_id || obj.id;
+                                const label = obj.label || contextMenu.label || obj.id;
+                                setImplicationTarget({ uri, label });
+                            },
+                        }] : []}
                     />
                 )
             }
+
+            {implicationTarget && (
+                <DesignImplicationModal
+                    tesseraUri={implicationTarget.uri}
+                    tesseraLabel={implicationTarget.label}
+                    designSpaceId={designSpaceId ?? ''}
+                    onClose={() => setImplicationTarget(null)}
+                    onCreated={() => setImplicationTarget(null)}
+                />
+            )}
 
             {floatingThread && (
                 <FloatingThreadPanel

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1092,6 +1092,11 @@ WHERE {
         return response.data;
     },
 
+    createDesignImplication: async (dsId: string, payload: CreateDesignImplicationPayload): Promise<DesignImplicationResponse> => {
+        const response = await apiClient.post<DesignImplicationResponse>(`/designspace/${dsId}/value-implication`, payload);
+        return response.data;
+    },
+
     createValueCriterion: async (dsId: string, payload: CreateValueCriterionPayload): Promise<ValueCriterionResponse> => {
         const response = await apiClient.post<ValueCriterionResponse>(`/designspace/${dsId}/value-criterion`, payload);
         return response.data;
@@ -1380,8 +1385,23 @@ export interface ValueTensionListResponse {
 }
 
 export interface DesignImplicationCount {
-    factor_uri: string;
+    tessera_uri: string;
     implication_count: number;
+}
+
+export interface CreateDesignImplicationPayload {
+    tessera_uri: string;
+    value_type_uri: string;
+    polarity_uri: string;
+}
+
+export interface DesignImplicationResponse {
+    implication_uri: string;
+    tessera_uri: string;
+    value_type_uri: string;
+    polarity_uri: string;
+    created_by: string;
+    created_at: string;
 }
 
 export interface CreateValueClaimPayload {


### PR DESCRIPTION
## Summary

- Rechtsklik op een Factor of CausalClaim in het CAUSA-canvas → "Waarde-implicatie koppelen"
- `DesignImplicationModal`: kies ValueType + Polariteit uit het AXIA-schema
- Schrijft `axia:DesignImplication` met `implicationSource` (de Tessera), `implicationTarget` (ValueType), `implicationPolarity`
- Werkt op elk CAUSA-canvas dat een `designSpaceId` meekrijgt
- `GET /value-implications` geüpdatet naar `axia:implicationSource` predicaat
- `HeatmapOverlay.tsx` bijgewerkt: `factor_uri` → `tessera_uri`

## Test plan

- [ ] Rechtsklik op een Factor in CAUSA → context menu toont "Waarde-implicatie koppelen"
- [ ] Rechtsklik op een CausalClaim (edge) → zelfde optie beschikbaar
- [ ] Dialog toont naam van de geselecteerde Factor/Claim
- [ ] ValueType en Polariteit kunnen worden geselecteerd uit AXIA-schema
- [ ] Na opslaan: `POST /value-implication` geeft 201, geen errors in console
- [ ] In readonly-modus is de actie niet zichtbaar

Closes #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)